### PR TITLE
fix: メンバーが複数のグループに所属できるように修正

### DIFF
--- a/businesses/Wiki/Member/Domain/Entity/Member.php
+++ b/businesses/Wiki/Member/Domain/Entity/Member.php
@@ -15,7 +15,7 @@ class Member
     /**
      * @param MemberIdentifier $memberIdentifier
      * @param MemberName $name
-     * @param GroupIdentifier|null $groupIdentifier
+     * @param GroupIdentifier[] $groupIdentifiers
      * @param Birthday|null $birthday
      * @param Career $career
      * @param ImagePath|null $imageLink
@@ -24,7 +24,7 @@ class Member
     public function __construct(
         private readonly MemberIdentifier $memberIdentifier,
         private MemberName $name,
-        private ?GroupIdentifier $groupIdentifier,
+        private array $groupIdentifiers,
         private ?Birthday $birthday,
         private Career $career,
         private ?ImagePath $imageLink,
@@ -47,14 +47,21 @@ class Member
         $this->name = $name;
     }
 
-    public function groupIdentifier(): ?GroupIdentifier
+    /**
+     * @return GroupIdentifier[]
+     */
+    public function groupIdentifiers(): array
     {
-        return $this->groupIdentifier;
+        return $this->groupIdentifiers;
     }
 
-    public function setGroupIdentifier(?GroupIdentifier $groupIdentifier): void
+    /**
+     * @param GroupIdentifier[] $groupIdentifiers
+     * @return void
+     */
+    public function setGroupIdentifiers(array $groupIdentifiers): void
     {
-        $this->groupIdentifier = $groupIdentifier;
+        $this->groupIdentifiers = $groupIdentifiers;
     }
 
     public function birthday(): ?Birthday

--- a/businesses/Wiki/Member/Domain/Factory/MemberFactory.php
+++ b/businesses/Wiki/Member/Domain/Factory/MemberFactory.php
@@ -22,7 +22,7 @@ readonly class MemberFactory implements MemberFactoryInterface
         return new Member(
             new MemberIdentifier($this->ulidGenerator->generate()),
             $name,
-            null,
+            [],
             null,
             new Career(''),
             null,

--- a/businesses/Wiki/Member/UseCase/Command/CreateMember/CreateMember.php
+++ b/businesses/Wiki/Member/UseCase/Command/CreateMember/CreateMember.php
@@ -19,7 +19,7 @@ class CreateMember implements CreateMemberInterface
     public function process(CreateMemberInputPort $input): ?Member
     {
         $member = $this->memberFactory->create($input->name());
-        $member->setGroupIdentifier($input->groupIdentifier());
+        $member->setGroupIdentifiers($input->groupIdentifiers());
         $member->setBirthday($input->birthday());
         $member->setCareer($input->career());
         if ($input->base64EncodedImage()) {

--- a/businesses/Wiki/Member/UseCase/Command/CreateMember/CreateMemberInput.php
+++ b/businesses/Wiki/Member/UseCase/Command/CreateMember/CreateMemberInput.php
@@ -12,7 +12,7 @@ class CreateMemberInput implements CreateMemberInputPort
 {
     /**
      * @param MemberName $name
-     * @param GroupIdentifier|null $groupIdentifier
+     * @param GroupIdentifier[] $groupIdentifiers
      * @param Birthday|null $birthday
      * @param Career $career
      * @param string|null $base64EncodedImage
@@ -20,7 +20,7 @@ class CreateMemberInput implements CreateMemberInputPort
      */
     public function __construct(
         private MemberName $name,
-        private ?GroupIdentifier $groupIdentifier,
+        private array $groupIdentifiers,
         private ?Birthday $birthday,
         private Career $career,
         private ?string $base64EncodedImage,
@@ -33,9 +33,12 @@ class CreateMemberInput implements CreateMemberInputPort
         return $this->name;
     }
 
-    public function groupIdentifier(): ?GroupIdentifier
+    /**
+     * @return GroupIdentifier[]
+     */
+    public function groupIdentifiers(): array
     {
-        return $this->groupIdentifier;
+        return $this->groupIdentifiers;
     }
 
     public function birthday(): ?Birthday

--- a/businesses/Wiki/Member/UseCase/Command/CreateMember/CreateMemberInputPort.php
+++ b/businesses/Wiki/Member/UseCase/Command/CreateMember/CreateMemberInputPort.php
@@ -12,7 +12,10 @@ interface CreateMemberInputPort
 {
     public function name(): MemberName;
 
-    public function groupIdentifier(): ?GroupIdentifier;
+    /**
+     * @return GroupIdentifier[]
+     */
+    public function groupIdentifiers(): array;
 
     public function birthday(): ?Birthday;
 

--- a/businesses/Wiki/Member/UseCase/Command/EditMember/EditMember.php
+++ b/businesses/Wiki/Member/UseCase/Command/EditMember/EditMember.php
@@ -29,7 +29,7 @@ readonly class EditMember implements EditMemberInterface
         }
 
         $member->setName($input->name());
-        $member->setGroupIdentifier($input->groupIdentifier());
+        $member->setGroupIdentifiers($input->groupIdentifiers());
         $member->setBirthday($input->birthday());
         $member->setCareer($input->career());
         if ($input->base64EncodedImage()) {

--- a/businesses/Wiki/Member/UseCase/Command/EditMember/EditMemberInput.php
+++ b/businesses/Wiki/Member/UseCase/Command/EditMember/EditMemberInput.php
@@ -11,10 +11,19 @@ use Businesses\Wiki\Member\Domain\ValueObject\RelevantVideoLinks;
 
 readonly class EditMemberInput implements EditMemberInputPort
 {
+    /**
+     * @param MemberIdentifier $memberIdentifier
+     * @param MemberName $name
+     * @param GroupIdentifier[] $groupIdentifiers
+     * @param Birthday|null $birthday
+     * @param Career $career
+     * @param string|null $base64EncodedImage
+     * @param RelevantVideoLinks $relevantVideoLinks
+     */
     public function __construct(
         private MemberIdentifier $memberIdentifier,
         private MemberName $name,
-        private ?GroupIdentifier $groupIdentifier,
+        private array $groupIdentifiers,
         private ?Birthday $birthday,
         private Career $career,
         private ?string $base64EncodedImage,
@@ -32,9 +41,12 @@ readonly class EditMemberInput implements EditMemberInputPort
         return $this->name;
     }
 
-    public function groupIdentifier(): ?GroupIdentifier
+    /**
+     * @return GroupIdentifier[]
+     */
+    public function groupIdentifiers(): array
     {
-        return $this->groupIdentifier;
+        return $this->groupIdentifiers;
     }
 
     public function birthday(): ?Birthday

--- a/businesses/Wiki/Member/UseCase/Command/EditMember/EditMemberInputPort.php
+++ b/businesses/Wiki/Member/UseCase/Command/EditMember/EditMemberInputPort.php
@@ -15,7 +15,10 @@ interface EditMemberInputPort
 
     public function name(): MemberName;
 
-    public function groupIdentifier(): ?GroupIdentifier;
+    /**
+     * @return GroupIdentifier[]
+     */
+    public function groupIdentifiers(): array;
 
     public function birthday(): ?Birthday;
 

--- a/businesses/Wiki/Member/UseCase/Query/MemberReadModel.php
+++ b/businesses/Wiki/Member/UseCase/Query/MemberReadModel.php
@@ -9,7 +9,7 @@ readonly class MemberReadModel
     /**
      * @param string $memberId
      * @param string $name
-     * @param string $groupName
+     * @param string[] $groupNames
      * @param DateTimeImmutable $birthday
      * @param string $career
      * @param string $imageUrl
@@ -18,7 +18,7 @@ readonly class MemberReadModel
     public function __construct(
         private string $memberId,
         private string $name,
-        private string $groupName,
+        private array $groupNames,
         private DateTimeImmutable $birthday,
         private string $career,
         private string $imageUrl,
@@ -36,9 +36,12 @@ readonly class MemberReadModel
         return $this->name;
     }
 
-    public function groupName(): string
+    /**
+     * @return string[]
+     */
+    public function groupNames(): array
     {
-        return $this->groupName;
+        return $this->groupNames;
     }
 
     public function birthday(): DateTimeImmutable
@@ -72,7 +75,7 @@ readonly class MemberReadModel
         return [
             'member_id' => $this->memberId,
             'name' => $this->name,
-            'group_name' => $this->groupName,
+            'group_name' => $this->groupNames,
             'birthday' => $this->birthday,
             'career' => $this->career,
             'image_url' => $this->imageUrl,

--- a/tests/Wiki/Member/Domain/Entity/MemberTest.php
+++ b/tests/Wiki/Member/Domain/Entity/MemberTest.php
@@ -28,7 +28,10 @@ class MemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -42,7 +45,7 @@ class MemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imagePath,
@@ -51,7 +54,7 @@ class MemberTest extends TestCase
         $this->assertSame((string)$memberIdentifier, (string)$member->memberIdentifier());
         $this->assertSame((string)$name, (string)$member->name());
         $this->assertSame((string)$birthday, (string)$member->birthday());
-        $this->assertSame((string)$groupIdentifier, (string)$member->groupIdentifier());
+        $this->assertSame($groupIdentifiers, $member->groupIdentifiers());
         $this->assertSame((string)$career, (string)$member->career());
         $this->assertSame((string)$imagePath, (string)$member->imageLink());
         $this->assertSame([(string)$link1, (string)$link2, (string)$link3], $member->relevantVideoLinks()->toString());
@@ -67,7 +70,10 @@ class MemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -81,7 +87,7 @@ class MemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imagePath,
@@ -105,7 +111,10 @@ class MemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -119,21 +128,25 @@ class MemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imagePath,
             $relevantVideoLinks,
         );
-        $this->assertSame((string)$groupIdentifier, (string)$member->groupIdentifier());
+        $this->assertSame($groupIdentifiers, $member->groupIdentifiers());
 
-        $newGroupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
-        $member->setGroupIdentifier($newGroupIdentifier);
-        $this->assertNotSame((string)$groupIdentifier, (string)$member->groupIdentifier());
-        $this->assertSame((string)$newGroupIdentifier, (string)$member->groupIdentifier());
+        $newGroupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
+        $member->setGroupIdentifiers($newGroupIdentifiers);
+        $this->assertNotSame($groupIdentifiers, $member->groupIdentifiers());
+        $this->assertSame($newGroupIdentifiers, $member->groupIdentifiers());
 
-        $member->setGroupIdentifier(null);
-        $this->assertNull($member->groupIdentifier());
+        $member->setGroupIdentifiers([]);
+        $this->assertEmpty($member->groupIdentifiers());
     }
 
     /**
@@ -146,7 +159,10 @@ class MemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -160,7 +176,7 @@ class MemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imagePath,
@@ -184,7 +200,10 @@ class MemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -198,7 +217,7 @@ class MemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imagePath,
@@ -226,7 +245,10 @@ class MemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -240,7 +262,7 @@ class MemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imagePath,

--- a/tests/Wiki/Member/Domain/Factory/MemberFactoryTest.php
+++ b/tests/Wiki/Member/Domain/Factory/MemberFactoryTest.php
@@ -34,7 +34,7 @@ class MemberFactoryTest extends TestCase
         $memberFactory = $this->app->make(MemberFactoryInterface::class);
         $member = $memberFactory->create($name);
         $this->assertSame((string)$name, (string)$member->name());
-        $this->assertNull($member->groupIdentifier());
+        $this->assertSame([], $member->groupIdentifiers());
         $this->assertNull($member->birthday());
         $this->assertSame('', (string)$member->career());
         $this->assertNull($member->imageLink());

--- a/tests/Wiki/Member/UseCase/Command/CreateMember/CreateMemberInputTest.php
+++ b/tests/Wiki/Member/UseCase/Command/CreateMember/CreateMemberInputTest.php
@@ -25,7 +25,10 @@ class CreateMemberInputTest extends TestCase
     public function test__construct(): void
     {
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -39,14 +42,14 @@ class CreateMemberInputTest extends TestCase
         $relevantVideoLinks = new RelevantVideoLinks($externalContentLinks);
         $input = new CreateMemberInput(
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $base64EncodedImage,
             $relevantVideoLinks,
         );
         $this->assertSame((string)$name, (string)$input->name());
-        $this->assertSame((string)$groupIdentifier, (string)$input->groupIdentifier());
+        $this->assertSame($groupIdentifiers, $input->groupIdentifiers());
         $this->assertSame($birthday, $input->birthday());
         $this->assertSame($career, $input->career());
         $this->assertSame($base64EncodedImage, $input->base64EncodedImage());

--- a/tests/Wiki/Member/UseCase/Command/CreateMember/CreateMemberTest.php
+++ b/tests/Wiki/Member/UseCase/Command/CreateMember/CreateMemberTest.php
@@ -54,7 +54,10 @@ class CreateMemberTest extends TestCase
     public function testProcess(): void
     {
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -68,7 +71,7 @@ class CreateMemberTest extends TestCase
         $relevantVideoLinks = new RelevantVideoLinks($externalContentLinks);
         $input = new CreateMemberInput(
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $base64EncodedImage,
@@ -86,7 +89,7 @@ class CreateMemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imageLink,
@@ -115,7 +118,7 @@ class CreateMemberTest extends TestCase
         $member = $createMember->process($input);
         $this->assertTrue(UlidValidator::isValid((string)$member->memberIdentifier()));
         $this->assertSame((string)$name, (string)$member->name());
-        $this->assertSame((string)$groupIdentifier, (string)$member->groupIdentifier());
+        $this->assertSame($groupIdentifiers, $member->groupIdentifiers());
         $this->assertSame($birthday, $member->birthday());
         $this->assertSame((string)$career, (string)$member->career());
         $this->assertSame((string)$imageLink, (string)$member->imageLink());

--- a/tests/Wiki/Member/UseCase/Command/EditMember/EditMemberInputTest.php
+++ b/tests/Wiki/Member/UseCase/Command/EditMember/EditMemberInputTest.php
@@ -27,7 +27,10 @@ class EditMemberInputTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -42,7 +45,7 @@ class EditMemberInputTest extends TestCase
         $input = new EditMemberInput(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $base64EncodedImage,
@@ -50,7 +53,7 @@ class EditMemberInputTest extends TestCase
         );
         $this->assertSame((string)$memberIdentifier, (string)$input->memberIdentifier());
         $this->assertSame((string)$name, (string)$input->name());
-        $this->assertSame((string)$groupIdentifier, (string)$input->groupIdentifier());
+        $this->assertSame($groupIdentifiers, $input->groupIdentifiers());
         $this->assertSame($birthday, $input->birthday());
         $this->assertSame($career, $input->career());
         $this->assertSame($base64EncodedImage, $input->base64EncodedImage());

--- a/tests/Wiki/Member/UseCase/Command/EditMember/EditMemberTest.php
+++ b/tests/Wiki/Member/UseCase/Command/EditMember/EditMemberTest.php
@@ -55,7 +55,10 @@ class EditMemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -70,7 +73,7 @@ class EditMemberTest extends TestCase
         $input = new EditMemberInput(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $base64EncodedImage,
@@ -87,7 +90,7 @@ class EditMemberTest extends TestCase
         $member = new Member(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $imageLink,
@@ -110,7 +113,7 @@ class EditMemberTest extends TestCase
         $member = $editMember->process($input);
         $this->assertSame((string)$memberIdentifier, (string)$member->memberIdentifier());
         $this->assertSame((string)$name, (string)$member->name());
-        $this->assertSame((string)$groupIdentifier, (string)$member->groupIdentifier());
+        $this->assertSame($groupIdentifiers, $member->groupIdentifiers());
         $this->assertSame($birthday, $member->birthday());
         $this->assertSame((string)$career, (string)$member->career());
         $this->assertSame((string)$imageLink, (string)$member->imageLink());
@@ -127,7 +130,10 @@ class EditMemberTest extends TestCase
     {
         $memberIdentifier = new MemberIdentifier(StrTestHelper::generateUlid());
         $name = new MemberName('채영');
-        $groupIdentifier = new GroupIdentifier(StrTestHelper::generateUlid());
+        $groupIdentifiers = [
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+            new GroupIdentifier(StrTestHelper::generateUlid()),
+        ];
         $birthday = new Birthday(new DateTimeImmutable('1994-01-01'));
         $career = new Career('### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -142,7 +148,7 @@ class EditMemberTest extends TestCase
         $input = new EditMemberInput(
             $memberIdentifier,
             $name,
-            $groupIdentifier,
+            $groupIdentifiers,
             $birthday,
             $career,
             $base64EncodedImage,

--- a/tests/Wiki/Member/UseCase/Query/MemberReadModelTest.php
+++ b/tests/Wiki/Member/UseCase/Query/MemberReadModelTest.php
@@ -19,7 +19,7 @@ class MemberReadModelTest extends TestCase
     {
         $memberId = StrTestHelper::generateUlid();
         $name = '채영';
-        $groupName = 'TWICE';
+        $groupNames = ['TWICE', 'MISAMO'];
         $birthday = new DateTimeImmutable('1994-01-01');
         $career = '### **경력 소개 예시**
 대학교 졸업 후, 주식회사 〇〇에 영업직으로 입사하여 법인 대상 IT 솔루션의 신규 고객 개척 및 기존 고객 관리에 4년간 종사했습니다. 고객의 잠재적인 과제를 깊이 있게 파악하고 해결책을 제안하는 \'과제 해결형 영업\'을 강점으로 삼고 있으며, 입사 3년 차에는 연간 개인 매출 목표의 120%를 달성하여 사내 영업 MVP를 수상했습니다.
@@ -44,7 +44,7 @@ class MemberReadModelTest extends TestCase
         $readModel = new MemberReadModel(
             $memberId,
             $name,
-            $groupName,
+            $groupNames,
             $birthday,
             $career,
             $imageUrl,
@@ -52,7 +52,7 @@ class MemberReadModelTest extends TestCase
         );
         $this->assertSame($memberId, $readModel->memberId());
         $this->assertSame($name, $readModel->name());
-        $this->assertSame($groupName, $readModel->groupName());
+        $this->assertSame($groupNames, $readModel->groupNames());
         $this->assertSame($birthday, $readModel->birthday());
         $this->assertSame($career, $readModel->career());
         $this->assertSame($imageUrl, $readModel->imageUrl());
@@ -60,7 +60,7 @@ class MemberReadModelTest extends TestCase
         $this->assertSame([
             'member_id' => $memberId,
             'name' => $name,
-            'group_name' => $groupName,
+            'group_name' => $groupNames,
             'birthday' => $birthday,
             'career' => $career,
             'image_url' => $imageUrl,


### PR DESCRIPTION
## 📝 変更内容

<!-- このプルリクエストで何を変更したか、簡潔に説明してください -->
- メンバーが複数のグループに所属できるように修正

## 🏷️ 変更の種類

<!-- 該当するものにチェック (x) を入れてください -->

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

<!-- なぜこの変更が必要なのかを説明してください -->
- グループからの派生ユニットにも所属しているなどメンバーによっては複数のグループに所属していることがあるから。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した 