### PR TITLE
add: AccountVerificationサブドメインにOutputパターン導入・エンドポイント作成

### DIFF
--- a/application/Http/Action/Account/AccountVerification/Command/ApproveVerification/ApproveVerificationAction.php
+++ b/application/Http/Action/Account/AccountVerification/Command/ApproveVerification/ApproveVerificationAction.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\AccountVerification\Command\ApproveVerification;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
+use Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification\ApproveVerificationInput;
+use Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification\ApproveVerificationInterface;
+use Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification\ApproveVerificationOutput;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationApprovalException;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ApproveVerificationAction
+{
+    public function __construct(
+        private ApproveVerificationInterface $approveVerification,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param ApproveVerificationRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ApproveVerificationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ApproveVerificationInput(
+                    verificationIdentifier: new VerificationIdentifier($request->verificationId()),
+                    reviewerAccountIdentifier: new AccountIdentifier($request->reviewerAccountIdentifier()),
+                );
+                $output = new ApproveVerificationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->approveVerification->process($input, $output);
+                DB::commit();
+            } catch (AccountVerificationNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('account_verification_not_found', $language), previous: $e);
+            } catch (InvalidVerificationApprovalException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_verification_approval', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/AccountVerification/Command/ApproveVerification/ApproveVerificationRequest.php
+++ b/application/Http/Action/Account/AccountVerification/Command/ApproveVerification/ApproveVerificationRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\AccountVerification\Command\ApproveVerification;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveVerificationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'reviewerAccountIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function verificationId(): string
+    {
+        return (string) $this->route('verificationId');
+    }
+
+    public function reviewerAccountIdentifier(): string
+    {
+        return (string) $this->input('reviewerAccountIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Account/AccountVerification/Command/RejectVerification/RejectVerificationAction.php
+++ b/application/Http/Action/Account/AccountVerification/Command/RejectVerification/RejectVerificationAction.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\AccountVerification\Command\RejectVerification;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
+use Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification\RejectVerificationInput;
+use Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification\RejectVerificationInterface;
+use Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification\RejectVerificationOutput;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationRejectionException;
+use Source\Account\AccountVerification\Domain\ValueObject\RejectionReason;
+use Source\Account\AccountVerification\Domain\ValueObject\RejectionReasonCode;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class RejectVerificationAction
+{
+    public function __construct(
+        private RejectVerificationInterface $rejectVerification,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RejectVerificationRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RejectVerificationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RejectVerificationInput(
+                    verificationIdentifier: new VerificationIdentifier($request->verificationId()),
+                    reviewerAccountIdentifier: new AccountIdentifier($request->reviewerAccountIdentifier()),
+                    rejectionReason: new RejectionReason(
+                        code: RejectionReasonCode::from($request->rejectionReasonCode()),
+                        detail: $request->rejectionReasonDetail(),
+                    ),
+                );
+                $output = new RejectVerificationOutput();
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->rejectVerification->process($input, $output);
+                DB::commit();
+            } catch (AccountVerificationNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('account_verification_not_found', $language), previous: $e);
+            } catch (InvalidVerificationRejectionException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_verification_rejection', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/AccountVerification/Command/RejectVerification/RejectVerificationRequest.php
+++ b/application/Http/Action/Account/AccountVerification/Command/RejectVerification/RejectVerificationRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\AccountVerification\Command\RejectVerification;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectVerificationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'reviewerAccountIdentifier' => ['required', 'uuid'],
+            'rejectionReasonCode' => ['required', 'string'],
+            'rejectionReasonDetail' => ['nullable', 'string'],
+        ];
+    }
+
+    public function verificationId(): string
+    {
+        return (string) $this->route('verificationId');
+    }
+
+    public function reviewerAccountIdentifier(): string
+    {
+        return (string) $this->input('reviewerAccountIdentifier');
+    }
+
+    public function rejectionReasonCode(): string
+    {
+        return (string) $this->input('rejectionReasonCode');
+    }
+
+    public function rejectionReasonDetail(): ?string
+    {
+        return $this->input('rejectionReasonDetail');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Account/AccountVerification/Command/RequestVerification/RequestVerificationAction.php
+++ b/application/Http/Action/Account/AccountVerification/Command/RequestVerification/RequestVerificationAction.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\AccountVerification\Command\RequestVerification;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\AccountVerification\Application\Exception\AccountVerificationAlreadyRequestedException;
+use Source\Account\AccountVerification\Application\Exception\DocumentStorageFailedException;
+use Source\Account\AccountVerification\Application\Exception\InvalidAccountCategoryForVerificationException;
+use Source\Account\AccountVerification\Application\Exception\InvalidDocumentsForVerificationException;
+use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\DocumentData;
+use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\RequestVerificationInput;
+use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\RequestVerificationInterface;
+use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\RequestVerificationOutput;
+use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
+use Source\Account\AccountVerification\Domain\ValueObject\DocumentType;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationType;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class RequestVerificationAction
+{
+    public function __construct(
+        private RequestVerificationInterface $requestVerification,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RequestVerificationRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RequestVerificationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $documents = array_map(
+                    static function (array $doc): DocumentData {
+                        $decoded = base64_decode($doc['fileContents'], true);
+
+                        if ($decoded === false) {
+                            throw new InvalidArgumentException('Invalid base64 encoding in fileContents.');
+                        }
+
+                        return new DocumentData(
+                            documentType: DocumentType::from($doc['documentType']),
+                            fileName: $doc['fileName'],
+                            fileContents: $decoded,
+                            fileSizeBytes: (int) $doc['fileSizeBytes'],
+                        );
+                    },
+                    $request->documents(),
+                );
+
+                $input = new RequestVerificationInput(
+                    accountIdentifier: new AccountIdentifier($request->accountIdentifier()),
+                    verificationType: VerificationType::from($request->verificationType()),
+                    applicantInfo: new ApplicantInfo($request->applicantName()),
+                    documents: $documents,
+                );
+                $output = new RequestVerificationOutput();
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->requestVerification->process($input, $output);
+                DB::commit();
+            } catch (InvalidAccountCategoryForVerificationException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_account_category_for_verification', $language), previous: $e);
+            } catch (AccountVerificationAlreadyRequestedException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('account_verification_already_requested', $language), previous: $e);
+            } catch (InvalidDocumentsForVerificationException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_documents_for_verification', $language), previous: $e);
+            } catch (DocumentStorageFailedException $e) {
+                DB::rollBack();
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Account/AccountVerification/Command/RequestVerification/RequestVerificationRequest.php
+++ b/application/Http/Action/Account/AccountVerification/Command/RequestVerification/RequestVerificationRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\AccountVerification\Command\RequestVerification;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RequestVerificationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'accountIdentifier' => ['required', 'uuid'],
+            'verificationType' => ['required', 'string'],
+            'applicantName' => ['required', 'string'],
+            'documents' => ['required', 'array', 'min:1'],
+            'documents.*.documentType' => ['required', 'string'],
+            'documents.*.fileName' => ['required', 'string'],
+            'documents.*.fileContents' => ['required', 'string'],
+            'documents.*.fileSizeBytes' => ['required', 'integer', 'min:1'],
+        ];
+    }
+
+    public function accountIdentifier(): string
+    {
+        return (string) $this->input('accountIdentifier');
+    }
+
+    public function verificationType(): string
+    {
+        return (string) $this->input('verificationType');
+    }
+
+    public function applicantName(): string
+    {
+        return (string) $this->input('applicantName');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function documents(): array
+    {
+        return (array) $this->input('documents');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -63,6 +63,12 @@ return [
     'affiliation_not_found' => 'The specified affiliation was not found.',
     'invalid_affiliation_status' => 'The affiliation status is invalid for this operation.',
     'delegation_permission_not_found' => 'The specified delegation permission was not found.',
+    'account_verification_not_found' => 'The specified account verification was not found.',
+    'invalid_verification_approval' => 'Only pending verifications can be approved.',
+    'invalid_verification_rejection' => 'Only pending verifications can be rejected.',
+    'invalid_account_category_for_verification' => 'This account category cannot request verification.',
+    'account_verification_already_requested' => 'An account verification has already been requested.',
+    'invalid_documents_for_verification' => 'The submitted documents do not meet the requirements.',
 
     // Wiki
     'unauthorized' => 'This action is not authorized.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -61,6 +61,12 @@ return [
     'invalid_delegation_approval' => 'Solo se pueden aprobar las delegaciones pendientes.',
     'invalid_delegation_revocation' => 'Solo se pueden revocar las delegaciones aprobadas.',
     'delegation_permission_not_found' => 'No se encontró el permiso de delegación especificado.',
+    'account_verification_not_found' => 'No se encontró la verificación de cuenta especificada.',
+    'invalid_verification_approval' => 'Solo se pueden aprobar las verificaciones pendientes.',
+    'invalid_verification_rejection' => 'Solo se pueden rechazar las verificaciones pendientes.',
+    'invalid_account_category_for_verification' => 'Este tipo de cuenta no puede solicitar verificación.',
+    'account_verification_already_requested' => 'Ya se ha enviado una solicitud de verificación de cuenta.',
+    'invalid_documents_for_verification' => 'Los documentos enviados no cumplen con los requisitos.',
 
     // Wiki
     'unauthorized' => 'Esta acción no está autorizada.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -63,6 +63,12 @@ return [
     'affiliation_not_found' => '指定された所属が見つかりません。',
     'invalid_affiliation_status' => '所属のステータスがこの操作に対して無効です。',
     'delegation_permission_not_found' => '指定された委任許可が見つかりません。',
+    'account_verification_not_found' => '指定された本人確認申請が見つかりません。',
+    'invalid_verification_approval' => '保留中の本人確認申請のみ承認できます。',
+    'invalid_verification_rejection' => '保留中の本人確認申請のみ却下できます。',
+    'invalid_account_category_for_verification' => 'このアカウント種別では本人確認を申請できません。',
+    'account_verification_already_requested' => '本人確認申請は既に提出されています。',
+    'invalid_documents_for_verification' => '提出された書類が要件を満たしていません。',
 
     // Wiki
     'unauthorized' => 'この操作は認可されていません。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -63,6 +63,12 @@ return [
     'affiliation_not_found' => '지정된 소속을 찾을 수 없습니다.',
     'invalid_affiliation_status' => '소속 상태가 이 작업에 유효하지 않습니다.',
     'delegation_permission_not_found' => '지정된 위임 권한을 찾을 수 없습니다.',
+    'account_verification_not_found' => '지정된 본인 확인 신청을 찾을 수 없습니다.',
+    'invalid_verification_approval' => '보류 중인 본인 확인 신청만 승인할 수 있습니다.',
+    'invalid_verification_rejection' => '보류 중인 본인 확인 신청만 거부할 수 있습니다.',
+    'invalid_account_category_for_verification' => '이 계정 유형으로는 본인 확인을 신청할 수 없습니다.',
+    'account_verification_already_requested' => '본인 확인 신청이 이미 제출되었습니다.',
+    'invalid_documents_for_verification' => '제출된 서류가 요건을 충족하지 않습니다.',
 
     // Wiki
     'unauthorized' => '이 작업은 인가되지 않았습니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -63,6 +63,12 @@ return [
     'affiliation_not_found' => '找不到指定的所属。',
     'invalid_affiliation_status' => '所属状态对此操作无效。',
     'delegation_permission_not_found' => '找不到指定的委托权限。',
+    'account_verification_not_found' => '找不到指定的身份验证申请。',
+    'invalid_verification_approval' => '只能批准待处理的身份验证申请。',
+    'invalid_verification_rejection' => '只能拒绝待处理的身份验证申请。',
+    'invalid_account_category_for_verification' => '此账户类型无法申请身份验证。',
+    'account_verification_already_requested' => '身份验证申请已提交。',
+    'invalid_documents_for_verification' => '提交的文件不符合要求。',
 
     // Wiki
     'unauthorized' => '此操作未获授权。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -63,6 +63,12 @@ return [
     'affiliation_not_found' => '找不到指定的所屬。',
     'invalid_affiliation_status' => '所屬狀態對此操作無效。',
     'delegation_permission_not_found' => '找不到指定的委託權限。',
+    'account_verification_not_found' => '找不到指定的身分驗證申請。',
+    'invalid_verification_approval' => '只能核准待處理的身分驗證申請。',
+    'invalid_verification_rejection' => '只能拒絕待處理的身分驗證申請。',
+    'invalid_account_category_for_verification' => '此帳戶類型無法申請身分驗證。',
+    'account_verification_already_requested' => '身分驗證申請已提交。',
+    'invalid_documents_for_verification' => '提交的文件不符合要求。',
 
     // Wiki
     'unauthorized' => '此操作未獲授權。',

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Application\Http\Action\Account\Account\Command\CreateAccount\CreateAccountAction;
 use Application\Http\Action\Account\Account\Command\DeleteAccount\DeleteAccountAction;
+use Application\Http\Action\Account\AccountVerification\Command\ApproveVerification\ApproveVerificationAction;
+use Application\Http\Action\Account\AccountVerification\Command\RejectVerification\RejectVerificationAction;
+use Application\Http\Action\Account\AccountVerification\Command\RequestVerification\RequestVerificationAction;
 use Application\Http\Action\Account\Delegation\Command\ApproveDelegation\ApproveDelegationAction;
 use Application\Http\Action\Account\Delegation\Command\RequestDelegation\RequestDelegationAction;
 use Application\Http\Action\Account\Delegation\Command\RevokeDelegation\RevokeDelegationAction;
@@ -33,3 +36,8 @@ Route::post('/identity-groups', CreateIdentityGroupAction::class);
 Route::post('/identity-groups/{identityGroupId}/add-member', AddIdentityToIdentityGroupAction::class);
 Route::post('/identity-groups/{identityGroupId}/remove-member', RemoveIdentityFromIdentityGroupAction::class);
 Route::delete('/identity-groups/{identityGroupId}', DeleteIdentityGroupAction::class);
+
+// AccountVerification
+Route::post('/account-verifications', RequestVerificationAction::class);
+Route::post('/account-verifications/{verificationId}/approve', ApproveVerificationAction::class);
+Route::post('/account-verifications/{verificationId}/reject', RejectVerificationAction::class);

--- a/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerification.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerification.php
@@ -6,7 +6,6 @@ namespace Source\Account\AccountVerification\Application\UseCase\Command\Approve
 
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
-use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 use Source\Account\AccountVerification\Domain\Repository\AccountVerificationRepositoryInterface;
 
 readonly class ApproveVerification implements ApproveVerificationInterface
@@ -19,10 +18,11 @@ readonly class ApproveVerification implements ApproveVerificationInterface
 
     /**
      * @param ApproveVerificationInputPort $input
-     * @return AccountVerification
+     * @param ApproveVerificationOutputPort $output
+     * @return void
      * @throws AccountVerificationNotFoundException
      */
-    public function process(ApproveVerificationInputPort $input): AccountVerification
+    public function process(ApproveVerificationInputPort $input, ApproveVerificationOutputPort $output): void
     {
         // Find the verification
         $verification = $this->verificationRepository->findById($input->verificationIdentifier());
@@ -45,6 +45,6 @@ readonly class ApproveVerification implements ApproveVerificationInterface
 
         $this->verificationRepository->save($verification);
 
-        return $verification;
+        $output->setVerification($verification);
     }
 }

--- a/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationInterface.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationInterface.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification;
 
 use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
-use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 
 interface ApproveVerificationInterface
 {
     /**
      * @param ApproveVerificationInputPort $input
-     * @return AccountVerification
+     * @param ApproveVerificationOutputPort $output
+     * @return void
      * @throws AccountVerificationNotFoundException
      */
-    public function process(ApproveVerificationInputPort $input): AccountVerification;
+    public function process(ApproveVerificationInputPort $input, ApproveVerificationOutputPort $output): void;
 }

--- a/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationOutput.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationOutput.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification;
+
+use DateTimeInterface;
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+
+class ApproveVerificationOutput implements ApproveVerificationOutputPort
+{
+    private ?AccountVerification $verification = null;
+
+    public function setVerification(AccountVerification $verification): void
+    {
+        $this->verification = $verification;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->verification === null) {
+            return [];
+        }
+
+        $verification = $this->verification;
+
+        return [
+            'verificationIdentifier' => (string) $verification->verificationIdentifier(),
+            'accountIdentifier' => (string) $verification->accountIdentifier(),
+            'verificationType' => $verification->verificationType()->value,
+            'status' => $verification->status()->value,
+            'applicantName' => $verification->applicantInfo()->fullName(),
+            'requestedAt' => $verification->requestedAt()->format(DateTimeInterface::ATOM),
+            'reviewedBy' => $verification->reviewedBy() !== null ? (string) $verification->reviewedBy() : null,
+            'reviewedAt' => $verification->reviewedAt()?->format(DateTimeInterface::ATOM),
+            'rejectionReason' => $verification->rejectionReason() !== null ? [
+                'code' => $verification->rejectionReason()->code()->value,
+                'detail' => $verification->rejectionReason()->detail(),
+            ] : null,
+            'documents' => array_map(fn ($doc) => [
+                'documentIdentifier' => (string) $doc->documentIdentifier(),
+                'documentType' => $doc->documentType()->value,
+                'documentPath' => (string) $doc->documentPath(),
+                'originalFileName' => $doc->originalFileName(),
+                'fileSizeBytes' => $doc->fileSizeBytes(),
+                'uploadedAt' => $doc->uploadedAt()->format(DateTimeInterface::ATOM),
+            ], $verification->documents()),
+        ];
+    }
+}

--- a/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationOutputPort.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification;
+
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+
+interface ApproveVerificationOutputPort
+{
+    public function setVerification(AccountVerification $verification): void;
+}

--- a/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerification.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerification.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification;
 
 use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
-use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 use Source\Account\AccountVerification\Domain\Repository\AccountVerificationRepositoryInterface;
 
 readonly class RejectVerification implements RejectVerificationInterface
@@ -17,10 +16,11 @@ readonly class RejectVerification implements RejectVerificationInterface
 
     /**
      * @param RejectVerificationInputPort $input
-     * @return AccountVerification
+     * @param RejectVerificationOutputPort $output
+     * @return void
      * @throws AccountVerificationNotFoundException
      */
-    public function process(RejectVerificationInputPort $input): AccountVerification
+    public function process(RejectVerificationInputPort $input, RejectVerificationOutputPort $output): void
     {
         // Find the verification
         $verification = $this->verificationRepository->findById($input->verificationIdentifier());
@@ -37,6 +37,6 @@ readonly class RejectVerification implements RejectVerificationInterface
 
         $this->verificationRepository->save($verification);
 
-        return $verification;
+        $output->setVerification($verification);
     }
 }

--- a/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationInterface.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationInterface.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification;
 
 use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
-use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 
 interface RejectVerificationInterface
 {
     /**
      * @param RejectVerificationInputPort $input
-     * @return AccountVerification
+     * @param RejectVerificationOutputPort $output
+     * @return void
      * @throws AccountVerificationNotFoundException
      */
-    public function process(RejectVerificationInputPort $input): AccountVerification;
+    public function process(RejectVerificationInputPort $input, RejectVerificationOutputPort $output): void;
 }

--- a/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationOutput.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationOutput.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification;
+
+use DateTimeInterface;
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+
+class RejectVerificationOutput implements RejectVerificationOutputPort
+{
+    private ?AccountVerification $verification = null;
+
+    public function setVerification(AccountVerification $verification): void
+    {
+        $this->verification = $verification;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->verification === null) {
+            return [];
+        }
+
+        $verification = $this->verification;
+
+        return [
+            'verificationIdentifier' => (string) $verification->verificationIdentifier(),
+            'accountIdentifier' => (string) $verification->accountIdentifier(),
+            'verificationType' => $verification->verificationType()->value,
+            'status' => $verification->status()->value,
+            'applicantName' => $verification->applicantInfo()->fullName(),
+            'requestedAt' => $verification->requestedAt()->format(DateTimeInterface::ATOM),
+            'reviewedBy' => $verification->reviewedBy() !== null ? (string) $verification->reviewedBy() : null,
+            'reviewedAt' => $verification->reviewedAt()?->format(DateTimeInterface::ATOM),
+            'rejectionReason' => $verification->rejectionReason() !== null ? [
+                'code' => $verification->rejectionReason()->code()->value,
+                'detail' => $verification->rejectionReason()->detail(),
+            ] : null,
+            'documents' => array_map(fn ($doc) => [
+                'documentIdentifier' => (string) $doc->documentIdentifier(),
+                'documentType' => $doc->documentType()->value,
+                'documentPath' => (string) $doc->documentPath(),
+                'originalFileName' => $doc->originalFileName(),
+                'fileSizeBytes' => $doc->fileSizeBytes(),
+                'uploadedAt' => $doc->uploadedAt()->format(DateTimeInterface::ATOM),
+            ], $verification->documents()),
+        ];
+    }
+}

--- a/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationOutputPort.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification;
+
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+
+interface RejectVerificationOutputPort
+{
+    public function setVerification(AccountVerification $verification): void;
+}

--- a/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerification.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerification.php
@@ -10,7 +10,6 @@ use Source\Account\AccountVerification\Application\Exception\AccountVerification
 use Source\Account\AccountVerification\Application\Exception\DocumentStorageFailedException;
 use Source\Account\AccountVerification\Application\Exception\InvalidAccountCategoryForVerificationException;
 use Source\Account\AccountVerification\Application\Service\DocumentStorageServiceInterface;
-use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 use Source\Account\AccountVerification\Domain\Entity\VerificationDocument;
 use Source\Account\AccountVerification\Domain\Factory\AccountVerificationFactoryInterface;
 use Source\Account\AccountVerification\Domain\Repository\AccountVerificationRepositoryInterface;
@@ -33,10 +32,11 @@ readonly class RequestVerification implements RequestVerificationInterface
 
     /**
      * @param RequestVerificationInputPort $input
-     * @return AccountVerification
+     * @param RequestVerificationOutputPort $output
+     * @return void
      * @throws DocumentStorageFailedException
      */
-    public function process(RequestVerificationInputPort $input): AccountVerification
+    public function process(RequestVerificationInputPort $input, RequestVerificationOutputPort $output): void
     {
         // Check if account is GENERAL
         $account = $this->accountRepository->findById($input->accountIdentifier());
@@ -102,6 +102,6 @@ readonly class RequestVerification implements RequestVerificationInterface
 
         $this->verificationRepository->save($verification);
 
-        return $verification;
+        $output->setVerification($verification);
     }
 }

--- a/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationInterface.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationInterface.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification;
 
 use Source\Account\AccountVerification\Application\Exception\DocumentStorageFailedException;
-use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 
 interface RequestVerificationInterface
 {
     /**
      * @param RequestVerificationInputPort $input
-     * @return AccountVerification
+     * @param RequestVerificationOutputPort $output
+     * @return void
      * @throws DocumentStorageFailedException
      */
-    public function process(RequestVerificationInputPort $input): AccountVerification;
+    public function process(RequestVerificationInputPort $input, RequestVerificationOutputPort $output): void;
 }

--- a/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationOutput.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationOutput.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification;
+
+use DateTimeInterface;
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+
+class RequestVerificationOutput implements RequestVerificationOutputPort
+{
+    private ?AccountVerification $verification = null;
+
+    public function setVerification(AccountVerification $verification): void
+    {
+        $this->verification = $verification;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->verification === null) {
+            return [];
+        }
+
+        $verification = $this->verification;
+
+        return [
+            'verificationIdentifier' => (string) $verification->verificationIdentifier(),
+            'accountIdentifier' => (string) $verification->accountIdentifier(),
+            'verificationType' => $verification->verificationType()->value,
+            'status' => $verification->status()->value,
+            'applicantName' => $verification->applicantInfo()->fullName(),
+            'requestedAt' => $verification->requestedAt()->format(DateTimeInterface::ATOM),
+            'reviewedBy' => $verification->reviewedBy() !== null ? (string) $verification->reviewedBy() : null,
+            'reviewedAt' => $verification->reviewedAt()?->format(DateTimeInterface::ATOM),
+            'rejectionReason' => $verification->rejectionReason() !== null ? [
+                'code' => $verification->rejectionReason()->code()->value,
+                'detail' => $verification->rejectionReason()->detail(),
+            ] : null,
+            'documents' => array_map(fn ($doc) => [
+                'documentIdentifier' => (string) $doc->documentIdentifier(),
+                'documentType' => $doc->documentType()->value,
+                'documentPath' => (string) $doc->documentPath(),
+                'originalFileName' => $doc->originalFileName(),
+                'fileSizeBytes' => $doc->fileSizeBytes(),
+                'uploadedAt' => $doc->uploadedAt()->format(DateTimeInterface::ATOM),
+            ], $verification->documents()),
+        ];
+    }
+}

--- a/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationOutputPort.php
+++ b/src/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification;
+
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+
+interface RequestVerificationOutputPort
+{
+    public function setVerification(AccountVerification $verification): void;
+}

--- a/src/Account/AccountVerification/Domain/Entity/AccountVerification.php
+++ b/src/Account/AccountVerification/Domain/Entity/AccountVerification.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Source\Account\AccountVerification\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationApprovalException;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationRejectionException;
 use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
 use Source\Account\AccountVerification\Domain\ValueObject\RejectionReason;
 use Source\Account\AccountVerification\Domain\ValueObject\VerificationIdentifier;
@@ -93,7 +94,7 @@ class AccountVerification
     public function approve(AccountIdentifier $reviewerAccountIdentifier): void
     {
         if (! $this->status->canTransitionTo(VerificationStatus::APPROVED)) {
-            throw new DomainException('Cannot approve this verification.');
+            throw new InvalidVerificationApprovalException();
         }
 
         $this->status = VerificationStatus::APPROVED;
@@ -105,7 +106,7 @@ class AccountVerification
     public function reject(AccountIdentifier $reviewerAccountIdentifier, RejectionReason $rejectionReason): void
     {
         if (! $this->status->canTransitionTo(VerificationStatus::REJECTED)) {
-            throw new DomainException('Cannot reject this verification.');
+            throw new InvalidVerificationRejectionException();
         }
 
         $this->status = VerificationStatus::REJECTED;

--- a/src/Account/AccountVerification/Domain/Exception/InvalidVerificationApprovalException.php
+++ b/src/Account/AccountVerification/Domain/Exception/InvalidVerificationApprovalException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Domain\Exception;
+
+use DomainException;
+
+class InvalidVerificationApprovalException extends DomainException
+{
+    public function __construct(string $message = 'Only pending verifications can be approved.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Account/AccountVerification/Domain/Exception/InvalidVerificationRejectionException.php
+++ b/src/Account/AccountVerification/Domain/Exception/InvalidVerificationRejectionException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\AccountVerification\Domain\Exception;
+
+use DomainException;
+
+class InvalidVerificationRejectionException extends DomainException
+{
+    public function __construct(string $message = 'Only pending verifications can be rejected.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/tests/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationOutputTest.php
+++ b/tests/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationOutputTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\AccountVerification\Application\UseCase\Command\ApproveVerification;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification\ApproveVerificationOutput;
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationIdentifier;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationStatus;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationType;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class ApproveVerificationOutputTest extends TestCase
+{
+    public function testToArrayWithVerification(): void
+    {
+        $verificationIdentifier = new VerificationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $reviewedBy = new AccountIdentifier(StrTestHelper::generateUuid());
+        $requestedAt = new DateTimeImmutable();
+        $reviewedAt = new DateTimeImmutable();
+
+        $verification = new AccountVerification(
+            $verificationIdentifier,
+            $accountIdentifier,
+            VerificationType::TALENT,
+            VerificationStatus::APPROVED,
+            new ApplicantInfo('Taro Yamada'),
+            $requestedAt,
+            $reviewedBy,
+            $reviewedAt,
+            null,
+        );
+
+        $output = new ApproveVerificationOutput();
+        $output->setVerification($verification);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $verificationIdentifier, $result['verificationIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result['accountIdentifier']);
+        $this->assertSame(VerificationType::TALENT->value, $result['verificationType']);
+        $this->assertSame(VerificationStatus::APPROVED->value, $result['status']);
+        $this->assertSame('Taro Yamada', $result['applicantName']);
+        $this->assertSame($requestedAt->format(DateTimeInterface::ATOM), $result['requestedAt']);
+        $this->assertSame((string) $reviewedBy, $result['reviewedBy']);
+        $this->assertSame($reviewedAt->format(DateTimeInterface::ATOM), $result['reviewedAt']);
+        $this->assertNull($result['rejectionReason']);
+        $this->assertSame([], $result['documents']);
+    }
+
+    public function testToArrayWithoutVerification(): void
+    {
+        $output = new ApproveVerificationOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationTest.php
+++ b/tests/Account/AccountVerification/Application/UseCase/Command/ApproveVerification/ApproveVerificationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Account\AccountVerification\Application\UseCase\Command\ApproveVerification;
 
 use DateTimeImmutable;
-use DomainException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
 use Source\Account\Account\Domain\Entity\Account;
@@ -17,7 +16,9 @@ use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
 use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
 use Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification\ApproveVerificationInput;
 use Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification\ApproveVerificationInterface;
+use Source\Account\AccountVerification\Application\UseCase\Command\ApproveVerification\ApproveVerificationOutput;
 use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationApprovalException;
 use Source\Account\AccountVerification\Domain\Repository\AccountVerificationRepositoryInterface;
 use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
 use Source\Account\AccountVerification\Domain\ValueObject\VerificationIdentifier;
@@ -72,9 +73,11 @@ class ApproveVerificationTest extends TestCase
         $this->app->instance(AccountVerificationRepositoryInterface::class, $verificationRepository);
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $useCase = $this->app->make(ApproveVerificationInterface::class);
-        $result = $useCase->process($input);
+        $output = new ApproveVerificationOutput();
+        $useCase->process($input, $output);
 
-        $this->assertTrue($result->isApproved());
+        $result = $output->toArray();
+        $this->assertSame(VerificationStatus::APPROVED->value, $result['status']);
         $this->assertSame(AccountCategory::TALENT, $account->accountCategory());
     }
 
@@ -107,7 +110,7 @@ class ApproveVerificationTest extends TestCase
         $this->expectException(AccountVerificationNotFoundException::class);
 
         $input = new ApproveVerificationInput($verificationId, $reviewerAccountId);
-        $useCase->process($input);
+        $useCase->process($input, new ApproveVerificationOutput());
     }
 
     /**
@@ -140,10 +143,10 @@ class ApproveVerificationTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $useCase = $this->app->make(ApproveVerificationInterface::class);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidVerificationApprovalException::class);
 
         $input = new ApproveVerificationInput($verificationId, $reviewerAccountId);
-        $useCase->process($input);
+        $useCase->process($input, new ApproveVerificationOutput());
     }
 
     private function createVerification(

--- a/tests/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationOutputTest.php
+++ b/tests/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationOutputTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\AccountVerification\Application\UseCase\Command\RejectVerification;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification\RejectVerificationOutput;
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
+use Source\Account\AccountVerification\Domain\ValueObject\RejectionReason;
+use Source\Account\AccountVerification\Domain\ValueObject\RejectionReasonCode;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationIdentifier;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationStatus;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationType;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class RejectVerificationOutputTest extends TestCase
+{
+    public function testToArrayWithVerification(): void
+    {
+        $verificationIdentifier = new VerificationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $reviewedBy = new AccountIdentifier(StrTestHelper::generateUuid());
+        $requestedAt = new DateTimeImmutable();
+        $reviewedAt = new DateTimeImmutable();
+        $rejectionReason = new RejectionReason(RejectionReasonCode::DOCUMENT_UNCLEAR, 'Image is blurry');
+
+        $verification = new AccountVerification(
+            $verificationIdentifier,
+            $accountIdentifier,
+            VerificationType::TALENT,
+            VerificationStatus::REJECTED,
+            new ApplicantInfo('Taro Yamada'),
+            $requestedAt,
+            $reviewedBy,
+            $reviewedAt,
+            $rejectionReason,
+        );
+
+        $output = new RejectVerificationOutput();
+        $output->setVerification($verification);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $verificationIdentifier, $result['verificationIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result['accountIdentifier']);
+        $this->assertSame(VerificationType::TALENT->value, $result['verificationType']);
+        $this->assertSame(VerificationStatus::REJECTED->value, $result['status']);
+        $this->assertSame('Taro Yamada', $result['applicantName']);
+        $this->assertSame($requestedAt->format(DateTimeInterface::ATOM), $result['requestedAt']);
+        $this->assertSame((string) $reviewedBy, $result['reviewedBy']);
+        $this->assertSame($reviewedAt->format(DateTimeInterface::ATOM), $result['reviewedAt']);
+        $this->assertSame(RejectionReasonCode::DOCUMENT_UNCLEAR->value, $result['rejectionReason']['code']);
+        $this->assertSame('Image is blurry', $result['rejectionReason']['detail']);
+        $this->assertSame([], $result['documents']);
+    }
+
+    public function testToArrayWithoutVerification(): void
+    {
+        $output = new RejectVerificationOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationTest.php
+++ b/tests/Account/AccountVerification/Application/UseCase/Command/RejectVerification/RejectVerificationTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Tests\Account\AccountVerification\Application\UseCase\Command\RejectVerification;
 
 use DateTimeImmutable;
-use DomainException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
 use Source\Account\AccountVerification\Application\Exception\AccountVerificationNotFoundException;
 use Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification\RejectVerificationInput;
 use Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification\RejectVerificationInterface;
+use Source\Account\AccountVerification\Application\UseCase\Command\RejectVerification\RejectVerificationOutput;
 use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationRejectionException;
 use Source\Account\AccountVerification\Domain\Repository\AccountVerificationRepositoryInterface;
 use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
 use Source\Account\AccountVerification\Domain\ValueObject\RejectionReason;
@@ -55,10 +56,12 @@ class RejectVerificationTest extends TestCase
 
         $this->app->instance(AccountVerificationRepositoryInterface::class, $verificationRepository);
         $useCase = $this->app->make(RejectVerificationInterface::class);
-        $result = $useCase->process($input);
+        $output = new RejectVerificationOutput();
+        $useCase->process($input, $output);
 
-        $this->assertTrue($result->isRejected());
-        $this->assertSame(RejectionReasonCode::DOCUMENT_UNCLEAR, $result->rejectionReason()->code());
+        $result = $output->toArray();
+        $this->assertSame(VerificationStatus::REJECTED->value, $result['status']);
+        $this->assertSame(RejectionReasonCode::DOCUMENT_UNCLEAR->value, $result['rejectionReason']['code']);
     }
 
     /**
@@ -87,7 +90,7 @@ class RejectVerificationTest extends TestCase
         $this->expectException(AccountVerificationNotFoundException::class);
 
         $input = new RejectVerificationInput($verificationId, $reviewerAccountId, $rejectionReason);
-        $useCase->process($input);
+        $useCase->process($input, new RejectVerificationOutput());
     }
 
     /**
@@ -116,10 +119,10 @@ class RejectVerificationTest extends TestCase
         $this->app->instance(AccountVerificationRepositoryInterface::class, $verificationRepository);
         $useCase = $this->app->make(RejectVerificationInterface::class);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidVerificationRejectionException::class);
 
         $input = new RejectVerificationInput($verificationId, $reviewerAccountId, $rejectionReason);
-        $useCase->process($input);
+        $useCase->process($input, new RejectVerificationOutput());
     }
 
     private function createVerification(

--- a/tests/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationOutputTest.php
+++ b/tests/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationOutputTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\AccountVerification\Application\UseCase\Command\RequestVerification;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\RequestVerificationOutput;
+use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
+use Source\Account\AccountVerification\Domain\Entity\VerificationDocument;
+use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
+use Source\Account\AccountVerification\Domain\ValueObject\DocumentIdentifier;
+use Source\Account\AccountVerification\Domain\ValueObject\DocumentPath;
+use Source\Account\AccountVerification\Domain\ValueObject\DocumentType;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationIdentifier;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationStatus;
+use Source\Account\AccountVerification\Domain\ValueObject\VerificationType;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class RequestVerificationOutputTest extends TestCase
+{
+    public function testToArrayWithVerification(): void
+    {
+        $verificationIdentifier = new VerificationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $requestedAt = new DateTimeImmutable();
+        $uploadedAt = new DateTimeImmutable();
+
+        $document = new VerificationDocument(
+            new DocumentIdentifier(StrTestHelper::generateUuid()),
+            $verificationIdentifier,
+            DocumentType::PASSPORT,
+            new DocumentPath('/verifications/documents/test-file.jpg'),
+            'my-passport.jpg',
+            1024000,
+            $uploadedAt,
+        );
+
+        $verification = new AccountVerification(
+            $verificationIdentifier,
+            $accountIdentifier,
+            VerificationType::TALENT,
+            VerificationStatus::PENDING,
+            new ApplicantInfo('Taro Yamada'),
+            $requestedAt,
+            null,
+            null,
+            null,
+            [$document],
+        );
+
+        $output = new RequestVerificationOutput();
+        $output->setVerification($verification);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $verificationIdentifier, $result['verificationIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result['accountIdentifier']);
+        $this->assertSame(VerificationType::TALENT->value, $result['verificationType']);
+        $this->assertSame(VerificationStatus::PENDING->value, $result['status']);
+        $this->assertSame('Taro Yamada', $result['applicantName']);
+        $this->assertSame($requestedAt->format(DateTimeInterface::ATOM), $result['requestedAt']);
+        $this->assertNull($result['reviewedBy']);
+        $this->assertNull($result['reviewedAt']);
+        $this->assertNull($result['rejectionReason']);
+        $this->assertCount(1, $result['documents']);
+        $this->assertSame((string) $document->documentIdentifier(), $result['documents'][0]['documentIdentifier']);
+        $this->assertSame(DocumentType::PASSPORT->value, $result['documents'][0]['documentType']);
+        $this->assertSame((string) $document->documentPath(), $result['documents'][0]['documentPath']);
+        $this->assertSame('my-passport.jpg', $result['documents'][0]['originalFileName']);
+        $this->assertSame(1024000, $result['documents'][0]['fileSizeBytes']);
+        $this->assertSame($uploadedAt->format(DateTimeInterface::ATOM), $result['documents'][0]['uploadedAt']);
+    }
+
+    public function testToArrayWithoutVerification(): void
+    {
+        $output = new RequestVerificationOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationTest.php
+++ b/tests/Account/AccountVerification/Application/UseCase/Command/RequestVerification/RequestVerificationTest.php
@@ -22,6 +22,7 @@ use Source\Account\AccountVerification\Application\Service\DocumentStorageServic
 use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\DocumentData;
 use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\RequestVerificationInput;
 use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\RequestVerificationInterface;
+use Source\Account\AccountVerification\Application\UseCase\Command\RequestVerification\RequestVerificationOutput;
 use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 use Source\Account\AccountVerification\Domain\Factory\AccountVerificationFactoryInterface;
 use Source\Account\AccountVerification\Domain\Repository\AccountVerificationRepositoryInterface;
@@ -107,11 +108,12 @@ class RequestVerificationTest extends TestCase
         $this->app->instance(DocumentRequirementValidator::class, new DocumentRequirementValidator());
 
         $useCase = $this->app->make(RequestVerificationInterface::class);
-        $result = $useCase->process($input);
+        $output = new RequestVerificationOutput();
+        $useCase->process($input, $output);
 
-        $this->assertInstanceOf(AccountVerification::class, $result);
-        $this->assertSame(VerificationStatus::PENDING, $result->status());
-        $this->assertCount(2, $result->documents());
+        $result = $output->toArray();
+        $this->assertSame(VerificationStatus::PENDING->value, $result['status']);
+        $this->assertCount(2, $result['documents']);
     }
 
     /**
@@ -180,11 +182,12 @@ class RequestVerificationTest extends TestCase
         $this->app->instance(DocumentRequirementValidator::class, new DocumentRequirementValidator());
 
         $useCase = $this->app->make(RequestVerificationInterface::class);
-        $result = $useCase->process($input);
+        $output = new RequestVerificationOutput();
+        $useCase->process($input, $output);
 
-        $this->assertInstanceOf(AccountVerification::class, $result);
-        $this->assertSame(VerificationStatus::PENDING, $result->status());
-        $this->assertCount(2, $result->documents());
+        $result = $output->toArray();
+        $this->assertSame(VerificationStatus::PENDING->value, $result['status']);
+        $this->assertCount(2, $result['documents']);
     }
 
     /**
@@ -236,7 +239,7 @@ class RequestVerificationTest extends TestCase
         $this->expectException(InvalidAccountCategoryForVerificationException::class);
 
         $input = new RequestVerificationInput($accountId, $verificationType, $applicantInfo, $documents);
-        $useCase->process($input);
+        $useCase->process($input, new RequestVerificationOutput());
     }
 
     /**
@@ -292,7 +295,7 @@ class RequestVerificationTest extends TestCase
         $this->expectException(AccountVerificationAlreadyRequestedException::class);
 
         $input = new RequestVerificationInput($accountId, $verificationType, $applicantInfo, $documents);
-        $useCase->process($input);
+        $useCase->process($input, new RequestVerificationOutput());
     }
 
     /**
@@ -349,7 +352,7 @@ class RequestVerificationTest extends TestCase
         $this->expectExceptionMessage('Selfie is required for talent verification.');
 
         $input = new RequestVerificationInput($accountId, $verificationType, $applicantInfo, $documents);
-        $useCase->process($input);
+        $useCase->process($input, new RequestVerificationOutput());
     }
 
     /**
@@ -406,7 +409,7 @@ class RequestVerificationTest extends TestCase
         $this->expectExceptionMessage('ID document is required for talent verification.');
 
         $input = new RequestVerificationInput($accountId, $verificationType, $applicantInfo, $documents);
-        $useCase->process($input);
+        $useCase->process($input, new RequestVerificationOutput());
     }
 
     /**
@@ -463,7 +466,7 @@ class RequestVerificationTest extends TestCase
         $this->expectExceptionMessage('Business document is required for agency verification.');
 
         $input = new RequestVerificationInput($accountId, $verificationType, $applicantInfo, $documents);
-        $useCase->process($input);
+        $useCase->process($input, new RequestVerificationOutput());
     }
 
     /**
@@ -528,7 +531,7 @@ class RequestVerificationTest extends TestCase
         $this->expectExceptionMessage('Failed to store verification documents: S3 connection failed');
 
         $input = new RequestVerificationInput($accountId, $verificationType, $applicantInfo, $documents);
-        $useCase->process($input);
+        $useCase->process($input, new RequestVerificationOutput());
     }
 
     /**
@@ -605,7 +608,7 @@ class RequestVerificationTest extends TestCase
         $this->expectException(DocumentStorageFailedException::class);
 
         $input = new RequestVerificationInput($accountId, $verificationType, $applicantInfo, $documents);
-        $useCase->process($input);
+        $useCase->process($input, new RequestVerificationOutput());
     }
 
     private function createAccount(AccountIdentifier $accountId, AccountCategory $category): Account

--- a/tests/Account/AccountVerification/Domain/Entity/AccountVerificationTest.php
+++ b/tests/Account/AccountVerification/Domain/Entity/AccountVerificationTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\Account\AccountVerification\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use PHPUnit\Framework\TestCase;
 use Source\Account\AccountVerification\Domain\Entity\AccountVerification;
 use Source\Account\AccountVerification\Domain\Entity\VerificationDocument;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationApprovalException;
+use Source\Account\AccountVerification\Domain\Exception\InvalidVerificationRejectionException;
 use Source\Account\AccountVerification\Domain\ValueObject\ApplicantInfo;
 use Source\Account\AccountVerification\Domain\ValueObject\DocumentIdentifier;
 use Source\Account\AccountVerification\Domain\ValueObject\DocumentPath;
@@ -78,7 +79,7 @@ class AccountVerificationTest extends TestCase
         $verification = $testData->verification;
         $reviewerAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidVerificationApprovalException::class);
 
         $verification->approve($reviewerAccountId);
     }
@@ -94,7 +95,7 @@ class AccountVerificationTest extends TestCase
         $verification = $testData->verification;
         $reviewerAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidVerificationApprovalException::class);
 
         $verification->approve($reviewerAccountId);
     }
@@ -131,7 +132,7 @@ class AccountVerificationTest extends TestCase
         $reviewerAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
         $rejectionReason = new RejectionReason(RejectionReasonCode::DOCUMENT_UNCLEAR);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidVerificationRejectionException::class);
 
         $verification->reject($reviewerAccountId, $rejectionReason);
     }
@@ -148,7 +149,7 @@ class AccountVerificationTest extends TestCase
         $reviewerAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
         $rejectionReason = new RejectionReason(RejectionReasonCode::DOCUMENT_UNCLEAR);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(InvalidVerificationRejectionException::class);
 
         $verification->reject($reviewerAccountId, $rejectionReason);
     }


### PR DESCRIPTION
## 📝 変更内容

- AccountVerificationサブドメインの3つのユースケース（ApproveVerification / RejectVerification / RequestVerification）にOutputパターン（OutputPort + Output）を導入
- ドメイン固有の例外クラス（InvalidVerificationApprovalException / InvalidVerificationRejectionException）を新規作成し、汎用例外からの移行
- 各ユースケースに対応するHTTPエンドポイント（Action + FormRequest）を新規作成
- 6言語（en / ja / ko / es / zh_CN / zh_TW）のエラーメッセージを追加
- Output系の単体テスト追加、既存ユースケーステストをOutputパターンに対応

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)

## 🎯 変更理由・背景

AccountVerificationサブドメインのユースケースにOutputパターンを導入し、ユースケース層とプレゼンテーション層の責務を明確に分離する。また、汎用例外（RuntimeException等）からドメイン固有の例外クラスへ移行することで、エラーハンドリングの精度を向上させる。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- OutputPort / Output の設計が他サブドメイン（Wiki, Delegation等）と一貫しているか
- Action内の例外ハンドリングの粒度が適切か
- エンティティの `approve()` / `reject()` メソッドがドメイン固有例外を投げるように変更された点

## 📖 関連情報

### 関連Issue・タスク

Closes #269

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した