### PR TITLE
add: WikiサブドメインにOutputパターン導入・エンドポイント作成

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/AutoCreateWiki/AutoCreateWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/AutoCreateWiki/AutoCreateWikiAction.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\AutoCreateWiki;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\AutoWikiCreationPayload;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class AutoCreateWikiAction
+{
+    public function __construct(
+        private AutoCreateWikiInterface $autoCreateWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param AutoCreateWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(AutoCreateWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $payload = new AutoWikiCreationPayload(
+                    Language::from($request->wikiLanguage()),
+                    ResourceType::from($request->resourceType()),
+                    new Name($request->name()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+
+                $input = new AutoCreateWikiInput(
+                    $payload,
+                    new PrincipalIdentifier($request->principalId()),
+                );
+                $output = new AutoCreateWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->autoCreateWiki->process($input, $output);
+                DB::commit();
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/AutoCreateWiki/AutoCreateWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/AutoCreateWiki/AutoCreateWikiRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\AutoCreateWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AutoCreateWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'language' => ['required', 'string'],
+            'name' => ['required', 'string'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function wikiLanguage(): string
+    {
+        return (string) $this->input('language');
+    }
+
+    public function name(): string
+    {
+        return (string) $this->input('name');
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\CreateWiki;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Application\Exception\DuplicateSlugException;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
+use Source\Wiki\Wiki\Domain\ValueObject\Color;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class CreateWikiAction
+{
+    public function __construct(
+        private CreateWikiInterface $createWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param CreateWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(CreateWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $resourceType = ResourceType::from($request->resourceType());
+                $basicClass = BasicInterface::resolveClass($resourceType);
+                $basic = $basicClass::fromArray($request->basic());
+                $sections = SectionContentCollection::fromArray($request->sections());
+
+                $input = new CreateWikiInput(
+                    $request->publishedWikiIdentifier() !== null ? new WikiIdentifier($request->publishedWikiIdentifier()) : null,
+                    Language::from($request->wikiLanguage()),
+                    $resourceType,
+                    $basic,
+                    $sections,
+                    $request->themeColor() !== null ? new Color($request->themeColor()) : null,
+                    new Slug($request->slug()),
+                    new PrincipalIdentifier($request->principalId()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new CreateWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->createWiki->process($input, $output);
+                DB::commit();
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (DuplicateSlugException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('duplicate_slug', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiRequest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\CreateWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'language' => ['required', 'string'],
+            'slug' => ['required', 'string'],
+            'basic' => ['required', 'array'],
+            'sections' => ['nullable', 'array'],
+            'themeColor' => ['nullable', 'string'],
+            'publishedWikiIdentifier' => ['nullable', 'uuid'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    /**
+     * @return string
+     */
+    public function wikiLanguage(): string
+    {
+        return (string) $this->input('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->input('slug');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function basic(): array
+    {
+        return (array) ($this->input('basic') ?? []);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function sections(): array
+    {
+        return (array) ($this->input('sections') ?? []);
+    }
+
+    public function themeColor(): ?string
+    {
+        $value = $this->input('themeColor');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function publishedWikiIdentifier(): ?string
+    {
+        $value = $this->input('publishedWikiIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\EditWiki;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
+use Source\Wiki\Wiki\Domain\ValueObject\Color;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class EditWikiAction
+{
+    public function __construct(
+        private EditWikiInterface $editWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param EditWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(EditWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $resourceType = ResourceType::from($request->resourceType());
+                $basicClass = BasicInterface::resolveClass($resourceType);
+                $basic = $basicClass::fromArray($request->basic());
+                $sections = SectionContentCollection::fromArray($request->sections());
+
+                $input = new EditWikiInput(
+                    new DraftWikiIdentifier($request->wikiId()),
+                    $basic,
+                    $sections,
+                    $request->themeColor() !== null ? new Color($request->themeColor()) : null,
+                    new PrincipalIdentifier($request->principalId()),
+                    $resourceType,
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new EditWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->editWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiRequest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\EditWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class EditWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'basic' => ['required', 'array'],
+            'sections' => ['nullable', 'array'],
+            'themeColor' => ['nullable', 'string'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function basic(): array
+    {
+        return (array) ($this->input('basic') ?? []);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function sections(): array
+    {
+        return (array) ($this->input('sections') ?? []);
+    }
+
+    public function themeColor(): ?string
+    {
+        $value = $this->input('themeColor');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiAction.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\MergeWiki;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use DateTimeImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\Exception\UnauthorizedException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
+use Source\Wiki\Wiki\Domain\ValueObject\Color;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class MergeWikiAction
+{
+    public function __construct(
+        private MergeWikiInterface $mergeWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param MergeWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(MergeWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $resourceType = ResourceType::from($request->resourceType());
+                $basicClass = BasicInterface::resolveClass($resourceType);
+                $basic = $basicClass::fromArray($request->basic());
+                $sections = SectionContentCollection::fromArray($request->sections());
+
+                $input = new MergeWikiInput(
+                    new DraftWikiIdentifier($request->wikiId()),
+                    $basic,
+                    $sections,
+                    $request->themeColor() !== null ? new Color($request->themeColor()) : null,
+                    new PrincipalIdentifier($request->principalId()),
+                    $resourceType,
+                    new DateTimeImmutable(),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new MergeWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->mergeWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (UnauthorizedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('unauthorized', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiRequest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\MergeWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MergeWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'basic' => ['required', 'array'],
+            'sections' => ['nullable', 'array'],
+            'themeColor' => ['nullable', 'string'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function basic(): array
+    {
+        return (array) ($this->input('basic') ?? []);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function sections(): array
+    {
+        return (array) ($this->input('sections') ?? []);
+    }
+
+    public function themeColor(): ?string
+    {
+        $value = $this->input('themeColor');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/PublishWiki/PublishWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/PublishWiki/PublishWikiAction.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\PublishWiki;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\InconsistentVersionException;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class PublishWikiAction
+{
+    public function __construct(
+        private PublishWikiInterface $publishWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param PublishWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(PublishWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new PublishWikiInput(
+                    new DraftWikiIdentifier($request->wikiId()),
+                    $request->publishedWikiIdentifier() !== null ? new WikiIdentifier($request->publishedWikiIdentifier()) : null,
+                    new PrincipalIdentifier($request->principalId()),
+                    ResourceType::from($request->resourceType()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new PublishWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->publishWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (InvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('invalid_status', $language), previous: $e);
+            } catch (InconsistentVersionException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('inconsistent_version', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/PublishWiki/PublishWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/PublishWiki/PublishWikiRequest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\PublishWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PublishWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'publishedWikiIdentifier' => ['nullable', 'uuid'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function publishedWikiIdentifier(): ?string
+    {
+        $value = $this->input('publishedWikiIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/RejectWiki/RejectWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/RejectWiki/RejectWikiAction.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\RejectWiki;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RejectWikiAction
+{
+    public function __construct(
+        private RejectWikiInterface $rejectWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RejectWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RejectWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RejectWikiInput(
+                    new DraftWikiIdentifier($request->wikiId()),
+                    new PrincipalIdentifier($request->principalId()),
+                    ResourceType::from($request->resourceType()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new RejectWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->rejectWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (InvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('invalid_status', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/RejectWiki/RejectWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/RejectWiki/RejectWikiRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\RejectWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/RollbackWiki/RollbackWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/RollbackWiki/RollbackWikiAction.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\RollbackWiki;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidRollbackTargetVersionException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\Exception\SnapshotNotFoundException;
+use Source\Wiki\Shared\Domain\Exception\VersionMismatchException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Version;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RollbackWikiAction
+{
+    public function __construct(
+        private RollbackWikiInterface $rollbackWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RollbackWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RollbackWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RollbackWikiInput(
+                    new PrincipalIdentifier($request->principalId()),
+                    new WikiIdentifier($request->wikiId()),
+                    new Version($request->targetVersion()),
+                    ResourceType::from($request->resourceType()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new RollbackWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->rollbackWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (SnapshotNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('snapshot_not_found', $language), previous: $e);
+            } catch (VersionMismatchException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('version_mismatch', $language), previous: $e);
+            } catch (InvalidRollbackTargetVersionException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_rollback_target_version', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/RollbackWiki/RollbackWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/RollbackWiki/RollbackWikiRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\RollbackWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RollbackWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'targetVersion' => ['required', 'integer', 'min:1'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function targetVersion(): int
+    {
+        return (int) $this->input('targetVersion');
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/SubmitWiki/SubmitWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/SubmitWiki/SubmitWikiAction.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\SubmitWiki;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class SubmitWikiAction
+{
+    public function __construct(
+        private SubmitWikiInterface $submitWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param SubmitWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(SubmitWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new SubmitWikiInput(
+                    new DraftWikiIdentifier($request->wikiId()),
+                    new PrincipalIdentifier($request->principalId()),
+                    ResourceType::from($request->resourceType()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new SubmitWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->submitWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (InvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('invalid_status', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/SubmitWiki/SubmitWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/SubmitWiki/SubmitWikiRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\SubmitWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SubmitWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/TranslateWiki/TranslateWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/TranslateWiki/TranslateWikiAction.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\TranslateWiki;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class TranslateWikiAction
+{
+    public function __construct(
+        private TranslateWikiInterface $translateWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param TranslateWikiRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(TranslateWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new TranslateWikiInput(
+                    new WikiIdentifier($request->wikiId()),
+                    new PrincipalIdentifier($request->principalId()),
+                    ResourceType::from($request->resourceType()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new TranslateWikiOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->translateWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/TranslateWiki/TranslateWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/TranslateWiki/TranslateWikiRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\TranslateWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TranslateWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -56,4 +56,12 @@ return [
     'cannot_remove_last_owner' => 'Cannot remove the last owner from the account.',
     'cannot_delete_default_identity_group' => 'Cannot delete the default identity group.',
     'cannot_delete_last_owner_group' => 'Cannot delete the last owner group with members.',
+
+    // Wiki
+    'unauthorized' => 'This action is not authorized.',
+    'inconsistent_version' => 'Published wiki versions in the translation set are not consistent.',
+    'snapshot_not_found' => 'The specified snapshot was not found.',
+    'version_mismatch' => 'Version mismatch detected in translation set.',
+    'invalid_rollback_target_version' => 'Target version must be less than current version.',
+    'invalid_status' => 'The status is invalid for this operation.',
 ];

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -56,4 +56,12 @@ return [
     'cannot_remove_last_owner' => 'No se puede eliminar al último propietario de la cuenta.',
     'cannot_delete_default_identity_group' => 'No se puede eliminar el grupo de identidad predeterminado.',
     'cannot_delete_last_owner_group' => 'No se puede eliminar el último grupo de propietarios con miembros.',
+
+    // Wiki
+    'unauthorized' => 'Esta acción no está autorizada.',
+    'inconsistent_version' => 'Las versiones de wiki publicadas en el conjunto de traducción no son consistentes.',
+    'snapshot_not_found' => 'No se encontró la instantánea especificada.',
+    'version_mismatch' => 'Se detectó una discrepancia de versión en el conjunto de traducción.',
+    'invalid_rollback_target_version' => 'La versión de destino debe ser menor que la versión actual.',
+    'invalid_status' => 'El estado no es válido para esta operación.',
 ];

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -56,4 +56,12 @@ return [
     'cannot_remove_last_owner' => 'アカウントから最後のオーナーを削除することはできません。',
     'cannot_delete_default_identity_group' => 'デフォルトのアイデンティティグループは削除できません。',
     'cannot_delete_last_owner_group' => 'メンバーがいる最後のオーナーグループは削除できません。',
+
+    // Wiki
+    'unauthorized' => 'この操作は認可されていません。',
+    'inconsistent_version' => '翻訳セット内の公開Wikiのバージョンが一致しません。',
+    'snapshot_not_found' => '指定されたスナップショットが見つかりません。',
+    'version_mismatch' => '翻訳セット内でバージョンの不一致が検出されました。',
+    'invalid_rollback_target_version' => 'ロールバック先のバージョンが無効です。',
+    'invalid_status' => 'ステータスが無効です。',
 ];

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -56,4 +56,12 @@ return [
     'cannot_remove_last_owner' => '계정에서 마지막 소유자를 제거할 수 없습니다.',
     'cannot_delete_default_identity_group' => '기본 아이덴티티 그룹은 삭제할 수 없습니다.',
     'cannot_delete_last_owner_group' => '멤버가 있는 마지막 소유자 그룹은 삭제할 수 없습니다.',
+
+    // Wiki
+    'unauthorized' => '이 작업은 인가되지 않았습니다.',
+    'inconsistent_version' => '번역 세트 내 공개 위키의 버전이 일치하지 않습니다.',
+    'snapshot_not_found' => '지정된 스냅샷을 찾을 수 없습니다.',
+    'version_mismatch' => '번역 세트에서 버전 불일치가 감지되었습니다.',
+    'invalid_rollback_target_version' => '롤백 대상 버전이 유효하지 않습니다.',
+    'invalid_status' => '이 작업에 대해 상태가 유효하지 않습니다.',
 ];

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -56,4 +56,12 @@ return [
     'cannot_remove_last_owner' => '无法移除账户的最后一个所有者。',
     'cannot_delete_default_identity_group' => '无法删除默认身份组。',
     'cannot_delete_last_owner_group' => '无法删除有成员的最后一个所有者组。',
+
+    // Wiki
+    'unauthorized' => '此操作未获授权。',
+    'inconsistent_version' => '翻译集中已发布的Wiki版本不一致。',
+    'snapshot_not_found' => '未找到指定的快照。',
+    'version_mismatch' => '翻译集中检测到版本不匹配。',
+    'invalid_rollback_target_version' => '目标版本必须小于当前版本。',
+    'invalid_status' => '此操作的状态无效。',
 ];

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -56,4 +56,12 @@ return [
     'cannot_remove_last_owner' => '無法移除帳戶的最後一個擁有者。',
     'cannot_delete_default_identity_group' => '無法刪除預設身分群組。',
     'cannot_delete_last_owner_group' => '無法刪除有成員的最後一個擁有者群組。',
+
+    // Wiki
+    'unauthorized' => '此操作未獲授權。',
+    'inconsistent_version' => '翻譯集中已發布的Wiki版本不一致。',
+    'snapshot_not_found' => '未找到指定的快照。',
+    'version_mismatch' => '翻譯集中檢測到版本不匹配。',
+    'invalid_rollback_target_version' => '目標版本必須小於當前版本。',
+    'invalid_status' => '此操作的狀態無效。',
 ];

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -3,6 +3,24 @@
 declare(strict_types=1);
 
 use Application\Http\Action\Wiki\Wiki\Command\ApproveWiki\ApproveWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\AutoCreateWiki\AutoCreateWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\CreateWiki\CreateWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\EditWiki\EditWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\MergeWiki\MergeWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\PublishWiki\PublishWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\RejectWiki\RejectWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\RollbackWiki\RollbackWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\TranslateWiki\TranslateWikiAction;
 use Illuminate\Support\Facades\Route;
 
+Route::post('/wiki/create', CreateWikiAction::class);
+Route::post('/wiki/auto-create', AutoCreateWikiAction::class);
 Route::post('/wiki/{wikiId}/approve', ApproveWikiAction::class);
+Route::post('/wiki/{wikiId}/edit', EditWikiAction::class);
+Route::post('/wiki/{wikiId}/merge', MergeWikiAction::class);
+Route::post('/wiki/{wikiId}/publish', PublishWikiAction::class);
+Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
+Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
+Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
+Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWiki.php
@@ -12,7 +12,6 @@ use Source\Wiki\Shared\Domain\Service\NormalizationServiceInterface;
 use Source\Wiki\Shared\Domain\Service\SlugGeneratorServiceInterface;
 use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Factory\DraftWikiFactoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Service\AutoWikiCreationServiceInterface;
@@ -33,11 +32,12 @@ readonly class AutoCreateWiki implements AutoCreateWikiInterface
 
     /**
      * @param AutoCreateWikiInputPort $input
-     * @return DraftWiki
+     * @param AutoCreateWikiOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(AutoCreateWikiInputPort $input): DraftWiki
+    public function process(AutoCreateWikiInputPort $input, AutoCreateWikiOutputPort $output): void
     {
         $principal = $this->principalRepository->findById($input->principalIdentifier());
         if ($principal === null) {
@@ -90,6 +90,6 @@ readonly class AutoCreateWiki implements AutoCreateWikiInterface
 
         $this->draftWikiRepository->save($draftWiki);
 
-        return $draftWiki;
+        $output->setDraftWiki($draftWiki);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiInterface.php
@@ -6,15 +6,15 @@ namespace Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki;
 
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 
 interface AutoCreateWikiInterface
 {
     /**
      * @param AutoCreateWikiInputPort $input
-     * @return DraftWiki
+     * @param AutoCreateWikiOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(AutoCreateWikiInputPort $input): DraftWiki;
+    public function process(AutoCreateWikiInputPort $input, AutoCreateWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class AutoCreateWikiOutput implements AutoCreateWikiOutputPort
+{
+    private ?DraftWiki $draftWiki = null;
+
+    public function setDraftWiki(DraftWiki $draftWiki): void
+    {
+        $this->draftWiki = $draftWiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->draftWiki->language()->value,
+            'name' => (string) $this->draftWiki->basic()->name(),
+            'resourceType' => $this->draftWiki->resourceType()->value,
+            'status' => $this->draftWiki->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface AutoCreateWikiOutputPort
+{
+    public function setDraftWiki(DraftWiki $draftWiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWiki.php
@@ -11,7 +11,6 @@ use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Factory\DraftWikiFactoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
@@ -30,12 +29,13 @@ readonly class CreateWiki implements CreateWikiInterface
 
     /**
      * @param CreateWikiInputPort $input
-     * @return DraftWiki
+     * @param CreateWikiOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      * @throws DuplicateSlugException
      */
-    public function process(CreateWikiInputPort $input): DraftWiki
+    public function process(CreateWikiInputPort $input, CreateWikiOutputPort $output): void
     {
         $principal = $this->principalRepository->findById($input->principalIdentifier());
         if ($principal === null) {
@@ -83,6 +83,6 @@ readonly class CreateWiki implements CreateWikiInterface
 
         $this->draftWikiRepository->save($wiki);
 
-        return $wiki;
+        $output->setDraftWiki($wiki);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInterface.php
@@ -7,16 +7,16 @@ namespace Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki;
 use Source\Wiki\Shared\Application\Exception\DuplicateSlugException;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 
 interface CreateWikiInterface
 {
     /**
      * @param CreateWikiInputPort $input
-     * @return DraftWiki
+     * @param CreateWikiOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      * @throws DuplicateSlugException
      */
-    public function process(CreateWikiInputPort $input): DraftWiki;
+    public function process(CreateWikiInputPort $input, CreateWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class CreateWikiOutput implements CreateWikiOutputPort
+{
+    private ?DraftWiki $draftWiki = null;
+
+    public function setDraftWiki(DraftWiki $draftWiki): void
+    {
+        $this->draftWiki = $draftWiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->draftWiki->language()->value,
+            'name' => (string) $this->draftWiki->basic()->name(),
+            'resourceType' => $this->draftWiki->resourceType()->value,
+            'status' => $this->draftWiki->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface CreateWikiOutputPort
+{
+    public function setDraftWiki(DraftWiki $draftWiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWiki.php
@@ -11,7 +11,6 @@ use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
@@ -26,12 +25,13 @@ readonly class EditWiki implements EditWikiInterface
 
     /**
      * @param EditWikiInputPort $input
-     * @return DraftWiki
+     * @param EditWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(EditWikiInputPort $input): DraftWiki
+    public function process(EditWikiInputPort $input, EditWikiOutputPort $output): void
     {
         $wiki = $this->draftWikiRepository->findById($input->wikiIdentifier());
 
@@ -67,6 +67,6 @@ readonly class EditWiki implements EditWikiInterface
 
         $this->draftWikiRepository->save($wiki);
 
-        return $wiki;
+        $output->setDraftWiki($wiki);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInterface.php
@@ -7,16 +7,16 @@ namespace Source\Wiki\Wiki\Application\UseCase\Command\EditWiki;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 
 interface EditWikiInterface
 {
     /**
      * @param EditWikiInputPort $input
-     * @return DraftWiki
+     * @param EditWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(EditWikiInputPort $input): DraftWiki;
+    public function process(EditWikiInputPort $input, EditWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\EditWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class EditWikiOutput implements EditWikiOutputPort
+{
+    private ?DraftWiki $draftWiki = null;
+
+    public function setDraftWiki(DraftWiki $draftWiki): void
+    {
+        $this->draftWiki = $draftWiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->draftWiki->language()->value,
+            'name' => (string) $this->draftWiki->basic()->name(),
+            'resourceType' => $this->draftWiki->resourceType()->value,
+            'status' => $this->draftWiki->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\EditWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface EditWikiOutputPort
+{
+    public function setDraftWiki(DraftWiki $draftWiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWiki.php
@@ -11,7 +11,6 @@ use Source\Wiki\Shared\Domain\Exception\UnauthorizedException;
 use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
@@ -26,12 +25,13 @@ readonly class MergeWiki implements MergeWikiInterface
 
     /**
      * @param MergeWikiInputPort $input
-     * @return DraftWiki
+     * @param MergeWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws UnauthorizedException
      * @throws PrincipalNotFoundException
      */
-    public function process(MergeWikiInputPort $input): DraftWiki
+    public function process(MergeWikiInputPort $input, MergeWikiOutputPort $output): void
     {
         $wiki = $this->draftWikiRepository->findById($input->wikiIdentifier());
 
@@ -69,6 +69,6 @@ readonly class MergeWiki implements MergeWikiInterface
 
         $this->draftWikiRepository->save($wiki);
 
-        return $wiki;
+        $output->setDraftWiki($wiki);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInterface.php
@@ -7,16 +7,16 @@ namespace Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\Exception\UnauthorizedException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 
 interface MergeWikiInterface
 {
     /**
      * @param MergeWikiInputPort $input
-     * @return DraftWiki
+     * @param MergeWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws UnauthorizedException
      * @throws PrincipalNotFoundException
      */
-    public function process(MergeWikiInputPort $input): DraftWiki;
+    public function process(MergeWikiInputPort $input, MergeWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class MergeWikiOutput implements MergeWikiOutputPort
+{
+    private ?DraftWiki $draftWiki = null;
+
+    public function setDraftWiki(DraftWiki $draftWiki): void
+    {
+        $this->draftWiki = $draftWiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->draftWiki->language()->value,
+            'name' => (string) $this->draftWiki->basic()->name(),
+            'resourceType' => $this->draftWiki->resourceType()->value,
+            'status' => $this->draftWiki->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface MergeWikiOutputPort
+{
+    public function setDraftWiki(DraftWiki $draftWiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWiki.php
@@ -16,7 +16,6 @@ use Source\Wiki\Shared\Domain\ValueObject\HistoryActionType;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\InconsistentVersionException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\Factory\WikiFactoryInterface;
 use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
 use Source\Wiki\Wiki\Domain\Factory\WikiSnapshotFactoryInterface;
@@ -47,14 +46,15 @@ readonly class PublishWiki implements PublishWikiInterface
 
     /**
      * @param PublishWikiInputPort $input
-     * @return Wiki
+     * @param PublishWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws InvalidStatusException
      * @throws InconsistentVersionException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(PublishWikiInputPort $input): Wiki
+    public function process(PublishWikiInputPort $input, PublishWikiOutputPort $output): void
     {
         $wiki = $this->draftWikiRepository->findById($input->wikiIdentifier());
 
@@ -157,6 +157,6 @@ readonly class PublishWiki implements PublishWikiInterface
 
         $this->draftWikiRepository->delete($wiki);
 
-        return $publishedWiki;
+        $output->setWiki($publishedWiki);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiInterface.php
@@ -9,18 +9,18 @@ use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Wiki\Application\Exception\InconsistentVersionException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\Wiki;
 
 interface PublishWikiInterface
 {
     /**
      * @param PublishWikiInputPort $input
-     * @return Wiki
+     * @param PublishWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws InvalidStatusException
      * @throws InconsistentVersionException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(PublishWikiInputPort $input): Wiki;
+    public function process(PublishWikiInputPort $input, PublishWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\Wiki;
+
+class PublishWikiOutput implements PublishWikiOutputPort
+{
+    private ?Wiki $wiki = null;
+
+    public function setWiki(Wiki $wiki): void
+    {
+        $this->wiki = $wiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, version: ?int}
+     */
+    public function toArray(): array
+    {
+        if ($this->wiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'version' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->wiki->language()->value,
+            'name' => (string) $this->wiki->basic()->name(),
+            'resourceType' => $this->wiki->resourceType()->value,
+            'version' => $this->wiki->version()->value(),
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\Wiki;
+
+interface PublishWikiOutputPort
+{
+    public function setWiki(Wiki $wiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, version: ?int}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWiki.php
@@ -14,7 +14,6 @@ use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
 use Source\Wiki\Shared\Domain\ValueObject\HistoryActionType;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\WikiHistoryRepositoryInterface;
@@ -34,13 +33,14 @@ readonly class RejectWiki implements RejectWikiInterface
 
     /**
      * @param RejectWikiInputPort $input
-     * @return DraftWiki
+     * @param RejectWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws InvalidStatusException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(RejectWikiInputPort $input): DraftWiki
+    public function process(RejectWikiInputPort $input, RejectWikiOutputPort $output): void
     {
         $wiki = $this->draftWikiRepository->findById($input->wikiIdentifier());
 
@@ -93,6 +93,6 @@ readonly class RejectWiki implements RejectWikiInterface
         );
         $this->wikiHistoryRepository->save($history);
 
-        return $wiki;
+        $output->setDraftWiki($wiki);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiInterface.php
@@ -8,17 +8,17 @@ use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 
 interface RejectWikiInterface
 {
     /**
      * @param RejectWikiInputPort $input
-     * @return DraftWiki
+     * @param RejectWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws InvalidStatusException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(RejectWikiInputPort $input): DraftWiki;
+    public function process(RejectWikiInputPort $input, RejectWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class RejectWikiOutput implements RejectWikiOutputPort
+{
+    private ?DraftWiki $draftWiki = null;
+
+    public function setDraftWiki(DraftWiki $draftWiki): void
+    {
+        $this->draftWiki = $draftWiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->draftWiki->language()->value,
+            'name' => (string) $this->draftWiki->basic()->name(),
+            'resourceType' => $this->draftWiki->resourceType()->value,
+            'status' => $this->draftWiki->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface RejectWikiOutputPort
+{
+    public function setDraftWiki(DraftWiki $draftWiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWiki.php
@@ -15,7 +15,6 @@ use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\HistoryActionType;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
 use Source\Wiki\Wiki\Domain\Factory\WikiSnapshotFactoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\WikiHistoryRepositoryInterface;
@@ -38,7 +37,8 @@ readonly class RollbackWiki implements RollbackWikiInterface
 
     /**
      * @param RollbackWikiInputPort $input
-     * @return Wiki[]
+     * @param RollbackWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws SnapshotNotFoundException
      * @throws VersionMismatchException
@@ -46,7 +46,7 @@ readonly class RollbackWiki implements RollbackWikiInterface
      * @throws PrincipalNotFoundException
      * @throws DisallowedException
      */
-    public function process(RollbackWikiInputPort $input): array
+    public function process(RollbackWikiInputPort $input, RollbackWikiOutputPort $output): void
     {
         // 1. Wiki存在確認
         $wiki = $this->wikiRepository->findById($input->wikiIdentifier());
@@ -154,6 +154,6 @@ readonly class RollbackWiki implements RollbackWikiInterface
             $rolledBackWikis[] = $w;
         }
 
-        return $rolledBackWikis;
+        $output->setWikis($rolledBackWikis);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiInterface.php
@@ -10,13 +10,13 @@ use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\Exception\SnapshotNotFoundException;
 use Source\Wiki\Shared\Domain\Exception\VersionMismatchException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\Wiki;
 
 interface RollbackWikiInterface
 {
     /**
      * @param RollbackWikiInputPort $input
-     * @return Wiki[]
+     * @param RollbackWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws SnapshotNotFoundException
      * @throws VersionMismatchException
@@ -24,5 +24,5 @@ interface RollbackWikiInterface
      * @throws PrincipalNotFoundException
      * @throws DisallowedException
      */
-    public function process(RollbackWikiInputPort $input): array;
+    public function process(RollbackWikiInputPort $input, RollbackWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutput.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\Wiki;
+
+class RollbackWikiOutput implements RollbackWikiOutputPort
+{
+    /** @var Wiki[]|null */
+    private ?array $wikis = null;
+
+    /**
+     * @param Wiki[] $wikis
+     */
+    public function setWikis(array $wikis): void
+    {
+        $this->wikis = $wikis;
+    }
+
+    /**
+     * @return array{wikis: array<int, array{language: string, name: string, resourceType: string, version: int}>}
+     */
+    public function toArray(): array
+    {
+        if ($this->wikis === null) {
+            return ['wikis' => []];
+        }
+
+        return [
+            'wikis' => array_map(
+                static fn (Wiki $wiki) => [
+                    'language' => $wiki->language()->value,
+                    'name' => (string) $wiki->basic()->name(),
+                    'resourceType' => $wiki->resourceType()->value,
+                    'version' => $wiki->version()->value(),
+                ],
+                $this->wikis,
+            ),
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\Wiki;
+
+interface RollbackWikiOutputPort
+{
+    /**
+     * @param Wiki[] $wikis
+     */
+    public function setWikis(array $wikis): void;
+
+    /**
+     * @return array{wikis: array<int, array{language: string, name: string, resourceType: string, version: int}>}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWiki.php
@@ -14,7 +14,6 @@ use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
 use Source\Wiki\Shared\Domain\ValueObject\HistoryActionType;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\WikiHistoryRepositoryInterface;
@@ -34,13 +33,14 @@ readonly class SubmitWiki implements SubmitWikiInterface
 
     /**
      * @param SubmitWikiInputPort $input
-     * @return DraftWiki
+     * @param SubmitWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws InvalidStatusException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(SubmitWikiInputPort $input): DraftWiki
+    public function process(SubmitWikiInputPort $input, SubmitWikiOutputPort $output): void
     {
         $wiki = $this->draftWikiRepository->findById($input->wikiIdentifier());
 
@@ -94,6 +94,6 @@ readonly class SubmitWiki implements SubmitWikiInterface
         );
         $this->wikiHistoryRepository->save($history);
 
-        return $wiki;
+        $output->setDraftWiki($wiki);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiInterface.php
@@ -8,17 +8,17 @@ use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 
 interface SubmitWikiInterface
 {
     /**
      * @param SubmitWikiInputPort $input
-     * @return DraftWiki
+     * @param SubmitWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws InvalidStatusException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(SubmitWikiInputPort $input): DraftWiki;
+    public function process(SubmitWikiInputPort $input, SubmitWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class SubmitWikiOutput implements SubmitWikiOutputPort
+{
+    private ?DraftWiki $draftWiki = null;
+
+    public function setDraftWiki(DraftWiki $draftWiki): void
+    {
+        $this->draftWiki = $draftWiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->draftWiki->language()->value,
+            'name' => (string) $this->draftWiki->basic()->name(),
+            'resourceType' => $this->draftWiki->resourceType()->value,
+            'status' => $this->draftWiki->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface SubmitWikiOutputPort
+{
+    public function setDraftWiki(DraftWiki $draftWiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
@@ -14,7 +14,6 @@ use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\Service\TranslationServiceInterface;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Factory\DraftWikiFactoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
@@ -34,12 +33,13 @@ readonly class TranslateWiki implements TranslateWikiInterface
 
     /**
      * @param TranslateWikiInputPort $input
-     * @return DraftWiki[]
+     * @param TranslateWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(TranslateWikiInputPort $input): array
+    public function process(TranslateWikiInputPort $input, TranslateWikiOutputPort $output): void
     {
         $wiki = $this->wikiRepository->findById($input->wikiIdentifier());
 
@@ -95,6 +95,6 @@ readonly class TranslateWiki implements TranslateWikiInterface
             $this->draftWikiRepository->save($wikiDraft);
         }
 
-        return $wikiDrafts;
+        $output->setDraftWikis($wikiDrafts);
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiInterface.php
@@ -7,16 +7,16 @@ namespace Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
-use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 
 interface TranslateWikiInterface
 {
     /**
      * @param TranslateWikiInputPort $input
-     * @return DraftWiki[]
+     * @param TranslateWikiOutputPort $output
+     * @return void
      * @throws WikiNotFoundException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(TranslateWikiInputPort $input): array;
+    public function process(TranslateWikiInputPort $input, TranslateWikiOutputPort $output): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutput.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class TranslateWikiOutput implements TranslateWikiOutputPort
+{
+    /** @var DraftWiki[]|null */
+    private ?array $draftWikis = null;
+
+    /**
+     * @param DraftWiki[] $draftWikis
+     */
+    public function setDraftWikis(array $draftWikis): void
+    {
+        $this->draftWikis = $draftWikis;
+    }
+
+    /**
+     * @return array{draftWikis: array<int, array{language: string, name: string, resourceType: string, status: string}>}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWikis === null) {
+            return ['draftWikis' => []];
+        }
+
+        return [
+            'draftWikis' => array_map(
+                static fn (DraftWiki $draftWiki) => [
+                    'language' => $draftWiki->language()->value,
+                    'name' => (string) $draftWiki->basic()->name(),
+                    'resourceType' => $draftWiki->resourceType()->value,
+                    'status' => $draftWiki->status()->value,
+                ],
+                $this->draftWikis,
+            ),
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface TranslateWikiOutputPort
+{
+    /**
+     * @param DraftWiki[] $draftWikis
+     */
+    public function setDraftWikis(array $draftWikis): void;
+
+    /**
+     * @return array{draftWikis: array<int, array{language: string, name: string, resourceType: string, status: string}>}
+     */
+    public function toArray(): array;
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiOutputTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AutoCreateWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftWikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftWiki(): void
+    {
+        $draftWiki = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new AutoCreateWikiOutput();
+        $output->setDraftWiki($draftWiki);
+
+        $result = $output->toArray();
+
+        $this->assertSame('ko', $result['language']);
+        $this->assertSame('TWICE', $result['name']);
+        $this->assertSame('group', $result['resourceType']);
+        $this->assertSame('pending', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftWikiがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftWiki(): void
+    {
+        $output = new AutoCreateWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiTest.php
@@ -19,6 +19,7 @@ use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Shared\Domain\ValueObject\Slug;
 use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWikiOutput;
 use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\GeneratedWikiData;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Service\AutoWikiCreationServiceInterface;
@@ -91,13 +92,12 @@ class AutoCreateWikiTest extends TestCase
         $input = new AutoCreateWikiInput($payload, $principalIdentifier);
         $useCase = $this->app->make(AutoCreateWikiInterface::class);
 
-        $result = $useCase->process($input);
+        $output = new AutoCreateWikiOutput();
+        $useCase->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertEquals((string) $payload->name(), (string) $result->basic()->name());
-        $this->assertEquals('ㅌㅇㅇㅅ', $result->basic()->normalizedName());
-        $this->assertEquals('twice', (string) $result->slug());
-        $this->assertEquals(ResourceType::GROUP, $result->resourceType());
-        $this->assertFalse($result->sections()->isEmpty());
+        $this->assertSame((string) $payload->name(), $result['name']);
+        $this->assertSame(ResourceType::GROUP->value, $result['resourceType']);
     }
 
     /**
@@ -153,11 +153,11 @@ class AutoCreateWikiTest extends TestCase
         $input = new AutoCreateWikiInput($payload, $principalIdentifier);
         $useCase = $this->app->make(AutoCreateWikiInterface::class);
 
-        $result = $useCase->process($input);
+        $output = new AutoCreateWikiOutput();
+        $useCase->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertEquals((string) $payload->name(), (string) $result->basic()->name());
-        $this->assertEquals('ㅌㅇㅇㅅ', $result->basic()->normalizedName());
-        $this->assertEquals('twice', (string) $result->slug());
+        $this->assertSame((string) $payload->name(), $result['name']);
     }
 
     /**
@@ -196,7 +196,7 @@ class AutoCreateWikiTest extends TestCase
         $useCase = $this->app->make(AutoCreateWikiInterface::class);
 
         $this->expectException(DisallowedException::class);
-        $useCase->process($input);
+        $useCase->process($input, new AutoCreateWikiOutput());
     }
 
     /**
@@ -232,7 +232,7 @@ class AutoCreateWikiTest extends TestCase
         $useCase = $this->app->make(AutoCreateWikiInterface::class);
 
         $this->expectException(PrincipalNotFoundException::class);
-        $useCase->process($input);
+        $useCase->process($input, new AutoCreateWikiOutput());
     }
 
     /**
@@ -293,9 +293,11 @@ class AutoCreateWikiTest extends TestCase
         $input = new AutoCreateWikiInput($payload, $principalIdentifier);
         $useCase = $this->app->make(AutoCreateWikiInterface::class);
 
-        $result = $useCase->process($input);
+        $output = new AutoCreateWikiOutput();
+        $useCase->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertTrue($result->sections()->isEmpty());
+        $this->assertNotNull($result['language']);
     }
 
     private function makePayload(): AutoWikiCreationPayload

--- a/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiOutputTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\CreateWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreateWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftWikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftWiki(): void
+    {
+        $draftWiki = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new CreateWikiOutput();
+        $output->setDraftWiki($draftWiki);
+
+        $result = $output->toArray();
+
+        $this->assertSame('ko', $result['language']);
+        $this->assertSame('TWICE', $result['name']);
+        $this->assertSame('group', $result['resourceType']);
+        $this->assertSame('pending', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftWikiがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftWiki(): void
+    {
+        $output = new CreateWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiTest.php
@@ -6,7 +6,6 @@ namespace Tests\Wiki\Wiki\Application\UseCase\Command\CreateWiki;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
-use Source\Shared\Application\Service\Uuid\UuidValidator;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\Language;
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
@@ -24,6 +23,7 @@ use Source\Wiki\Shared\Domain\ValueObject\Version;
 use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\Factory\DraftWikiFactoryInterface;
@@ -103,7 +103,7 @@ class CreateWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $useCase = $this->app->make(CreateWikiInterface::class);
-        $useCase->process($input);
+        $useCase->process($input, new CreateWikiOutput());
     }
 
     /**
@@ -157,7 +157,7 @@ class CreateWikiTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $useCase = $this->app->make(CreateWikiInterface::class);
-        $useCase->process($input);
+        $useCase->process($input, new CreateWikiOutput());
     }
 
     /**
@@ -216,7 +216,7 @@ class CreateWikiTest extends TestCase
 
         $this->expectException(DuplicateSlugException::class);
         $useCase = $this->app->make(CreateWikiInterface::class);
-        $useCase->process($input);
+        $useCase->process($input, new CreateWikiOutput());
     }
 
     /**
@@ -289,18 +289,14 @@ class CreateWikiTest extends TestCase
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
 
         $useCase = $this->app->make(CreateWikiInterface::class);
-        $wiki = $useCase->process($input);
+        $output = new CreateWikiOutput();
+        $useCase->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertTrue(UuidValidator::isValid((string) $wiki->wikiIdentifier()));
-        $this->assertSame((string) $testData->publishedWikiIdentifier, (string) $wiki->publishedWikiIdentifier());
-        $this->assertSame((string) $testData->translationSetIdentifier, (string) $wiki->translationSetIdentifier());
-        $this->assertSame((string) $testData->editorIdentifier, (string) $wiki->editorIdentifier());
-        $this->assertSame($testData->language->value, $wiki->language()->value);
-        $this->assertSame($testData->resourceType->value, $wiki->resourceType()->value);
-        $this->assertSame($testData->basic, $wiki->basic());
-        $this->assertSame($testData->sections, $wiki->sections());
-        $this->assertSame((string) $testData->themeColor, (string) $wiki->themeColor());
-        $this->assertSame($testData->status, $wiki->status());
+        $this->assertSame($testData->language->value, $result['language']);
+        $this->assertSame((string) $testData->basic->name(), $result['name']);
+        $this->assertSame($testData->resourceType->value, $result['resourceType']);
+        $this->assertSame($testData->status->value, $result['status']);
     }
 
     /**

--- a/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\EditWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class EditWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftWikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftWiki(): void
+    {
+        $draftWiki = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new EditWikiOutput();
+        $output->setDraftWiki($draftWiki);
+
+        $result = $output->toArray();
+
+        $this->assertSame('ko', $result['language']);
+        $this->assertSame('TWICE', $result['name']);
+        $this->assertSame('group', $result['resourceType']);
+        $this->assertSame('pending', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftWikiがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftWiki(): void
+    {
+        $output = new EditWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiTest.php
@@ -22,6 +22,7 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
@@ -122,15 +123,14 @@ class EditWikiTest extends TestCase
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
 
         $editWiki = $this->app->make(EditWikiInterface::class);
-        $wiki = $editWiki->process($input);
+        $output = new EditWikiOutput();
+        $editWiki->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertSame((string) $testData->wikiIdentifier, (string) $wiki->wikiIdentifier());
-        $this->assertSame($updatedBasic, $wiki->basic());
-        $this->assertSame($updatedSections, $wiki->sections());
-        $this->assertSame((string) $updatedThemeColor, (string) $wiki->themeColor());
-        $this->assertSame($testData->language->value, $wiki->language()->value);
-        $this->assertSame($testData->resourceType->value, $wiki->resourceType()->value);
-        $this->assertSame($testData->status, $wiki->status());
+        $this->assertSame($testData->language->value, $result['language']);
+        $this->assertSame((string) $updatedBasic->name(), $result['name']);
+        $this->assertSame($testData->resourceType->value, $result['resourceType']);
+        $this->assertSame($testData->status->value, $result['status']);
     }
 
     /**
@@ -173,7 +173,7 @@ class EditWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $editWiki = $this->app->make(EditWikiInterface::class);
-        $editWiki->process($input);
+        $editWiki->process($input, new EditWikiOutput());
     }
 
     /**
@@ -219,7 +219,7 @@ class EditWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $editWiki = $this->app->make(EditWikiInterface::class);
-        $editWiki->process($input);
+        $editWiki->process($input, new EditWikiOutput());
     }
 
     /**
@@ -274,7 +274,7 @@ class EditWikiTest extends TestCase
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
 
         $editWiki = $this->app->make(EditWikiInterface::class);
-        $editWiki->process($input);
+        $editWiki->process($input, new EditWikiOutput());
     }
 
     /**
@@ -325,7 +325,7 @@ class EditWikiTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $editWiki = $this->app->make(EditWikiInterface::class);
-        $editWiki->process($input);
+        $editWiki->process($input, new EditWikiOutput());
     }
 
     /**

--- a/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\MergeWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class MergeWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftWikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftWiki(): void
+    {
+        $draftWiki = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new MergeWikiOutput();
+        $output->setDraftWiki($draftWiki);
+
+        $result = $output->toArray();
+
+        $this->assertSame('ko', $result['language']);
+        $this->assertSame('TWICE', $result['name']);
+        $this->assertSame('group', $result['resourceType']);
+        $this->assertSame('pending', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftWikiがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftWiki(): void
+    {
+        $output = new MergeWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiTest.php
@@ -23,6 +23,7 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
@@ -125,17 +126,14 @@ class MergeWikiTest extends TestCase
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
 
         $mergeWiki = $this->app->make(MergeWikiInterface::class);
-        $wiki = $mergeWiki->process($input);
+        $output = new MergeWikiOutput();
+        $mergeWiki->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertSame((string) $testData->wikiIdentifier, (string) $wiki->wikiIdentifier());
-        $this->assertSame($updatedBasic, $wiki->basic());
-        $this->assertSame($updatedSections, $wiki->sections());
-        $this->assertSame((string) $updatedThemeColor, (string) $wiki->themeColor());
-        $this->assertSame($testData->language->value, $wiki->language()->value);
-        $this->assertSame($testData->resourceType->value, $wiki->resourceType()->value);
-        $this->assertSame($testData->status, $wiki->status());
-        $this->assertSame($principalIdentifier, $wiki->mergerIdentifier());
-        $this->assertSame($mergedAt, $wiki->mergedAt());
+        $this->assertSame($testData->language->value, $result['language']);
+        $this->assertSame((string) $updatedBasic->name(), $result['name']);
+        $this->assertSame($testData->resourceType->value, $result['resourceType']);
+        $this->assertSame($testData->status->value, $result['status']);
     }
 
     /**
@@ -180,7 +178,7 @@ class MergeWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $mergeWiki = $this->app->make(MergeWikiInterface::class);
-        $mergeWiki->process($input);
+        $mergeWiki->process($input, new MergeWikiOutput());
     }
 
     /**
@@ -228,7 +226,7 @@ class MergeWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $mergeWiki = $this->app->make(MergeWikiInterface::class);
-        $mergeWiki->process($input);
+        $mergeWiki->process($input, new MergeWikiOutput());
     }
 
     /**
@@ -285,7 +283,7 @@ class MergeWikiTest extends TestCase
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
 
         $mergeWiki = $this->app->make(MergeWikiInterface::class);
-        $mergeWiki->process($input);
+        $mergeWiki->process($input, new MergeWikiOutput());
     }
 
     /**
@@ -338,7 +336,7 @@ class MergeWikiTest extends TestCase
 
         $this->expectException(UnauthorizedException::class);
         $mergeWiki = $this->app->make(MergeWikiInterface::class);
-        $mergeWiki->process($input);
+        $mergeWiki->process($input, new MergeWikiOutput());
     }
 
     /**

--- a/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\PublishWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Shared\Domain\ValueObject\Version;
+use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\Wiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class PublishWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: Wikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithWiki(): void
+    {
+        $wiki = new Wiki(
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            new Version(3),
+        );
+
+        $output = new PublishWikiOutput();
+        $output->setWiki($wiki);
+
+        $result = $output->toArray();
+
+        $this->assertSame('ko', $result['language']);
+        $this->assertSame('TWICE', $result['name']);
+        $this->assertSame('group', $result['resourceType']);
+        $this->assertSame(3, $result['version']);
+    }
+
+    /**
+     * 正常系: Wikiがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutWiki(): void
+    {
+        $output = new PublishWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'version' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiTest.php
@@ -27,6 +27,7 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\PublishWiki\PublishWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\Entity\WikiHistory;
@@ -175,11 +176,12 @@ class PublishWikiTest extends TestCase
         $this->app->instance(WikiSnapshotRepositoryInterface::class, $wikiSnapshotRepository);
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishedWiki = $publishWiki->process($input);
-        $this->assertSame((string) $dummyPublishWiki->publishedWikiIdentifier, (string) $publishedWiki->wikiIdentifier());
-        $this->assertSame($dummyPublishWiki->language->value, $publishedWiki->language()->value);
-        $this->assertSame((string) $dummyPublishWiki->name, (string) $publishedWiki->basic()->name());
-        $this->assertSame($dummyPublishWiki->publishedVersion->value() + 1, $publishedWiki->version()->value());
+        $output = new PublishWikiOutput();
+        $publishWiki->process($input, $output);
+        $result = $output->toArray();
+        $this->assertSame($dummyPublishWiki->language->value, $result['language']);
+        $this->assertSame((string) $dummyPublishWiki->name, $result['name']);
+        $this->assertSame($dummyPublishWiki->publishedVersion->value() + 1, $result['version']);
     }
 
     /**
@@ -277,11 +279,11 @@ class PublishWikiTest extends TestCase
         $this->app->instance(WikiSnapshotRepositoryInterface::class, $wikiSnapshotRepository);
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishedWiki = $publishWiki->process($input);
-        $this->assertSame((string) $dummyPublishWiki->publishedWikiIdentifier, (string) $publishedWiki->wikiIdentifier());
-        $this->assertSame($dummyPublishWiki->language->value, $publishedWiki->language()->value);
-        $this->assertSame((string) $dummyPublishWiki->translationSetIdentifier, (string) $publishedWiki->translationSetIdentifier());
-        $this->assertSame($dummyPublishWiki->version->value(), $publishedWiki->version()->value());
+        $output = new PublishWikiOutput();
+        $publishWiki->process($input, $output);
+        $result = $output->toArray();
+        $this->assertSame($dummyPublishWiki->language->value, $result['language']);
+        $this->assertSame($dummyPublishWiki->version->value(), $result['version']);
     }
 
     /**
@@ -331,7 +333,7 @@ class PublishWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishWiki->process($input);
+        $publishWiki->process($input, new PublishWikiOutput());
     }
 
     /**
@@ -384,7 +386,7 @@ class PublishWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishWiki->process($input);
+        $publishWiki->process($input, new PublishWikiOutput());
     }
 
     /**
@@ -433,7 +435,7 @@ class PublishWikiTest extends TestCase
 
         $this->expectException(InvalidStatusException::class);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishWiki->process($input);
+        $publishWiki->process($input, new PublishWikiOutput());
     }
 
     /**
@@ -493,7 +495,7 @@ class PublishWikiTest extends TestCase
 
         $this->expectException(InconsistentVersionException::class);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishWiki->process($input);
+        $publishWiki->process($input, new PublishWikiOutput());
     }
 
     /**
@@ -556,7 +558,7 @@ class PublishWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishWiki->process($input);
+        $publishWiki->process($input, new PublishWikiOutput());
     }
 
     /**
@@ -612,7 +614,7 @@ class PublishWikiTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishWiki->process($input);
+        $publishWiki->process($input, new PublishWikiOutput());
     }
 
     /**
@@ -701,7 +703,7 @@ class PublishWikiTest extends TestCase
         $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
 
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $publishWiki->process($input);
+        $publishWiki->process($input, new PublishWikiOutput());
 
         $this->assertSame(ApprovalStatus::UnderReview, $dummyPublishWiki->status);
     }
@@ -820,9 +822,11 @@ class PublishWikiTest extends TestCase
         $this->app->instance(ContributionPointServiceInterface::class, $contributionPointService);
 
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $result = $publishWiki->process($input);
+        $output = new PublishWikiOutput();
+        $publishWiki->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertSame((string) $dummyPublishWiki->publishedWikiIdentifier, (string) $result->wikiIdentifier());
+        $this->assertNotNull($result['language']);
     }
 
     /**
@@ -937,9 +941,11 @@ class PublishWikiTest extends TestCase
         $this->app->instance(ContributionPointServiceInterface::class, $contributionPointService);
 
         $publishWiki = $this->app->make(PublishWikiInterface::class);
-        $result = $publishWiki->process($input);
+        $output = new PublishWikiOutput();
+        $publishWiki->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertSame((string) $dummyPublishWiki->publishedWikiIdentifier, (string) $result->wikiIdentifier());
+        $this->assertNotNull($result['language']);
     }
 
     /**

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\RejectWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RejectWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftWikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftWiki(): void
+    {
+        $draftWiki = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new RejectWikiOutput();
+        $output->setDraftWiki($draftWiki);
+
+        $result = $output->toArray();
+
+        $this->assertSame('ko', $result['language']);
+        $this->assertSame('TWICE', $result['name']);
+        $this->assertSame('group', $result['resourceType']);
+        $this->assertSame('pending', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftWikiがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftWiki(): void
+    {
+        $output = new RejectWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiTest.php
@@ -25,6 +25,7 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\RejectWiki\RejectWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Entity\WikiHistory;
 use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
@@ -126,9 +127,10 @@ class RejectWikiTest extends TestCase
         $this->app->instance(WikiHistoryRepositoryInterface::class, $wikiHistoryRepository);
         $this->app->instance(WikiHistoryFactoryInterface::class, $wikiHistoryFactory);
         $rejectWiki = $this->app->make(RejectWikiInterface::class);
-        $wiki = $rejectWiki->process($input);
-        $this->assertNotSame($dummyRejectWiki->status, $wiki->status());
-        $this->assertSame(ApprovalStatus::Rejected, $wiki->status());
+        $output = new RejectWikiOutput();
+        $rejectWiki->process($input, $output);
+        $result = $output->toArray();
+        $this->assertSame(ApprovalStatus::Rejected->value, $result['status']);
     }
 
     /**
@@ -174,7 +176,7 @@ class RejectWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $rejectWiki = $this->app->make(RejectWikiInterface::class);
-        $rejectWiki->process($input);
+        $rejectWiki->process($input, new RejectWikiOutput());
     }
 
     /**
@@ -223,7 +225,7 @@ class RejectWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $rejectWiki = $this->app->make(RejectWikiInterface::class);
-        $rejectWiki->process($input);
+        $rejectWiki->process($input, new RejectWikiOutput());
     }
 
     /**
@@ -269,7 +271,7 @@ class RejectWikiTest extends TestCase
 
         $this->expectException(InvalidStatusException::class);
         $rejectWiki = $this->app->make(RejectWikiInterface::class);
-        $rejectWiki->process($input);
+        $rejectWiki->process($input, new RejectWikiOutput());
     }
 
     /**
@@ -323,7 +325,7 @@ class RejectWikiTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $rejectWiki = $this->app->make(RejectWikiInterface::class);
-        $rejectWiki->process($input);
+        $rejectWiki->process($input, new RejectWikiOutput());
     }
 
     /**

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\RollbackWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Shared\Domain\ValueObject\Version;
+use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\Wiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RollbackWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: Wikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithWikis(): void
+    {
+        $wiki1 = new Wiki(
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            new Version(3),
+        );
+
+        $wiki2 = new Wiki(
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice-ja'),
+            Language::JAPANESE,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            new Version(3),
+        );
+
+        $output = new RollbackWikiOutput();
+        $output->setWikis([$wiki1, $wiki2]);
+
+        $result = $output->toArray();
+
+        $this->assertCount(2, $result['wikis']);
+        $this->assertSame('ko', $result['wikis'][0]['language']);
+        $this->assertSame('TWICE', $result['wikis'][0]['name']);
+        $this->assertSame('group', $result['wikis'][0]['resourceType']);
+        $this->assertSame(3, $result['wikis'][0]['version']);
+        $this->assertSame('ja', $result['wikis'][1]['language']);
+    }
+
+    /**
+     * 正常系: Wikiがセットされていない場合、toArrayが空の配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutWikis(): void
+    {
+        $output = new RollbackWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame(['wikis' => []], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiTest.php
@@ -25,6 +25,7 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\RollbackWiki\RollbackWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\Entity\WikiHistory;
 use Source\Wiki\Wiki\Domain\Entity\WikiSnapshot;
@@ -156,12 +157,13 @@ class RollbackWikiTest extends TestCase
         $this->app->instance(WikiHistoryRepositoryInterface::class, $wikiHistoryRepository);
 
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $result = $rollbackWiki->process($input);
+        $output = new RollbackWikiOutput();
+        $rollbackWiki->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertCount(1, $result);
-        $this->assertSame((string) $wikiIdentifier, (string) $result[0]->wikiIdentifier());
-        $this->assertSame((string) $snapshot->basic()->name(), (string) $result[0]->basic()->name());
-        $this->assertSame(6, $result[0]->version()->value());
+        $this->assertCount(1, $result['wikis']);
+        $this->assertSame((string) $snapshot->basic()->name(), $result['wikis'][0]['name']);
+        $this->assertSame(6, $result['wikis'][0]['version']);
     }
 
     /**
@@ -260,9 +262,11 @@ class RollbackWikiTest extends TestCase
         $this->app->instance(WikiHistoryRepositoryInterface::class, $wikiHistoryRepository);
 
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $result = $rollbackWiki->process($input);
+        $output = new RollbackWikiOutput();
+        $rollbackWiki->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result['wikis']);
     }
 
     /**
@@ -321,7 +325,7 @@ class RollbackWikiTest extends TestCase
         $this->expectException(DisallowedException::class);
         $this->setPolicyEvaluatorResult(false);
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $rollbackWiki->process($input);
+        $rollbackWiki->process($input, new RollbackWikiOutput());
     }
 
     /**
@@ -361,7 +365,7 @@ class RollbackWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $rollbackWiki->process($input);
+        $rollbackWiki->process($input, new RollbackWikiOutput());
     }
 
     /**
@@ -411,7 +415,7 @@ class RollbackWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $rollbackWiki->process($input);
+        $rollbackWiki->process($input, new RollbackWikiOutput());
     }
 
     /**
@@ -481,7 +485,7 @@ class RollbackWikiTest extends TestCase
 
         $this->expectException(SnapshotNotFoundException::class);
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $rollbackWiki->process($input);
+        $rollbackWiki->process($input, new RollbackWikiOutput());
     }
 
     /**
@@ -544,7 +548,7 @@ class RollbackWikiTest extends TestCase
 
         $this->expectException(VersionMismatchException::class);
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $rollbackWiki->process($input);
+        $rollbackWiki->process($input, new RollbackWikiOutput());
     }
 
     /**
@@ -602,7 +606,7 @@ class RollbackWikiTest extends TestCase
 
         $this->expectException(InvalidRollbackTargetVersionException::class);
         $rollbackWiki = $this->app->make(RollbackWikiInterface::class);
-        $rollbackWiki->process($input);
+        $rollbackWiki->process($input, new RollbackWikiOutput());
     }
 
     private function createWiki(

--- a/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\SubmitWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class SubmitWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftWikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftWiki(): void
+    {
+        $draftWiki = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new SubmitWikiOutput();
+        $output->setDraftWiki($draftWiki);
+
+        $result = $output->toArray();
+
+        $this->assertSame('ko', $result['language']);
+        $this->assertSame('TWICE', $result['name']);
+        $this->assertSame('group', $result['resourceType']);
+        $this->assertSame('pending', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftWikiがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftWiki(): void
+    {
+        $output = new SubmitWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiTest.php
@@ -24,6 +24,7 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Entity\WikiHistory;
 use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
@@ -123,9 +124,10 @@ class SubmitWikiTest extends TestCase
         $this->app->instance(WikiHistoryRepositoryInterface::class, $wikiHistoryRepository);
         $this->app->instance(WikiHistoryFactoryInterface::class, $wikiHistoryFactory);
         $submitWiki = $this->app->make(SubmitWikiInterface::class);
-        $wiki = $submitWiki->process($input);
-        $this->assertNotSame($dummySubmitWiki->status, $wiki->status());
-        $this->assertSame(ApprovalStatus::UnderReview, $wiki->status());
+        $output = new SubmitWikiOutput();
+        $submitWiki->process($input, $output);
+        $result = $output->toArray();
+        $this->assertSame(ApprovalStatus::UnderReview->value, $result['status']);
     }
 
     /**
@@ -171,7 +173,7 @@ class SubmitWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $submitWiki = $this->app->make(SubmitWikiInterface::class);
-        $submitWiki->process($input);
+        $submitWiki->process($input, new SubmitWikiOutput());
     }
 
     /**
@@ -220,7 +222,7 @@ class SubmitWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $submitWiki = $this->app->make(SubmitWikiInterface::class);
-        $submitWiki->process($input);
+        $submitWiki->process($input, new SubmitWikiOutput());
     }
 
     /**
@@ -270,7 +272,7 @@ class SubmitWikiTest extends TestCase
 
         $this->expectException(InvalidStatusException::class);
         $submitWiki = $this->app->make(SubmitWikiInterface::class);
-        $submitWiki->process($input);
+        $submitWiki->process($input, new SubmitWikiOutput());
     }
 
     /**
@@ -322,7 +324,7 @@ class SubmitWikiTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $submitWiki = $this->app->make(SubmitWikiInterface::class);
-        $submitWiki->process($input);
+        $submitWiki->process($input, new SubmitWikiOutput());
     }
 
     /**

--- a/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\TranslateWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class TranslateWikiOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftWikiがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftWikis(): void
+    {
+        $draftWiki1 = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::JAPANESE,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $draftWiki2 = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('twice'),
+            Language::ENGLISH,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+                mainImageIdentifier: null,
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new TranslateWikiOutput();
+        $output->setDraftWikis([$draftWiki1, $draftWiki2]);
+
+        $result = $output->toArray();
+
+        $this->assertCount(2, $result['draftWikis']);
+        $this->assertSame('ja', $result['draftWikis'][0]['language']);
+        $this->assertSame('TWICE', $result['draftWikis'][0]['name']);
+        $this->assertSame('group', $result['draftWikis'][0]['resourceType']);
+        $this->assertSame('pending', $result['draftWikis'][0]['status']);
+        $this->assertSame('en', $result['draftWikis'][1]['language']);
+    }
+
+    /**
+     * 正常系: DraftWikiがセットされていない場合、toArrayが空の配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftWikis(): void
+    {
+        $output = new TranslateWikiOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame(['draftWikis' => []], $result);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
@@ -23,6 +23,7 @@ use Source\Wiki\Wiki\Application\Service\TranslationServiceInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiOutput;
 use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\Factory\DraftWikiFactoryInterface;
@@ -176,11 +177,11 @@ class TranslateWikiTest extends TestCase
         $this->app->instance(DraftWikiFactoryInterface::class, $draftWikiFactory);
 
         $translateWiki = $this->app->make(TranslateWikiInterface::class);
-        $wikis = $translateWiki->process($input);
+        $output = new TranslateWikiOutput();
+        $translateWiki->process($input, $output);
+        $result = $output->toArray();
 
-        $this->assertCount(2, $wikis);
-        $this->assertInstanceOf(DraftWiki::class, $wikis[0]);
-        $this->assertInstanceOf(DraftWiki::class, $wikis[1]);
+        $this->assertCount(2, $result['draftWikis']);
     }
 
     /**
@@ -218,7 +219,7 @@ class TranslateWikiTest extends TestCase
 
         $this->expectException(WikiNotFoundException::class);
         $translateWiki = $this->app->make(TranslateWikiInterface::class);
-        $translateWiki->process($input);
+        $translateWiki->process($input, new TranslateWikiOutput());
     }
 
     /**
@@ -258,7 +259,7 @@ class TranslateWikiTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $translateWiki = $this->app->make(TranslateWikiInterface::class);
-        $translateWiki->process($input);
+        $translateWiki->process($input, new TranslateWikiOutput());
     }
 
     /**
@@ -308,7 +309,7 @@ class TranslateWikiTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $translateWiki = $this->app->make(TranslateWikiInterface::class);
-        $translateWiki->process($input);
+        $translateWiki->process($input, new TranslateWikiOutput());
     }
 
     private function createTalentBasic(string $name): TalentBasic


### PR DESCRIPTION
## 📝 変更内容

- WikiサブドメインのすべてのCommand系ユースケース（AutoCreateWiki, CreateWiki, EditWiki, MergeWiki, PublishWiki, RejectWiki, RollbackWiki, SubmitWiki, TranslateWiki）にOutputパターン（Output DTO + OutputPort インターフェース）を導入
- 各ユースケースに対応するAPIエンドポイント（Action + Request）を作成
- エラーメッセージの多言語対応（en, es, ja, ko, zh_CN, zh_TW）を追加
- 既存のユースケーステストをOutputパターンに対応するよう更新
- 新規にOutput DTOのユニットテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)

## 🎯 変更理由・背景

WikiサブドメインのユースケースにClean ArchitectureのOutputパターンを導入し、ユースケース層とプレゼンテーション層の依存関係を適切に分離する。これにより、ユースケースの実行結果を統一的なOutput DTOで返却し、ActionクラスがOutputPortを実装してレスポンスを生成する構成となる。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Output DTO（`*Output.php`）のプロパティ設計が各ユースケースの責務に適切か
- OutputPort インターフェースの設計（特にRollbackWiki, TranslateWikiはエラーケースが多い）
- Action → Request → UseCase → Output → Action(OutputPort) のフローが一貫しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #266

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した