### PR TITLE
add: InvitationサブドメインにOutputパターン導入・独自例外への移行・エンドポイント作成

### DIFF
--- a/application/Http/Action/Account/Invitation/Command/CreateInvitation/CreateInvitationAction.php
+++ b/application/Http/Action/Account/Invitation/Command/CreateInvitation/CreateInvitationAction.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Invitation\Command\CreateInvitation;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Invitation\Application\Exception\DisallowedInvitationException;
+use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitationInput;
+use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitationInterface;
+use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitationOutput;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class CreateInvitationAction
+{
+    public function __construct(
+        private CreateInvitationInterface $createInvitation,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param CreateInvitationRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(CreateInvitationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new CreateInvitationInput(
+                    accountIdentifier: new AccountIdentifier($request->accountIdentifier()),
+                    inviterIdentityIdentifier: new IdentityIdentifier($request->inviterIdentityIdentifier()),
+                    emails: array_map(
+                        static fn (string $email) => new Email($email),
+                        $request->emails()
+                    ),
+                );
+                $output = new CreateInvitationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->createInvitation->process($input, $output);
+                DB::commit();
+            } catch (DisallowedInvitationException $e) {
+                DB::rollBack();
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed_invitation', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Account/Invitation/Command/CreateInvitation/CreateInvitationRequest.php
+++ b/application/Http/Action/Account/Invitation/Command/CreateInvitation/CreateInvitationRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Invitation\Command\CreateInvitation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateInvitationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'accountIdentifier' => ['required', 'uuid'],
+            'inviterIdentityIdentifier' => ['required', 'uuid'],
+            'emails' => ['required', 'array', 'min:1'],
+            'emails.*' => ['required', 'email', 'distinct'],
+        ];
+    }
+
+    public function accountIdentifier(): string
+    {
+        return (string) $this->input('accountIdentifier');
+    }
+
+    public function inviterIdentityIdentifier(): string
+    {
+        return (string) $this->input('inviterIdentityIdentifier');
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function emails(): array
+    {
+        return (array) $this->input('emails');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -69,6 +69,10 @@ return [
     'invalid_account_category_for_verification' => 'This account category cannot request verification.',
     'account_verification_already_requested' => 'An account verification has already been requested.',
     'invalid_documents_for_verification' => 'The submitted documents do not meet the requirements.',
+    'invitation_already_used_or_revoked' => 'This invitation has already been used or revoked.',
+    'invitation_expired' => 'This invitation link has expired.',
+    'invitation_not_pending' => 'Only pending invitations can be revoked.',
+    'disallowed_invitation' => 'You do not have permission to create invitations.',
 
     // Wiki
     'unauthorized' => 'This action is not authorized.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -67,6 +67,10 @@ return [
     'invalid_account_category_for_verification' => 'Este tipo de cuenta no puede solicitar verificación.',
     'account_verification_already_requested' => 'Ya se ha enviado una solicitud de verificación de cuenta.',
     'invalid_documents_for_verification' => 'Los documentos enviados no cumplen con los requisitos.',
+    'invitation_already_used_or_revoked' => 'Esta invitación ya ha sido utilizada o revocada.',
+    'invitation_expired' => 'El enlace de invitación ha expirado.',
+    'invitation_not_pending' => 'Solo se pueden revocar las invitaciones pendientes.',
+    'disallowed_invitation' => 'No tiene permiso para crear invitaciones.',
 
     // Wiki
     'unauthorized' => 'Esta acción no está autorizada.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -69,6 +69,10 @@ return [
     'invalid_account_category_for_verification' => 'このアカウント種別では本人確認を申請できません。',
     'account_verification_already_requested' => '本人確認申請は既に提出されています。',
     'invalid_documents_for_verification' => '提出された書類が要件を満たしていません。',
+    'invitation_already_used_or_revoked' => 'この招待は既に使用済みまたは取り消されています。',
+    'invitation_expired' => 'この招待リンクは有効期限が切れています。',
+    'invitation_not_pending' => 'PENDING状態の招待のみ取り消すことができます。',
+    'disallowed_invitation' => '招待を作成する権限がありません。',
 
     // Wiki
     'unauthorized' => 'この操作は認可されていません。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -69,6 +69,10 @@ return [
     'invalid_account_category_for_verification' => '이 계정 유형으로는 본인 확인을 신청할 수 없습니다.',
     'account_verification_already_requested' => '본인 확인 신청이 이미 제출되었습니다.',
     'invalid_documents_for_verification' => '제출된 서류가 요건을 충족하지 않습니다.',
+    'invitation_already_used_or_revoked' => '이 초대는 이미 사용되었거나 취소되었습니다.',
+    'invitation_expired' => '이 초대 링크의 유효기간이 만료되었습니다.',
+    'invitation_not_pending' => '보류 중인 초대만 취소할 수 있습니다.',
+    'disallowed_invitation' => '초대를 생성할 권한이 없습니다.',
 
     // Wiki
     'unauthorized' => '이 작업은 인가되지 않았습니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -69,6 +69,10 @@ return [
     'invalid_account_category_for_verification' => '此账户类型无法申请身份验证。',
     'account_verification_already_requested' => '身份验证申请已提交。',
     'invalid_documents_for_verification' => '提交的文件不符合要求。',
+    'invitation_already_used_or_revoked' => '该邀请已被使用或已被撤销。',
+    'invitation_expired' => '该邀请链接已过期。',
+    'invitation_not_pending' => '只能撤销待处理的邀请。',
+    'disallowed_invitation' => '您没有创建邀请的权限。',
 
     // Wiki
     'unauthorized' => '此操作未获授权。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -69,6 +69,10 @@ return [
     'invalid_account_category_for_verification' => '此帳戶類型無法申請身分驗證。',
     'account_verification_already_requested' => '身分驗證申請已提交。',
     'invalid_documents_for_verification' => '提交的文件不符合要求。',
+    'invitation_already_used_or_revoked' => '該邀請已被使用或已被撤銷。',
+    'invitation_expired' => '該邀請連結已過期。',
+    'invitation_not_pending' => '只能撤銷待處理的邀請。',
+    'disallowed_invitation' => '您沒有建立邀請的權限。',
 
     // Wiki
     'unauthorized' => '此操作未獲授權。',

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -16,6 +16,7 @@ use Application\Http\Action\Account\IdentityGroup\Command\AddIdentityToIdentityG
 use Application\Http\Action\Account\IdentityGroup\Command\CreateIdentityGroup\CreateIdentityGroupAction;
 use Application\Http\Action\Account\IdentityGroup\Command\DeleteIdentityGroup\DeleteIdentityGroupAction;
 use Application\Http\Action\Account\IdentityGroup\Command\RemoveIdentityFromIdentityGroup\RemoveIdentityFromIdentityGroupAction;
+use Application\Http\Action\Account\Invitation\Command\CreateInvitation\CreateInvitationAction;
 use Illuminate\Support\Facades\Route;
 
 // Account
@@ -36,6 +37,9 @@ Route::post('/identity-groups', CreateIdentityGroupAction::class);
 Route::post('/identity-groups/{identityGroupId}/add-member', AddIdentityToIdentityGroupAction::class);
 Route::post('/identity-groups/{identityGroupId}/remove-member', RemoveIdentityFromIdentityGroupAction::class);
 Route::delete('/identity-groups/{identityGroupId}', DeleteIdentityGroupAction::class);
+
+// Invitation
+Route::post('/invitations', CreateInvitationAction::class);
 
 // AccountVerification
 Route::post('/account-verifications', RequestVerificationAction::class);

--- a/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitation.php
+++ b/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitation.php
@@ -7,7 +7,6 @@ namespace Source\Account\Invitation\Application\UseCase\Command\CreateInvitation
 use Source\Account\IdentityGroup\Domain\Repository\IdentityGroupRepositoryInterface;
 use Source\Account\IdentityGroup\Domain\ValueObject\AccountRole;
 use Source\Account\Invitation\Application\Exception\DisallowedInvitationException;
-use Source\Account\Invitation\Domain\Entity\Invitation;
 use Source\Account\Invitation\Domain\Event\InvitationCreated;
 use Source\Account\Invitation\Domain\Factory\InvitationFactoryInterface;
 use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
@@ -21,10 +20,7 @@ readonly class CreateInvitation implements CreateInvitationInterface
     ) {
     }
 
-    /**
-     * @return array<Invitation>
-     */
-    public function process(CreateInvitationInputPort $input): array
+    public function process(CreateInvitationInputPort $input, CreateInvitationOutputPort $output): void
     {
         $this->assertInviterHasPermission($input);
 
@@ -59,7 +55,7 @@ readonly class CreateInvitation implements CreateInvitationInterface
             $invitations[] = $invitation;
         }
 
-        return $invitations;
+        $output->setInvitations($invitations);
     }
 
     private function assertInviterHasPermission(CreateInvitationInputPort $input): void

--- a/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationInterface.php
+++ b/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationInterface.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Invitation\Application\UseCase\Command\CreateInvitation;
 
-use Source\Account\Invitation\Domain\Entity\Invitation;
-
 interface CreateInvitationInterface
 {
-    /**
-     * @return array<Invitation>
-     */
-    public function process(CreateInvitationInputPort $input): array;
+    public function process(CreateInvitationInputPort $input, CreateInvitationOutputPort $output): void;
 }

--- a/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationOutput.php
+++ b/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationOutput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Invitation\Application\UseCase\Command\CreateInvitation;
+
+use Source\Account\Invitation\Domain\Entity\Invitation;
+
+class CreateInvitationOutput implements CreateInvitationOutputPort
+{
+    /** @var array<Invitation> */
+    private array $invitations = [];
+
+    /**
+     * @param array<Invitation> $invitations
+     */
+    public function setInvitations(array $invitations): void
+    {
+        $this->invitations = $invitations;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(fn (Invitation $invitation) => [
+            'invitationIdentifier' => (string) $invitation->invitationIdentifier(),
+            'accountIdentifier' => (string) $invitation->accountIdentifier(),
+            'invitedByIdentityIdentifier' => (string) $invitation->invitedByIdentityIdentifier(),
+            'email' => (string) $invitation->email(),
+            'token' => (string) $invitation->token(),
+            'status' => $invitation->status()->value,
+            'expiresAt' => $invitation->expiresAt()->format('Y-m-d\TH:i:sP'),
+            'createdAt' => $invitation->createdAt()->format('Y-m-d\TH:i:sP'),
+        ], $this->invitations);
+    }
+}

--- a/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationOutputPort.php
+++ b/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationOutputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Invitation\Application\UseCase\Command\CreateInvitation;
+
+use Source\Account\Invitation\Domain\Entity\Invitation;
+
+interface CreateInvitationOutputPort
+{
+    /**
+     * @param array<Invitation> $invitations
+     */
+    public function setInvitations(array $invitations): void;
+}

--- a/src/Account/Invitation/Domain/Entity/Invitation.php
+++ b/src/Account/Invitation/Domain/Entity/Invitation.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
+use Source\Account\Invitation\Domain\Exception\InvitationAlreadyUsedOrRevokedException;
+use Source\Account\Invitation\Domain\Exception\InvitationExpiredException;
+use Source\Account\Invitation\Domain\Exception\InvitationNotPendingException;
 use Source\Account\Invitation\Domain\ValueObject\InvitationIdentifier;
 use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
@@ -92,11 +94,11 @@ class Invitation
     public function assertAcceptable(): void
     {
         if (! $this->status->isPending()) {
-            throw new DomainException('この招待は既に使用済みまたは取り消されています。');
+            throw new InvitationAlreadyUsedOrRevokedException();
         }
 
         if ($this->isExpired()) {
-            throw new DomainException('この招待リンクは有効期限が切れています。');
+            throw new InvitationExpiredException();
         }
     }
 
@@ -112,7 +114,7 @@ class Invitation
     public function revoke(): void
     {
         if (! $this->status->isPending()) {
-            throw new DomainException('PENDING状態の招待のみ取り消すことができます。');
+            throw new InvitationNotPendingException();
         }
 
         $this->status = InvitationStatus::REVOKED;

--- a/src/Account/Invitation/Domain/Exception/InvitationAlreadyUsedOrRevokedException.php
+++ b/src/Account/Invitation/Domain/Exception/InvitationAlreadyUsedOrRevokedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Invitation\Domain\Exception;
+
+use DomainException;
+
+class InvitationAlreadyUsedOrRevokedException extends DomainException
+{
+    public function __construct(string $message = 'This invitation has already been used or revoked.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Account/Invitation/Domain/Exception/InvitationExpiredException.php
+++ b/src/Account/Invitation/Domain/Exception/InvitationExpiredException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Invitation\Domain\Exception;
+
+use DomainException;
+
+class InvitationExpiredException extends DomainException
+{
+    public function __construct(string $message = 'This invitation link has expired.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Account/Invitation/Domain/Exception/InvitationNotPendingException.php
+++ b/src/Account/Invitation/Domain/Exception/InvitationNotPendingException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Invitation\Domain\Exception;
+
+use DomainException;
+
+class InvitationNotPendingException extends DomainException
+{
+    public function __construct(string $message = 'Only pending invitations can be revoked.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationOutputTest.php
+++ b/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationOutputTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Invitation\Application\UseCase\Command\CreateInvitation;
+
+use DateTimeImmutable;
+use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitationOutput;
+use Source\Account\Invitation\Domain\Entity\Invitation;
+use Source\Account\Invitation\Domain\ValueObject\InvitationIdentifier;
+use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
+use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreateInvitationOutputTest extends TestCase
+{
+    /**
+     * 正常系: InvitationsがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithInvitations(): void
+    {
+        $invitationIdentifier = new InvitationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $invitedByIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $email = new Email('test@example.com');
+        $token = new InvitationToken(StrTestHelper::generateHex(64));
+        $status = InvitationStatus::PENDING;
+        $expiresAt = new DateTimeImmutable('+7 days');
+        $createdAt = new DateTimeImmutable();
+
+        $invitation = new Invitation(
+            $invitationIdentifier,
+            $accountIdentifier,
+            $invitedByIdentityIdentifier,
+            $email,
+            $token,
+            $status,
+            $expiresAt,
+            null,
+            null,
+            $createdAt,
+        );
+
+        $output = new CreateInvitationOutput();
+        $output->setInvitations([$invitation]);
+
+        $result = $output->toArray();
+
+        $this->assertCount(1, $result);
+        $this->assertSame((string) $invitationIdentifier, $result[0]['invitationIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result[0]['accountIdentifier']);
+        $this->assertSame((string) $invitedByIdentityIdentifier, $result[0]['invitedByIdentityIdentifier']);
+        $this->assertSame((string) $email, $result[0]['email']);
+        $this->assertSame((string) $token, $result[0]['token']);
+        $this->assertSame($status->value, $result[0]['status']);
+        $this->assertSame($expiresAt->format('Y-m-d\TH:i:sP'), $result[0]['expiresAt']);
+        $this->assertSame($createdAt->format('Y-m-d\TH:i:sP'), $result[0]['createdAt']);
+    }
+
+    /**
+     * 正常系: Invitationsが未セットの場合toArrayが空配列を返すこと.
+     */
+    public function testToArrayWithoutInvitations(): void
+    {
+        $output = new CreateInvitationOutput();
+        $this->assertSame([], $output->toArray());
+    }
+}

--- a/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationTest.php
+++ b/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationTest.php
@@ -15,6 +15,7 @@ use Source\Account\Invitation\Application\Exception\DisallowedInvitationExceptio
 use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitation;
 use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitationInput;
 use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitationInterface;
+use Source\Account\Invitation\Application\UseCase\Command\CreateInvitation\CreateInvitationOutput;
 use Source\Account\Invitation\Domain\Entity\Invitation;
 use Source\Account\Invitation\Domain\Event\InvitationCreated;
 use Source\Account\Invitation\Domain\Factory\InvitationFactoryInterface;
@@ -88,10 +89,10 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
-        $result = $useCase->process($data->input);
+        $output = new CreateInvitationOutput();
+        $useCase->process($data->input, $output);
 
-        $this->assertCount(1, $result);
-        $this->assertSame($data->invitation, $result[0]);
+        $this->assertCount(1, $output->toArray());
 
         Event::assertDispatched(InvitationCreated::class, static fn (InvitationCreated $event) => (string) $event->invitationIdentifier === (string) $data->invitation->invitationIdentifier()
             && (string) $event->accountIdentifier === (string) $data->accountIdentifier
@@ -135,10 +136,10 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
-        $result = $useCase->process($data->input);
+        $output = new CreateInvitationOutput();
+        $useCase->process($data->input, $output);
 
-        $this->assertCount(1, $result);
-        $this->assertSame($data->invitation, $result[0]);
+        $this->assertCount(1, $output->toArray());
     }
 
     /**
@@ -167,7 +168,8 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
-        $useCase->process($data->input);
+        $output = new CreateInvitationOutput();
+        $useCase->process($data->input, $output);
     }
 
     /**
@@ -196,7 +198,8 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
-        $useCase->process($data->input);
+        $output = new CreateInvitationOutput();
+        $useCase->process($data->input, $output);
     }
 
     /**
@@ -242,9 +245,10 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
-        $result = $useCase->process($data->input);
+        $output = new CreateInvitationOutput();
+        $useCase->process($data->input, $output);
 
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $output->toArray());
     }
 
     /**
@@ -309,11 +313,10 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
-        $result = $useCase->process($input);
+        $output = new CreateInvitationOutput();
+        $useCase->process($input, $output);
 
-        $this->assertCount(2, $result);
-        $this->assertSame($invitation1, $result[0]);
-        $this->assertSame($invitation2, $result[1]);
+        $this->assertCount(2, $output->toArray());
 
         Event::assertDispatchedTimes(InvitationCreated::class, 2);
     }
@@ -361,9 +364,10 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
-        $result = $useCase->process($data->input);
+        $output = new CreateInvitationOutput();
+        $useCase->process($data->input, $output);
 
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $output->toArray());
     }
 
     private function createTestData(AccountRole $role): CreateInvitationTestData

--- a/tests/Account/Invitation/Domain/Entity/InvitationTest.php
+++ b/tests/Account/Invitation/Domain/Entity/InvitationTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Tests\Account\Invitation\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use PHPUnit\Framework\TestCase;
 use Source\Account\Invitation\Domain\Entity\Invitation;
+use Source\Account\Invitation\Domain\Exception\InvitationAlreadyUsedOrRevokedException;
+use Source\Account\Invitation\Domain\Exception\InvitationExpiredException;
+use Source\Account\Invitation\Domain\Exception\InvitationNotPendingException;
 use Source\Account\Invitation\Domain\ValueObject\InvitationIdentifier;
 use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
@@ -86,8 +88,7 @@ class InvitationTest extends TestCase
     {
         $invitation = $this->createInvitation(InvitationStatus::ACCEPTED);
 
-        $this->expectException(DomainException::class);
-        $this->expectExceptionMessage('この招待は既に使用済みまたは取り消されています。');
+        $this->expectException(InvitationAlreadyUsedOrRevokedException::class);
 
         $invitation->assertAcceptable();
     }
@@ -96,8 +97,7 @@ class InvitationTest extends TestCase
     {
         $invitation = $this->createInvitation(InvitationStatus::REVOKED);
 
-        $this->expectException(DomainException::class);
-        $this->expectExceptionMessage('この招待は既に使用済みまたは取り消されています。');
+        $this->expectException(InvitationAlreadyUsedOrRevokedException::class);
 
         $invitation->assertAcceptable();
     }
@@ -106,8 +106,7 @@ class InvitationTest extends TestCase
     {
         $invitation = $this->createInvitation(expiresAt: new DateTimeImmutable('-1 day'));
 
-        $this->expectException(DomainException::class);
-        $this->expectExceptionMessage('この招待リンクは有効期限が切れています。');
+        $this->expectException(InvitationExpiredException::class);
 
         $invitation->assertAcceptable();
     }
@@ -129,8 +128,7 @@ class InvitationTest extends TestCase
         $invitation = $this->createInvitation(InvitationStatus::ACCEPTED);
         $acceptedByIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
 
-        $this->expectException(DomainException::class);
-        $this->expectExceptionMessage('この招待は既に使用済みまたは取り消されています。');
+        $this->expectException(InvitationAlreadyUsedOrRevokedException::class);
 
         $invitation->accept($acceptedByIdentityIdentifier);
     }
@@ -140,8 +138,7 @@ class InvitationTest extends TestCase
         $invitation = $this->createInvitation(expiresAt: new DateTimeImmutable('-1 day'));
         $acceptedByIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
 
-        $this->expectException(DomainException::class);
-        $this->expectExceptionMessage('この招待リンクは有効期限が切れています。');
+        $this->expectException(InvitationExpiredException::class);
 
         $invitation->accept($acceptedByIdentityIdentifier);
     }
@@ -159,8 +156,7 @@ class InvitationTest extends TestCase
     {
         $invitation = $this->createInvitation(InvitationStatus::ACCEPTED);
 
-        $this->expectException(DomainException::class);
-        $this->expectExceptionMessage('PENDING状態の招待のみ取り消すことができます。');
+        $this->expectException(InvitationNotPendingException::class);
 
         $invitation->revoke();
     }
@@ -169,8 +165,7 @@ class InvitationTest extends TestCase
     {
         $invitation = $this->createInvitation(InvitationStatus::REVOKED);
 
-        $this->expectException(DomainException::class);
-        $this->expectExceptionMessage('PENDING状態の招待のみ取り消すことができます。');
+        $this->expectException(InvitationNotPendingException::class);
 
         $invitation->revoke();
     }


### PR DESCRIPTION
## 📝 変更内容

- InvitationサブドメインのCreateInvitation UseCaseにOutputパターン（OutputPort/Output）を導入
- Invitationエンティティの`DomainException`を独自例外クラス3つに置き換え
  - `InvitationAlreadyUsedOrRevokedException`
  - `InvitationExpiredException`
  - `InvitationNotPendingException`
- `POST /invitations` エンドポイント（CreateInvitationAction + CreateInvitationRequest）を新規作成
- 6言語（en/ja/ko/es/zh_CN/zh_TW）のエラーメッセージを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🔧 リファクタリング (Refactoring)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

Invitationサブドメインにおいて、UseCaseの戻り値をOutputパターンに統一し、ドメイン層の例外を汎用DomainExceptionから独自例外クラスに移行することで、エラーハンドリングの明確化と一貫性を向上させる。また、招待作成のAPIエンドポイントを追加する。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- CreateInvitationOutputの`toArray()`のレスポンス構造が適切か
- CreateInvitationActionのエラーハンドリング（DisallowedInvitationException → 403, InvalidArgumentException → 422）が適切か
- 独自例外クラスのデフォルトメッセージが英語で統一されているか

## 📖 関連情報

### 関連Issue・タスク

Closes #270

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した