### PR TITLE
add: Delegation・DelegationPermissionにOutputパターン導入・エンドポイント作成

### DIFF
--- a/application/Http/Action/Account/Delegation/Command/ApproveDelegation/ApproveDelegationAction.php
+++ b/application/Http/Action/Account/Delegation/Command/ApproveDelegation/ApproveDelegationAction.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Delegation\Command\ApproveDelegation;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Delegation\Application\Exception\DelegationNotFoundException;
+use Source\Account\Delegation\Application\Exception\DisallowedDelegationOperationException;
+use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationInput;
+use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationInterface;
+use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationOutput;
+use Source\Account\Delegation\Domain\Exception\InvalidDelegationApprovalException;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ApproveDelegationAction
+{
+    public function __construct(
+        private ApproveDelegationInterface $approveDelegation,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param ApproveDelegationRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ApproveDelegationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ApproveDelegationInput(
+                    delegationIdentifier: new DelegationIdentifier($request->delegationId()),
+                    approverIdentifier: new IdentityIdentifier($request->approverIdentifier()),
+                );
+                $output = new ApproveDelegationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->approveDelegation->process($input, $output);
+                DB::commit();
+            } catch (DelegationNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('delegation_not_found', $language), previous: $e);
+            } catch (DisallowedDelegationOperationException $e) {
+                DB::rollBack();
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed_delegation_operation', $language), previous: $e);
+            } catch (InvalidDelegationApprovalException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_delegation_approval', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/Delegation/Command/ApproveDelegation/ApproveDelegationRequest.php
+++ b/application/Http/Action/Account/Delegation/Command/ApproveDelegation/ApproveDelegationRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Delegation\Command\ApproveDelegation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveDelegationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'approverIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function delegationId(): string
+    {
+        return (string) $this->route('delegationId');
+    }
+
+    public function approverIdentifier(): string
+    {
+        return (string) $this->input('approverIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Account/Delegation/Command/RequestDelegation/RequestDelegationAction.php
+++ b/application/Http/Action/Account/Delegation/Command/RequestDelegation/RequestDelegationAction.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Delegation\Command\RequestDelegation;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Affiliation\Application\Exception\AffiliationNotFoundException;
+use Source\Account\Affiliation\Application\Exception\InvalidAffiliationStatusException;
+use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegationInput;
+use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegationInterface;
+use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegationOutput;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RequestDelegationAction
+{
+    public function __construct(
+        private RequestDelegationInterface $requestDelegation,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RequestDelegationRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RequestDelegationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RequestDelegationInput(
+                    affiliationIdentifier: new AffiliationIdentifier($request->affiliationIdentifier()),
+                    delegateIdentifier: new IdentityIdentifier($request->delegateIdentifier()),
+                    delegatorIdentifier: new IdentityIdentifier($request->delegatorIdentifier()),
+                );
+                $output = new RequestDelegationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->requestDelegation->process($input, $output);
+                DB::commit();
+            } catch (AffiliationNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('affiliation_not_found', $language), previous: $e);
+            } catch (InvalidAffiliationStatusException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_affiliation_status', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Account/Delegation/Command/RequestDelegation/RequestDelegationRequest.php
+++ b/application/Http/Action/Account/Delegation/Command/RequestDelegation/RequestDelegationRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Delegation\Command\RequestDelegation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RequestDelegationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'affiliationIdentifier' => ['required', 'uuid'],
+            'delegateIdentifier' => ['required', 'uuid'],
+            'delegatorIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function affiliationIdentifier(): string
+    {
+        return (string) $this->input('affiliationIdentifier');
+    }
+
+    public function delegateIdentifier(): string
+    {
+        return (string) $this->input('delegateIdentifier');
+    }
+
+    public function delegatorIdentifier(): string
+    {
+        return (string) $this->input('delegatorIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Account/Delegation/Command/RevokeDelegation/RevokeDelegationAction.php
+++ b/application/Http/Action/Account/Delegation/Command/RevokeDelegation/RevokeDelegationAction.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Delegation\Command\RevokeDelegation;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Delegation\Application\Exception\DelegationNotFoundException;
+use Source\Account\Delegation\Application\Exception\DisallowedDelegationOperationException;
+use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegationInput;
+use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegationInterface;
+use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegationOutput;
+use Source\Account\Delegation\Domain\Exception\InvalidDelegationRevocationException;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RevokeDelegationAction
+{
+    public function __construct(
+        private RevokeDelegationInterface $revokeDelegation,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RevokeDelegationRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RevokeDelegationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RevokeDelegationInput(
+                    delegationIdentifier: new DelegationIdentifier($request->delegationId()),
+                    revokerIdentifier: new IdentityIdentifier($request->revokerIdentifier()),
+                );
+                $output = new RevokeDelegationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->revokeDelegation->process($input, $output);
+                DB::commit();
+            } catch (DelegationNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('delegation_not_found', $language), previous: $e);
+            } catch (DisallowedDelegationOperationException $e) {
+                DB::rollBack();
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed_delegation_operation', $language), previous: $e);
+            } catch (InvalidDelegationRevocationException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_delegation_revocation', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/Delegation/Command/RevokeDelegation/RevokeDelegationRequest.php
+++ b/application/Http/Action/Account/Delegation/Command/RevokeDelegation/RevokeDelegationRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Delegation\Command\RevokeDelegation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RevokeDelegationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'revokerIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function delegationId(): string
+    {
+        return (string) $this->route('delegationId');
+    }
+
+    public function revokerIdentifier(): string
+    {
+        return (string) $this->input('revokerIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Account/DelegationPermission/Command/GrantDelegationPermission/GrantDelegationPermissionAction.php
+++ b/application/Http/Action/Account/DelegationPermission/Command/GrantDelegationPermission/GrantDelegationPermissionAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\DelegationPermission\Command\GrantDelegationPermission;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermissionInput;
+use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermissionInterface;
+use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermissionOutput;
+use Source\Account\IdentityGroup\Application\Exception\IdentityGroupNotFoundException;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Account\Shared\Domain\ValueObject\IdentityGroupIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class GrantDelegationPermissionAction
+{
+    public function __construct(
+        private GrantDelegationPermissionInterface $grantDelegationPermission,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param GrantDelegationPermissionRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GrantDelegationPermissionRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GrantDelegationPermissionInput(
+                    identityGroupIdentifier: new IdentityGroupIdentifier($request->identityGroupIdentifier()),
+                    targetAccountIdentifier: new AccountIdentifier($request->targetAccountIdentifier()),
+                    affiliationIdentifier: new AffiliationIdentifier($request->affiliationIdentifier()),
+                );
+                $output = new GrantDelegationPermissionOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->grantDelegationPermission->process($input, $output);
+                DB::commit();
+            } catch (IdentityGroupNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('identity_group_not_found', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Account/DelegationPermission/Command/GrantDelegationPermission/GrantDelegationPermissionRequest.php
+++ b/application/Http/Action/Account/DelegationPermission/Command/GrantDelegationPermission/GrantDelegationPermissionRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\DelegationPermission\Command\GrantDelegationPermission;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GrantDelegationPermissionRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'identityGroupIdentifier' => ['required', 'uuid'],
+            'targetAccountIdentifier' => ['required', 'uuid'],
+            'affiliationIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function identityGroupIdentifier(): string
+    {
+        return (string) $this->input('identityGroupIdentifier');
+    }
+
+    public function targetAccountIdentifier(): string
+    {
+        return (string) $this->input('targetAccountIdentifier');
+    }
+
+    public function affiliationIdentifier(): string
+    {
+        return (string) $this->input('affiliationIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Account/DelegationPermission/Command/RevokeDelegationPermission/RevokeDelegationPermissionAction.php
+++ b/application/Http/Action/Account/DelegationPermission/Command/RevokeDelegationPermission/RevokeDelegationPermissionAction.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\DelegationPermission\Command\RevokeDelegationPermission;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\DelegationPermission\Application\Exception\DelegationPermissionNotFoundException;
+use Source\Account\DelegationPermission\Application\UseCase\Command\RevokeDelegationPermission\RevokeDelegationPermissionInput;
+use Source\Account\DelegationPermission\Application\UseCase\Command\RevokeDelegationPermission\RevokeDelegationPermissionInterface;
+use Source\Account\DelegationPermission\Domain\ValueObject\DelegationPermissionIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RevokeDelegationPermissionAction
+{
+    public function __construct(
+        private RevokeDelegationPermissionInterface $revokeDelegationPermission,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RevokeDelegationPermissionRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RevokeDelegationPermissionRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RevokeDelegationPermissionInput(
+                    delegationPermissionIdentifier: new DelegationPermissionIdentifier($request->delegationPermissionId()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->revokeDelegationPermission->process($input);
+                DB::commit();
+            } catch (DelegationPermissionNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('delegation_permission_not_found', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Account/DelegationPermission/Command/RevokeDelegationPermission/RevokeDelegationPermissionRequest.php
+++ b/application/Http/Action/Account/DelegationPermission/Command/RevokeDelegationPermission/RevokeDelegationPermissionRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\DelegationPermission\Command\RevokeDelegationPermission;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RevokeDelegationPermissionRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function delegationPermissionId(): string
+    {
+        return (string) $this->route('delegationPermissionId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -56,6 +56,13 @@ return [
     'cannot_remove_last_owner' => 'Cannot remove the last owner from the account.',
     'cannot_delete_default_identity_group' => 'Cannot delete the default identity group.',
     'cannot_delete_last_owner_group' => 'Cannot delete the last owner group with members.',
+    'delegation_not_found' => 'The specified delegation was not found.',
+    'disallowed_delegation_operation' => 'This delegation operation is not allowed.',
+    'invalid_delegation_approval' => 'Only pending delegations can be approved.',
+    'invalid_delegation_revocation' => 'Only approved delegations can be revoked.',
+    'affiliation_not_found' => 'The specified affiliation was not found.',
+    'invalid_affiliation_status' => 'The affiliation status is invalid for this operation.',
+    'delegation_permission_not_found' => 'The specified delegation permission was not found.',
 
     // Wiki
     'unauthorized' => 'This action is not authorized.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -56,6 +56,11 @@ return [
     'cannot_remove_last_owner' => 'No se puede eliminar al último propietario de la cuenta.',
     'cannot_delete_default_identity_group' => 'No se puede eliminar el grupo de identidad predeterminado.',
     'cannot_delete_last_owner_group' => 'No se puede eliminar el último grupo de propietarios con miembros.',
+    'delegation_not_found' => 'No se encontró la delegación especificada.',
+    'disallowed_delegation_operation' => 'Esta operación de delegación no está permitida.',
+    'invalid_delegation_approval' => 'Solo se pueden aprobar las delegaciones pendientes.',
+    'invalid_delegation_revocation' => 'Solo se pueden revocar las delegaciones aprobadas.',
+    'delegation_permission_not_found' => 'No se encontró el permiso de delegación especificado.',
 
     // Wiki
     'unauthorized' => 'Esta acción no está autorizada.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -56,6 +56,13 @@ return [
     'cannot_remove_last_owner' => 'アカウントから最後のオーナーを削除することはできません。',
     'cannot_delete_default_identity_group' => 'デフォルトのアイデンティティグループは削除できません。',
     'cannot_delete_last_owner_group' => 'メンバーがいる最後のオーナーグループは削除できません。',
+    'delegation_not_found' => '指定された委任が見つかりません。',
+    'disallowed_delegation_operation' => 'この委任操作は許可されていません。',
+    'invalid_delegation_approval' => '保留中の委任のみ承認できます。',
+    'invalid_delegation_revocation' => '承認済みの委任のみ取り消しできます。',
+    'affiliation_not_found' => '指定された所属が見つかりません。',
+    'invalid_affiliation_status' => '所属のステータスがこの操作に対して無効です。',
+    'delegation_permission_not_found' => '指定された委任許可が見つかりません。',
 
     // Wiki
     'unauthorized' => 'この操作は認可されていません。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -56,6 +56,13 @@ return [
     'cannot_remove_last_owner' => '계정에서 마지막 소유자를 제거할 수 없습니다.',
     'cannot_delete_default_identity_group' => '기본 아이덴티티 그룹은 삭제할 수 없습니다.',
     'cannot_delete_last_owner_group' => '멤버가 있는 마지막 소유자 그룹은 삭제할 수 없습니다.',
+    'delegation_not_found' => '지정된 위임을 찾을 수 없습니다.',
+    'disallowed_delegation_operation' => '이 위임 작업은 허용되지 않습니다.',
+    'invalid_delegation_approval' => '보류 중인 위임만 승인할 수 있습니다.',
+    'invalid_delegation_revocation' => '승인된 위임만 취소할 수 있습니다.',
+    'affiliation_not_found' => '지정된 소속을 찾을 수 없습니다.',
+    'invalid_affiliation_status' => '소속 상태가 이 작업에 유효하지 않습니다.',
+    'delegation_permission_not_found' => '지정된 위임 권한을 찾을 수 없습니다.',
 
     // Wiki
     'unauthorized' => '이 작업은 인가되지 않았습니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -56,6 +56,13 @@ return [
     'cannot_remove_last_owner' => '无法移除账户的最后一个所有者。',
     'cannot_delete_default_identity_group' => '无法删除默认身份组。',
     'cannot_delete_last_owner_group' => '无法删除有成员的最后一个所有者组。',
+    'delegation_not_found' => '找不到指定的委托。',
+    'disallowed_delegation_operation' => '不允许此委托操作。',
+    'invalid_delegation_approval' => '只能批准待处理的委托。',
+    'invalid_delegation_revocation' => '只能撤销已批准的委托。',
+    'affiliation_not_found' => '找不到指定的所属。',
+    'invalid_affiliation_status' => '所属状态对此操作无效。',
+    'delegation_permission_not_found' => '找不到指定的委托权限。',
 
     // Wiki
     'unauthorized' => '此操作未获授权。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -56,6 +56,13 @@ return [
     'cannot_remove_last_owner' => '無法移除帳戶的最後一個擁有者。',
     'cannot_delete_default_identity_group' => '無法刪除預設身分群組。',
     'cannot_delete_last_owner_group' => '無法刪除有成員的最後一個擁有者群組。',
+    'delegation_not_found' => '找不到指定的委託。',
+    'disallowed_delegation_operation' => '不允許此委託操作。',
+    'invalid_delegation_approval' => '只能核准待處理的委託。',
+    'invalid_delegation_revocation' => '只能撤銷已核准的委託。',
+    'affiliation_not_found' => '找不到指定的所屬。',
+    'invalid_affiliation_status' => '所屬狀態對此操作無效。',
+    'delegation_permission_not_found' => '找不到指定的委託權限。',
 
     // Wiki
     'unauthorized' => '此操作未獲授權。',

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 use Application\Http\Action\Account\Account\Command\CreateAccount\CreateAccountAction;
 use Application\Http\Action\Account\Account\Command\DeleteAccount\DeleteAccountAction;
+use Application\Http\Action\Account\Delegation\Command\ApproveDelegation\ApproveDelegationAction;
+use Application\Http\Action\Account\Delegation\Command\RequestDelegation\RequestDelegationAction;
+use Application\Http\Action\Account\Delegation\Command\RevokeDelegation\RevokeDelegationAction;
+use Application\Http\Action\Account\DelegationPermission\Command\GrantDelegationPermission\GrantDelegationPermissionAction;
+use Application\Http\Action\Account\DelegationPermission\Command\RevokeDelegationPermission\RevokeDelegationPermissionAction;
 use Application\Http\Action\Account\IdentityGroup\Command\AddIdentityToIdentityGroup\AddIdentityToIdentityGroupAction;
 use Application\Http\Action\Account\IdentityGroup\Command\CreateIdentityGroup\CreateIdentityGroupAction;
 use Application\Http\Action\Account\IdentityGroup\Command\DeleteIdentityGroup\DeleteIdentityGroupAction;
@@ -13,6 +18,15 @@ use Illuminate\Support\Facades\Route;
 // Account
 Route::post('/accounts', CreateAccountAction::class);
 Route::delete('/accounts/{accountId}', DeleteAccountAction::class);
+
+// Delegation
+Route::post('/delegations', RequestDelegationAction::class);
+Route::post('/delegations/{delegationId}/approve', ApproveDelegationAction::class);
+Route::post('/delegations/{delegationId}/revoke', RevokeDelegationAction::class);
+
+// DelegationPermission
+Route::post('/delegation-permissions', GrantDelegationPermissionAction::class);
+Route::delete('/delegation-permissions/{delegationPermissionId}', RevokeDelegationPermissionAction::class);
 
 // IdentityGroup
 Route::post('/identity-groups', CreateIdentityGroupAction::class);

--- a/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegation.php
+++ b/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegation.php
@@ -6,7 +6,6 @@ namespace Source\Account\Delegation\Application\UseCase\Command\ApproveDelegatio
 
 use Source\Account\Delegation\Application\Exception\DelegationNotFoundException;
 use Source\Account\Delegation\Application\Exception\DisallowedDelegationOperationException;
-use Source\Account\Delegation\Domain\Entity\Delegation;
 use Source\Account\Delegation\Domain\Event\DelegationApproved;
 use Source\Account\Delegation\Domain\Repository\DelegationRepositoryInterface;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
@@ -19,7 +18,7 @@ readonly class ApproveDelegation implements ApproveDelegationInterface
     ) {
     }
 
-    public function process(ApproveDelegationInputPort $input): Delegation
+    public function process(ApproveDelegationInputPort $input, ApproveDelegationOutputPort $output): void
     {
         $delegation = $this->delegationRepository->findById($input->delegationIdentifier());
 
@@ -42,6 +41,6 @@ readonly class ApproveDelegation implements ApproveDelegationInterface
             $delegation->approvedAt(),
         ));
 
-        return $delegation;
+        $output->setDelegation($delegation);
     }
 }

--- a/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationInterface.php
+++ b/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation;
 
-use Source\Account\Delegation\Domain\Entity\Delegation;
-
 interface ApproveDelegationInterface
 {
-    public function process(ApproveDelegationInputPort $input): Delegation;
+    public function process(ApproveDelegationInputPort $input, ApproveDelegationOutputPort $output): void;
 }

--- a/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationOutput.php
+++ b/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationOutput.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation;
+
+use DateTimeInterface;
+use Source\Account\Delegation\Domain\Entity\Delegation;
+
+class ApproveDelegationOutput implements ApproveDelegationOutputPort
+{
+    private ?Delegation $delegation = null;
+
+    public function setDelegation(Delegation $delegation): void
+    {
+        $this->delegation = $delegation;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->delegation === null) {
+            return [];
+        }
+
+        $delegation = $this->delegation;
+
+        return [
+            'delegationIdentifier' => (string) $delegation->delegationIdentifier(),
+            'affiliationIdentifier' => (string) $delegation->affiliationIdentifier(),
+            'delegateIdentifier' => (string) $delegation->delegateIdentifier(),
+            'delegatorIdentifier' => (string) $delegation->delegatorIdentifier(),
+            'status' => $delegation->status()->value,
+            'direction' => $delegation->direction()->value,
+            'requestedAt' => $delegation->requestedAt()->format(DateTimeInterface::ATOM),
+            'approvedAt' => $delegation->approvedAt()?->format(DateTimeInterface::ATOM),
+            'revokedAt' => $delegation->revokedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationOutputPort.php
+++ b/src/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation;
+
+use Source\Account\Delegation\Domain\Entity\Delegation;
+
+interface ApproveDelegationOutputPort
+{
+    public function setDelegation(Delegation $delegation): void;
+}

--- a/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegation.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegation.php
@@ -7,7 +7,6 @@ namespace Source\Account\Delegation\Application\UseCase\Command\RequestDelegatio
 use Source\Account\Affiliation\Application\Exception\AffiliationNotFoundException;
 use Source\Account\Affiliation\Application\Exception\InvalidAffiliationStatusException;
 use Source\Account\Affiliation\Domain\Repository\AffiliationRepositoryInterface;
-use Source\Account\Delegation\Domain\Entity\Delegation;
 use Source\Account\Delegation\Domain\Factory\DelegationFactoryInterface;
 use Source\Account\Delegation\Domain\Repository\DelegationRepositoryInterface;
 
@@ -20,7 +19,7 @@ readonly class RequestDelegation implements RequestDelegationInterface
     ) {
     }
 
-    public function process(RequestDelegationInputPort $input): Delegation
+    public function process(RequestDelegationInputPort $input, RequestDelegationOutputPort $output): void
     {
         $affiliation = $this->affiliationRepository->findById($input->affiliationIdentifier());
 
@@ -40,6 +39,6 @@ readonly class RequestDelegation implements RequestDelegationInterface
 
         $this->delegationRepository->save($delegation);
 
-        return $delegation;
+        $output->setDelegation($delegation);
     }
 }

--- a/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationInterface.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Delegation\Application\UseCase\Command\RequestDelegation;
 
-use Source\Account\Delegation\Domain\Entity\Delegation;
-
 interface RequestDelegationInterface
 {
-    public function process(RequestDelegationInputPort $input): Delegation;
+    public function process(RequestDelegationInputPort $input, RequestDelegationOutputPort $output): void;
 }

--- a/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationOutput.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationOutput.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Application\UseCase\Command\RequestDelegation;
+
+use DateTimeInterface;
+use Source\Account\Delegation\Domain\Entity\Delegation;
+
+class RequestDelegationOutput implements RequestDelegationOutputPort
+{
+    private ?Delegation $delegation = null;
+
+    public function setDelegation(Delegation $delegation): void
+    {
+        $this->delegation = $delegation;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->delegation === null) {
+            return [];
+        }
+
+        $delegation = $this->delegation;
+
+        return [
+            'delegationIdentifier' => (string) $delegation->delegationIdentifier(),
+            'affiliationIdentifier' => (string) $delegation->affiliationIdentifier(),
+            'delegateIdentifier' => (string) $delegation->delegateIdentifier(),
+            'delegatorIdentifier' => (string) $delegation->delegatorIdentifier(),
+            'status' => $delegation->status()->value,
+            'direction' => $delegation->direction()->value,
+            'requestedAt' => $delegation->requestedAt()->format(DateTimeInterface::ATOM),
+            'approvedAt' => $delegation->approvedAt()?->format(DateTimeInterface::ATOM),
+            'revokedAt' => $delegation->revokedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationOutputPort.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Application\UseCase\Command\RequestDelegation;
+
+use Source\Account\Delegation\Domain\Entity\Delegation;
+
+interface RequestDelegationOutputPort
+{
+    public function setDelegation(Delegation $delegation): void;
+}

--- a/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegation.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegation.php
@@ -6,7 +6,6 @@ namespace Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation
 
 use Source\Account\Delegation\Application\Exception\DelegationNotFoundException;
 use Source\Account\Delegation\Application\Exception\DisallowedDelegationOperationException;
-use Source\Account\Delegation\Domain\Entity\Delegation;
 use Source\Account\Delegation\Domain\Event\DelegationRevoked;
 use Source\Account\Delegation\Domain\Repository\DelegationRepositoryInterface;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
@@ -19,7 +18,7 @@ readonly class RevokeDelegation implements RevokeDelegationInterface
     ) {
     }
 
-    public function process(RevokeDelegationInputPort $input): Delegation
+    public function process(RevokeDelegationInputPort $input, RevokeDelegationOutputPort $output): void
     {
         $delegation = $this->delegationRepository->findById($input->delegationIdentifier());
 
@@ -44,6 +43,6 @@ readonly class RevokeDelegation implements RevokeDelegationInterface
             $delegation->revokedAt(),
         ));
 
-        return $delegation;
+        $output->setDelegation($delegation);
     }
 }

--- a/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationInterface.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation;
 
-use Source\Account\Delegation\Domain\Entity\Delegation;
-
 interface RevokeDelegationInterface
 {
-    public function process(RevokeDelegationInputPort $input): Delegation;
+    public function process(RevokeDelegationInputPort $input, RevokeDelegationOutputPort $output): void;
 }

--- a/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationOutput.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationOutput.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation;
+
+use DateTimeInterface;
+use Source\Account\Delegation\Domain\Entity\Delegation;
+
+class RevokeDelegationOutput implements RevokeDelegationOutputPort
+{
+    private ?Delegation $delegation = null;
+
+    public function setDelegation(Delegation $delegation): void
+    {
+        $this->delegation = $delegation;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->delegation === null) {
+            return [];
+        }
+
+        $delegation = $this->delegation;
+
+        return [
+            'delegationIdentifier' => (string) $delegation->delegationIdentifier(),
+            'affiliationIdentifier' => (string) $delegation->affiliationIdentifier(),
+            'delegateIdentifier' => (string) $delegation->delegateIdentifier(),
+            'delegatorIdentifier' => (string) $delegation->delegatorIdentifier(),
+            'status' => $delegation->status()->value,
+            'direction' => $delegation->direction()->value,
+            'requestedAt' => $delegation->requestedAt()->format(DateTimeInterface::ATOM),
+            'approvedAt' => $delegation->approvedAt()?->format(DateTimeInterface::ATOM),
+            'revokedAt' => $delegation->revokedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationOutputPort.php
+++ b/src/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation;
+
+use Source\Account\Delegation\Domain\Entity\Delegation;
+
+interface RevokeDelegationOutputPort
+{
+    public function setDelegation(Delegation $delegation): void;
+}

--- a/src/Account/Delegation/Domain/Entity/Delegation.php
+++ b/src/Account/Delegation/Domain/Entity/Delegation.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Source\Account\Delegation\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
+use Source\Account\Delegation\Domain\Exception\InvalidDelegationApprovalException;
+use Source\Account\Delegation\Domain\Exception\InvalidDelegationRevocationException;
 use Source\Account\Delegation\Domain\ValueObject\DelegationDirection;
 use Source\Account\Delegation\Domain\ValueObject\DelegationStatus;
 use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
@@ -75,7 +76,7 @@ class Delegation
     public function approve(): void
     {
         if (! $this->status->isPending()) {
-            throw new DomainException('Only pending delegations can be approved.');
+            throw new InvalidDelegationApprovalException();
         }
 
         $this->status = DelegationStatus::APPROVED;
@@ -85,7 +86,7 @@ class Delegation
     public function revoke(): void
     {
         if (! $this->status->isApproved()) {
-            throw new DomainException('Only approved delegations can be revoked.');
+            throw new InvalidDelegationRevocationException();
         }
 
         $this->status = DelegationStatus::REVOKED;

--- a/src/Account/Delegation/Domain/Exception/InvalidDelegationApprovalException.php
+++ b/src/Account/Delegation/Domain/Exception/InvalidDelegationApprovalException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Domain\Exception;
+
+use DomainException;
+
+class InvalidDelegationApprovalException extends DomainException
+{
+    public function __construct(string $message = 'Only pending delegations can be approved.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Account/Delegation/Domain/Exception/InvalidDelegationRevocationException.php
+++ b/src/Account/Delegation/Domain/Exception/InvalidDelegationRevocationException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Delegation\Domain\Exception;
+
+use DomainException;
+
+class InvalidDelegationRevocationException extends DomainException
+{
+    public function __construct(string $message = 'Only approved delegations can be revoked.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermission.php
+++ b/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermission.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission;
 
-use Source\Account\DelegationPermission\Domain\Entity\DelegationPermission;
 use Source\Account\DelegationPermission\Domain\Factory\DelegationPermissionFactoryInterface;
 use Source\Account\DelegationPermission\Domain\Repository\DelegationPermissionRepositoryInterface;
 use Source\Account\IdentityGroup\Application\Exception\IdentityGroupNotFoundException;
@@ -22,7 +21,7 @@ readonly class GrantDelegationPermission implements GrantDelegationPermissionInt
     /**
      * @throws IdentityGroupNotFoundException
      */
-    public function process(GrantDelegationPermissionInputPort $input): DelegationPermission
+    public function process(GrantDelegationPermissionInputPort $input, GrantDelegationPermissionOutputPort $output): void
     {
         $identityGroup = $this->identityGroupRepository->findById($input->identityGroupIdentifier());
 
@@ -38,6 +37,6 @@ readonly class GrantDelegationPermission implements GrantDelegationPermissionInt
 
         $this->delegationPermissionRepository->save($delegationPermission);
 
-        return $delegationPermission;
+        $output->setDelegationPermission($delegationPermission);
     }
 }

--- a/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionInterface.php
+++ b/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission;
 
-use Source\Account\DelegationPermission\Domain\Entity\DelegationPermission;
-
 interface GrantDelegationPermissionInterface
 {
-    public function process(GrantDelegationPermissionInputPort $input): DelegationPermission;
+    public function process(GrantDelegationPermissionInputPort $input, GrantDelegationPermissionOutputPort $output): void;
 }

--- a/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionOutput.php
+++ b/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionOutput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission;
+
+use DateTimeInterface;
+use Source\Account\DelegationPermission\Domain\Entity\DelegationPermission;
+
+class GrantDelegationPermissionOutput implements GrantDelegationPermissionOutputPort
+{
+    private ?DelegationPermission $delegationPermission = null;
+
+    public function setDelegationPermission(DelegationPermission $delegationPermission): void
+    {
+        $this->delegationPermission = $delegationPermission;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->delegationPermission === null) {
+            return [];
+        }
+
+        $dp = $this->delegationPermission;
+
+        return [
+            'delegationPermissionIdentifier' => (string) $dp->delegationPermissionIdentifier(),
+            'identityGroupIdentifier' => (string) $dp->identityGroupIdentifier(),
+            'targetAccountIdentifier' => (string) $dp->targetAccountIdentifier(),
+            'affiliationIdentifier' => (string) $dp->affiliationIdentifier(),
+            'createdAt' => $dp->createdAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionOutputPort.php
+++ b/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission;
+
+use Source\Account\DelegationPermission\Domain\Entity\DelegationPermission;
+
+interface GrantDelegationPermissionOutputPort
+{
+    public function setDelegationPermission(DelegationPermission $delegationPermission): void;
+}

--- a/tests/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationOutputTest.php
+++ b/tests/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationOutputTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Delegation\Application\UseCase\Command\ApproveDelegation;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationOutput;
+use Source\Account\Delegation\Domain\Entity\Delegation;
+use Source\Account\Delegation\Domain\ValueObject\DelegationDirection;
+use Source\Account\Delegation\Domain\ValueObject\DelegationStatus;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class ApproveDelegationOutputTest extends TestCase
+{
+    public function testToArrayWithDelegation(): void
+    {
+        $delegationIdentifier = new DelegationIdentifier(StrTestHelper::generateUuid());
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $delegateIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $delegatorIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $requestedAt = new DateTimeImmutable('-1 day');
+        $approvedAt = new DateTimeImmutable();
+
+        $delegation = new Delegation(
+            $delegationIdentifier,
+            $affiliationIdentifier,
+            $delegateIdentifier,
+            $delegatorIdentifier,
+            DelegationStatus::APPROVED,
+            DelegationDirection::FROM_AGENCY,
+            $requestedAt,
+            $approvedAt,
+            null,
+        );
+
+        $output = new ApproveDelegationOutput();
+        $output->setDelegation($delegation);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $delegationIdentifier, $result['delegationIdentifier']);
+        $this->assertSame((string) $affiliationIdentifier, $result['affiliationIdentifier']);
+        $this->assertSame((string) $delegateIdentifier, $result['delegateIdentifier']);
+        $this->assertSame((string) $delegatorIdentifier, $result['delegatorIdentifier']);
+        $this->assertSame(DelegationStatus::APPROVED->value, $result['status']);
+        $this->assertSame(DelegationDirection::FROM_AGENCY->value, $result['direction']);
+        $this->assertSame($requestedAt->format(DateTimeInterface::ATOM), $result['requestedAt']);
+        $this->assertSame($approvedAt->format(DateTimeInterface::ATOM), $result['approvedAt']);
+        $this->assertNull($result['revokedAt']);
+    }
+
+    public function testToArrayWithoutDelegation(): void
+    {
+        $output = new ApproveDelegationOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationTest.php
+++ b/tests/Account/Delegation/Application/UseCase/Command/ApproveDelegation/ApproveDelegationTest.php
@@ -12,6 +12,7 @@ use Source\Account\Delegation\Application\Exception\DisallowedDelegationOperatio
 use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegation;
 use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationInput;
 use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationInterface;
+use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationOutput;
 use Source\Account\Delegation\Domain\Entity\Delegation;
 use Source\Account\Delegation\Domain\Event\DelegationApproved;
 use Source\Account\Delegation\Domain\Repository\DelegationRepositoryInterface;
@@ -69,10 +70,11 @@ class ApproveDelegationTest extends TestCase
 
         $useCase = $this->app->make(ApproveDelegationInterface::class);
 
-        $result = $useCase->process($testData->input);
+        $output = new ApproveDelegationOutput();
 
-        $this->assertTrue($result->isApproved());
-        $this->assertNotNull($result->approvedAt());
+        $useCase->process($testData->input, $output);
+
+        $this->assertSame((string) $testData->delegation->delegationIdentifier(), $output->toArray()['delegationIdentifier']);
     }
 
     /**
@@ -98,10 +100,12 @@ class ApproveDelegationTest extends TestCase
 
         $useCase = $this->app->make(ApproveDelegationInterface::class);
 
+        $output = new ApproveDelegationOutput();
+
         $this->expectException(DelegationNotFoundException::class);
         $this->expectExceptionMessage('Delegation not found.');
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 
     /**
@@ -131,10 +135,12 @@ class ApproveDelegationTest extends TestCase
 
         $useCase = $this->app->make(ApproveDelegationInterface::class);
 
+        $output = new ApproveDelegationOutput();
+
         $this->expectException(DisallowedDelegationOperationException::class);
         $this->expectExceptionMessage('Only the delegator can approve this delegation.');
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 
     private function createTestData(): ApproveDelegationTestData

--- a/tests/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationOutputTest.php
+++ b/tests/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationOutputTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Delegation\Application\UseCase\Command\RequestDelegation;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegationOutput;
+use Source\Account\Delegation\Domain\Entity\Delegation;
+use Source\Account\Delegation\Domain\ValueObject\DelegationDirection;
+use Source\Account\Delegation\Domain\ValueObject\DelegationStatus;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class RequestDelegationOutputTest extends TestCase
+{
+    public function testToArrayWithDelegation(): void
+    {
+        $delegationIdentifier = new DelegationIdentifier(StrTestHelper::generateUuid());
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $delegateIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $delegatorIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $requestedAt = new DateTimeImmutable();
+
+        $delegation = new Delegation(
+            $delegationIdentifier,
+            $affiliationIdentifier,
+            $delegateIdentifier,
+            $delegatorIdentifier,
+            DelegationStatus::PENDING,
+            DelegationDirection::FROM_AGENCY,
+            $requestedAt,
+            null,
+            null,
+        );
+
+        $output = new RequestDelegationOutput();
+        $output->setDelegation($delegation);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $delegationIdentifier, $result['delegationIdentifier']);
+        $this->assertSame((string) $affiliationIdentifier, $result['affiliationIdentifier']);
+        $this->assertSame((string) $delegateIdentifier, $result['delegateIdentifier']);
+        $this->assertSame((string) $delegatorIdentifier, $result['delegatorIdentifier']);
+        $this->assertSame(DelegationStatus::PENDING->value, $result['status']);
+        $this->assertSame(DelegationDirection::FROM_AGENCY->value, $result['direction']);
+        $this->assertSame($requestedAt->format(DateTimeInterface::ATOM), $result['requestedAt']);
+        $this->assertNull($result['approvedAt']);
+        $this->assertNull($result['revokedAt']);
+    }
+
+    public function testToArrayWithoutDelegation(): void
+    {
+        $output = new RequestDelegationOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationTest.php
+++ b/tests/Account/Delegation/Application/UseCase/Command/RequestDelegation/RequestDelegationTest.php
@@ -16,6 +16,7 @@ use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
 use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegation;
 use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegationInput;
 use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegationInterface;
+use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegationOutput;
 use Source\Account\Delegation\Domain\Entity\Delegation;
 use Source\Account\Delegation\Domain\Factory\DelegationFactoryInterface;
 use Source\Account\Delegation\Domain\Repository\DelegationRepositoryInterface;
@@ -86,13 +87,11 @@ class RequestDelegationTest extends TestCase
 
         $useCase = $this->app->make(RequestDelegationInterface::class);
 
-        $result = $useCase->process($testData->input);
+        $output = new RequestDelegationOutput();
 
-        $this->assertSame((string) $testData->delegationIdentifier, (string) $result->delegationIdentifier());
-        $this->assertSame((string) $testData->affiliationIdentifier, (string) $result->affiliationIdentifier());
-        $this->assertSame((string) $testData->delegateIdentifier, (string) $result->delegateIdentifier());
-        $this->assertSame((string) $testData->delegatorIdentifier, (string) $result->delegatorIdentifier());
-        $this->assertTrue($result->isPending());
+        $useCase->process($testData->input, $output);
+
+        $this->assertSame((string) $testData->delegation->delegationIdentifier(), $output->toArray()['delegationIdentifier']);
     }
 
     /**
@@ -120,10 +119,12 @@ class RequestDelegationTest extends TestCase
 
         $useCase = $this->app->make(RequestDelegationInterface::class);
 
+        $output = new RequestDelegationOutput();
+
         $this->expectException(AffiliationNotFoundException::class);
         $this->expectExceptionMessage('Affiliation not found.');
 
-        $useCase->process($testData->input);
+        $useCase->process($testData->input, $output);
     }
 
     /**
@@ -151,10 +152,12 @@ class RequestDelegationTest extends TestCase
 
         $useCase = $this->app->make(RequestDelegationInterface::class);
 
+        $output = new RequestDelegationOutput();
+
         $this->expectException(InvalidAffiliationStatusException::class);
         $this->expectExceptionMessage('Delegation can only be requested for active affiliations.');
 
-        $useCase->process($testData->input);
+        $useCase->process($testData->input, $output);
     }
 
     private function createTestData(): RequestDelegationTestData

--- a/tests/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationOutputTest.php
+++ b/tests/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationOutputTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Delegation\Application\UseCase\Command\RevokeDelegation;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegationOutput;
+use Source\Account\Delegation\Domain\Entity\Delegation;
+use Source\Account\Delegation\Domain\ValueObject\DelegationDirection;
+use Source\Account\Delegation\Domain\ValueObject\DelegationStatus;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class RevokeDelegationOutputTest extends TestCase
+{
+    public function testToArrayWithDelegation(): void
+    {
+        $delegationIdentifier = new DelegationIdentifier(StrTestHelper::generateUuid());
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $delegateIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $delegatorIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $requestedAt = new DateTimeImmutable('-2 days');
+        $approvedAt = new DateTimeImmutable('-1 day');
+        $revokedAt = new DateTimeImmutable();
+
+        $delegation = new Delegation(
+            $delegationIdentifier,
+            $affiliationIdentifier,
+            $delegateIdentifier,
+            $delegatorIdentifier,
+            DelegationStatus::REVOKED,
+            DelegationDirection::FROM_AGENCY,
+            $requestedAt,
+            $approvedAt,
+            $revokedAt,
+        );
+
+        $output = new RevokeDelegationOutput();
+        $output->setDelegation($delegation);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $delegationIdentifier, $result['delegationIdentifier']);
+        $this->assertSame((string) $affiliationIdentifier, $result['affiliationIdentifier']);
+        $this->assertSame((string) $delegateIdentifier, $result['delegateIdentifier']);
+        $this->assertSame((string) $delegatorIdentifier, $result['delegatorIdentifier']);
+        $this->assertSame(DelegationStatus::REVOKED->value, $result['status']);
+        $this->assertSame(DelegationDirection::FROM_AGENCY->value, $result['direction']);
+        $this->assertSame($requestedAt->format(DateTimeInterface::ATOM), $result['requestedAt']);
+        $this->assertSame($approvedAt->format(DateTimeInterface::ATOM), $result['approvedAt']);
+        $this->assertSame($revokedAt->format(DateTimeInterface::ATOM), $result['revokedAt']);
+    }
+
+    public function testToArrayWithoutDelegation(): void
+    {
+        $output = new RevokeDelegationOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationTest.php
+++ b/tests/Account/Delegation/Application/UseCase/Command/RevokeDelegation/RevokeDelegationTest.php
@@ -12,6 +12,7 @@ use Source\Account\Delegation\Application\Exception\DisallowedDelegationOperatio
 use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegation;
 use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegationInput;
 use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegationInterface;
+use Source\Account\Delegation\Application\UseCase\Command\RevokeDelegation\RevokeDelegationOutput;
 use Source\Account\Delegation\Domain\Entity\Delegation;
 use Source\Account\Delegation\Domain\Event\DelegationRevoked;
 use Source\Account\Delegation\Domain\Repository\DelegationRepositoryInterface;
@@ -73,10 +74,11 @@ class RevokeDelegationTest extends TestCase
 
         $useCase = $this->app->make(RevokeDelegationInterface::class);
 
-        $result = $useCase->process($input);
+        $output = new RevokeDelegationOutput();
 
-        $this->assertTrue($result->isRevoked());
-        $this->assertNotNull($result->revokedAt());
+        $useCase->process($input, $output);
+
+        $this->assertSame((string) $testData->delegation->delegationIdentifier(), $output->toArray()['delegationIdentifier']);
     }
 
     /**
@@ -112,10 +114,11 @@ class RevokeDelegationTest extends TestCase
 
         $useCase = $this->app->make(RevokeDelegationInterface::class);
 
-        $result = $useCase->process($input);
+        $output = new RevokeDelegationOutput();
 
-        $this->assertTrue($result->isRevoked());
-        $this->assertNotNull($result->revokedAt());
+        $useCase->process($input, $output);
+
+        $this->assertSame((string) $testData->delegation->delegationIdentifier(), $output->toArray()['delegationIdentifier']);
     }
 
     /**
@@ -141,10 +144,12 @@ class RevokeDelegationTest extends TestCase
 
         $useCase = $this->app->make(RevokeDelegationInterface::class);
 
+        $output = new RevokeDelegationOutput();
+
         $this->expectException(DelegationNotFoundException::class);
         $this->expectExceptionMessage('Delegation not found.');
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 
     /**
@@ -174,10 +179,12 @@ class RevokeDelegationTest extends TestCase
 
         $useCase = $this->app->make(RevokeDelegationInterface::class);
 
+        $output = new RevokeDelegationOutput();
+
         $this->expectException(DisallowedDelegationOperationException::class);
         $this->expectExceptionMessage('Only the delegator or delegate can revoke this delegation.');
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 
     private function createTestData(): RevokeDelegationTestData

--- a/tests/Account/Delegation/Domain/Entity/DelegationTest.php
+++ b/tests/Account/Delegation/Domain/Entity/DelegationTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Tests\Account\Delegation\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use PHPUnit\Framework\TestCase;
 use Source\Account\Delegation\Domain\Entity\Delegation;
+use Source\Account\Delegation\Domain\Exception\InvalidDelegationApprovalException;
+use Source\Account\Delegation\Domain\Exception\InvalidDelegationRevocationException;
 use Source\Account\Delegation\Domain\ValueObject\DelegationDirection;
 use Source\Account\Delegation\Domain\ValueObject\DelegationStatus;
 use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
@@ -81,7 +82,7 @@ class DelegationTest extends TestCase
     {
         $delegation = $this->createApprovedDelegation();
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidDelegationApprovalException::class);
         $this->expectExceptionMessage('Only pending delegations can be approved.');
 
         $delegation->approve();
@@ -101,7 +102,7 @@ class DelegationTest extends TestCase
     {
         $delegation = $this->createPendingDelegation();
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidDelegationRevocationException::class);
         $this->expectExceptionMessage('Only approved delegations can be revoked.');
 
         $delegation->revoke();

--- a/tests/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionOutputTest.php
+++ b/tests/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionOutputTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermissionOutput;
+use Source\Account\DelegationPermission\Domain\Entity\DelegationPermission;
+use Source\Account\DelegationPermission\Domain\ValueObject\DelegationPermissionIdentifier;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Account\Shared\Domain\ValueObject\IdentityGroupIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class GrantDelegationPermissionOutputTest extends TestCase
+{
+    public function testToArrayWithDelegationPermission(): void
+    {
+        $delegationPermissionIdentifier = new DelegationPermissionIdentifier(StrTestHelper::generateUuid());
+        $identityGroupIdentifier = new IdentityGroupIdentifier(StrTestHelper::generateUuid());
+        $targetAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $createdAt = new DateTimeImmutable();
+
+        $delegationPermission = new DelegationPermission(
+            $delegationPermissionIdentifier,
+            $identityGroupIdentifier,
+            $targetAccountIdentifier,
+            $affiliationIdentifier,
+            $createdAt,
+        );
+
+        $output = new GrantDelegationPermissionOutput();
+        $output->setDelegationPermission($delegationPermission);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $delegationPermissionIdentifier, $result['delegationPermissionIdentifier']);
+        $this->assertSame((string) $identityGroupIdentifier, $result['identityGroupIdentifier']);
+        $this->assertSame((string) $targetAccountIdentifier, $result['targetAccountIdentifier']);
+        $this->assertSame((string) $affiliationIdentifier, $result['affiliationIdentifier']);
+        $this->assertSame($createdAt->format(DateTimeInterface::ATOM), $result['createdAt']);
+    }
+
+    public function testToArrayWithoutDelegationPermission(): void
+    {
+        $output = new GrantDelegationPermissionOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionTest.php
+++ b/tests/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionTest.php
@@ -10,6 +10,7 @@ use Mockery;
 use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermission;
 use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermissionInput;
 use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermissionInterface;
+use Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission\GrantDelegationPermissionOutput;
 use Source\Account\DelegationPermission\Domain\Entity\DelegationPermission;
 use Source\Account\DelegationPermission\Domain\Factory\DelegationPermissionFactoryInterface;
 use Source\Account\DelegationPermission\Domain\Repository\DelegationPermissionRepositoryInterface;
@@ -104,12 +105,11 @@ class GrantDelegationPermissionTest extends TestCase
             $affiliationIdentifier,
         );
 
-        $result = $useCase->process($input);
+        $output = new GrantDelegationPermissionOutput();
 
-        $this->assertSame((string) $delegationPermissionIdentifier, (string) $result->delegationPermissionIdentifier());
-        $this->assertSame((string) $identityGroupIdentifier, (string) $result->identityGroupIdentifier());
-        $this->assertSame((string) $targetAccountIdentifier, (string) $result->targetAccountIdentifier());
-        $this->assertSame((string) $affiliationIdentifier, (string) $result->affiliationIdentifier());
+        $useCase->process($input, $output);
+
+        $this->assertSame((string) $delegationPermission->delegationPermissionIdentifier(), $output->toArray()['delegationPermissionIdentifier']);
     }
 
     /**
@@ -145,8 +145,10 @@ class GrantDelegationPermissionTest extends TestCase
             $affiliationIdentifier,
         );
 
+        $output = new GrantDelegationPermissionOutput();
+
         $this->expectException(IdentityGroupNotFoundException::class);
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 }


### PR DESCRIPTION
## 📝 変更内容

- Delegation サブドメイン（RequestDelegation / ApproveDelegation / RevokeDelegation）にOutputパターンを導入
- DelegationPermission サブドメイン（GrantDelegationPermission / RevokeDelegationPermission）にOutputパターンを導入
- Delegationエンティティに独自例外クラス（InvalidDelegationApprovalException / InvalidDelegationRevocationException）を追加
- 5つのAPIエンドポイント（Action / Request）を作成しルーティングに追加
- 各Output・UseCaseのユニットテストを追加・更新
- 6言語のerrors.phpにDelegation関連エラーメッセージを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Delegation・DelegationPermissionサブドメインのユースケースにOutputパターンを導入し、プレゼンテーション層との責務分離を明確化する。また、ドメイン固有の例外クラスに移行することでエラーハンドリングの粒度を向上させる。APIエンドポイントを作成し、外部からのアクセスを可能にする。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Output クラスの構造と既存サブドメイン（Wiki等）との一貫性
- 独自例外クラス（InvalidDelegationApprovalException / InvalidDelegationRevocationException）の設計
- APIエンドポイントのルーティング設計（RESTful な命名）
- Request クラスのバリデーションルール

## 📖 関連情報

### 関連Issue・タスク

Closes #268

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した