### PR TITLE
add: PrincipalサブドメインにOutputパターン・独自例外・エンドポイント追加

### DIFF
--- a/application/Http/Action/Wiki/Principal/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupAction.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyMemberException;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class AddPrincipalToPrincipalGroupAction
+{
+    public function __construct(
+        private AddPrincipalToPrincipalGroupInterface $addPrincipalToPrincipalGroup,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(AddPrincipalToPrincipalGroupRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new AddPrincipalToPrincipalGroupInput(
+                    new PrincipalGroupIdentifier($request->principalGroupId()),
+                    new PrincipalIdentifier($request->principalIdentifier()),
+                );
+                $output = new AddPrincipalToPrincipalGroupOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->addPrincipalToPrincipalGroup->process($input, $output);
+                DB::commit();
+            } catch (PrincipalGroupNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('principal_group_not_found', $language), previous: $e);
+            } catch (PrincipalAlreadyMemberException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('principal_already_member', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddPrincipalToPrincipalGroupRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function principalGroupId(): string
+    {
+        return (string) $this->route('principalGroupId');
+    }
+
+    public function principalIdentifier(): string
+    {
+        return (string) $this->input('principalIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/AttachPolicyToRole/AttachPolicyToRoleAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/AttachPolicyToRole/AttachPolicyToRoleAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PolicyNotFoundException;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachPolicyToRole\AttachPolicyToRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachPolicyToRole\AttachPolicyToRoleInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class AttachPolicyToRoleAction
+{
+    public function __construct(
+        private AttachPolicyToRoleInterface $attachPolicyToRole,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(AttachPolicyToRoleRequest $request): Response
+    {
+        try {
+            try {
+                $input = new AttachPolicyToRoleInput(
+                    new RoleIdentifier($request->roleId()),
+                    new PolicyIdentifier($request->policyIdentifier()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->attachPolicyToRole->process($input);
+                DB::commit();
+            } catch (RoleNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('role_not_found', $language), previous: $e);
+            } catch (PolicyNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('policy_not_found', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/AttachPolicyToRole/AttachPolicyToRoleRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/AttachPolicyToRole/AttachPolicyToRoleRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttachPolicyToRoleRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'policyIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function roleId(): string
+    {
+        return (string) $this->route('roleId');
+    }
+
+    public function policyIdentifier(): string
+    {
+        return (string) $this->input('policyIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/AttachRoleToPrincipalGroup/AttachRoleToPrincipalGroupAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/AttachRoleToPrincipalGroup/AttachRoleToPrincipalGroupAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class AttachRoleToPrincipalGroupAction
+{
+    public function __construct(
+        private AttachRoleToPrincipalGroupInterface $attachRoleToPrincipalGroup,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(AttachRoleToPrincipalGroupRequest $request): Response
+    {
+        try {
+            try {
+                $input = new AttachRoleToPrincipalGroupInput(
+                    new PrincipalGroupIdentifier($request->principalGroupId()),
+                    new RoleIdentifier($request->roleIdentifier()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->attachRoleToPrincipalGroup->process($input);
+                DB::commit();
+            } catch (PrincipalGroupNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('principal_group_not_found', $language), previous: $e);
+            } catch (RoleNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('role_not_found', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/AttachRoleToPrincipalGroup/AttachRoleToPrincipalGroupRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/AttachRoleToPrincipalGroup/AttachRoleToPrincipalGroupRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttachRoleToPrincipalGroupRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'roleIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function principalGroupId(): string
+    {
+        return (string) $this->route('principalGroupId');
+    }
+
+    public function roleIdentifier(): string
+    {
+        return (string) $this->input('roleIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreatePolicy/CreatePolicyAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreatePolicy/CreatePolicyAction.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreatePolicy;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyOutput;
+use Source\Wiki\Principal\Domain\ValueObject\Condition;
+use Source\Wiki\Principal\Domain\ValueObject\ConditionClause;
+use Source\Wiki\Principal\Domain\ValueObject\Effect;
+use Source\Wiki\Principal\Domain\ValueObject\Statement;
+use Source\Wiki\Shared\Domain\ValueObject\Action;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class CreatePolicyAction
+{
+    public function __construct(
+        private CreatePolicyInterface $createPolicy,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(CreatePolicyRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $statements = array_map(
+                    static fn (array $s) => new Statement(
+                        Effect::from($s['effect']),
+                        array_map(static fn (string $a) => Action::from($a), $s['actions']),
+                        array_map(static fn (string $r) => ResourceType::from($r), $s['resourceTypes']),
+                        isset($s['condition']) ? new Condition(
+                            array_map(
+                                static fn (array $c) => new ConditionClause($c['field'], $c['operator'], $c['value']),
+                                $s['condition']['clauses'] ?? [],
+                            ),
+                        ) : null,
+                    ),
+                    $request->statements(),
+                );
+
+                $input = new CreatePolicyInput(
+                    $request->name(),
+                    $statements,
+                    $request->isSystemPolicy(),
+                );
+                $output = new CreatePolicyOutput();
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            try {
+                $this->createPolicy->process($input, $output);
+                DB::commit();
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreatePolicy/CreatePolicyRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreatePolicy/CreatePolicyRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreatePolicy;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreatePolicyRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'statements' => ['required', 'array'],
+            'isSystemPolicy' => ['required', 'boolean'],
+        ];
+    }
+
+    public function name(): string
+    {
+        return (string) $this->input('name');
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function statements(): array
+    {
+        return (array) $this->input('statements');
+    }
+
+    public function isSystemPolicy(): bool
+    {
+        return (bool) $this->input('isSystemPolicy');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreatePrincipal/CreatePrincipalAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreatePrincipal/CreatePrincipalAction.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreatePrincipal;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalOutput;
+use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyExistsException;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class CreatePrincipalAction
+{
+    public function __construct(
+        private CreatePrincipalInterface $createPrincipal,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(CreatePrincipalRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new CreatePrincipalInput(
+                    new IdentityIdentifier($request->identityIdentifier()),
+                    new AccountIdentifier($request->accountIdentifier()),
+                );
+                $output = new CreatePrincipalOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->createPrincipal->process($input, $output);
+                DB::commit();
+            } catch (PrincipalAlreadyExistsException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('principal_already_exists', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreatePrincipal/CreatePrincipalRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreatePrincipal/CreatePrincipalRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreatePrincipal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreatePrincipalRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'identityIdentifier' => ['required', 'uuid'],
+            'accountIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function identityIdentifier(): string
+    {
+        return (string) $this->input('identityIdentifier');
+    }
+
+    public function accountIdentifier(): string
+    {
+        return (string) $this->input('accountIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreatePrincipalGroup/CreatePrincipalGroupAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreatePrincipalGroup/CreatePrincipalGroupAction.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreatePrincipalGroup;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class CreatePrincipalGroupAction
+{
+    public function __construct(
+        private CreatePrincipalGroupInterface $createPrincipalGroup,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(CreatePrincipalGroupRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new CreatePrincipalGroupInput(
+                    new AccountIdentifier($request->accountIdentifier()),
+                    $request->name(),
+                );
+                $output = new CreatePrincipalGroupOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            try {
+                $this->createPrincipalGroup->process($input, $output);
+                DB::commit();
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreatePrincipalGroup/CreatePrincipalGroupRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreatePrincipalGroup/CreatePrincipalGroupRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreatePrincipalGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreatePrincipalGroupRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'accountIdentifier' => ['required', 'uuid'],
+            'name' => ['required', 'string'],
+        ];
+    }
+
+    public function accountIdentifier(): string
+    {
+        return (string) $this->input('accountIdentifier');
+    }
+
+    public function name(): string
+    {
+        return (string) $this->input('name');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreateRole/CreateRoleAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreateRole/CreateRoleAction.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreateRole;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleOutput;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class CreateRoleAction
+{
+    public function __construct(
+        private CreateRoleInterface $createRole,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(CreateRoleRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $policies = array_map(
+                    static fn (string $id) => new PolicyIdentifier($id),
+                    $request->policies() ?? [],
+                );
+
+                $input = new CreateRoleInput(
+                    $request->name(),
+                    $policies,
+                    $request->isSystemRole(),
+                );
+                $output = new CreateRoleOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            try {
+                $this->createRole->process($input, $output);
+                DB::commit();
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/CreateRole/CreateRoleRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreateRole/CreateRoleRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\CreateRole;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateRoleRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'policies' => ['nullable', 'array'],
+            'policies.*' => ['uuid'],
+            'isSystemRole' => ['required', 'boolean'],
+        ];
+    }
+
+    public function name(): string
+    {
+        return (string) $this->input('name');
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function policies(): ?array
+    {
+        return $this->input('policies');
+    }
+
+    public function isSystemRole(): bool
+    {
+        return (bool) $this->input('isSystemRole');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DeletePolicy/DeletePolicyAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/DeletePolicy/DeletePolicyAction.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DeletePolicy;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\CannotDeleteSystemPolicyException;
+use Source\Wiki\Principal\Application\Exception\PolicyNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePolicy\DeletePolicyInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePolicy\DeletePolicyInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class DeletePolicyAction
+{
+    public function __construct(
+        private DeletePolicyInterface $deletePolicy,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(DeletePolicyRequest $request): Response
+    {
+        try {
+            try {
+                $input = new DeletePolicyInput(
+                    new PolicyIdentifier($request->policyId()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->deletePolicy->process($input);
+                DB::commit();
+            } catch (PolicyNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('policy_not_found', $language), previous: $e);
+            } catch (CannotDeleteSystemPolicyException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('cannot_delete_system_policy', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DeletePolicy/DeletePolicyRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/DeletePolicy/DeletePolicyRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DeletePolicy;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeletePolicyRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function policyId(): string
+    {
+        return (string) $this->route('policyId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DeletePrincipalGroup/DeletePrincipalGroupAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/DeletePrincipalGroup/DeletePrincipalGroupAction.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DeletePrincipalGroup;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\CannotDeleteDefaultPrincipalGroupException;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePrincipalGroup\DeletePrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePrincipalGroup\DeletePrincipalGroupInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class DeletePrincipalGroupAction
+{
+    public function __construct(
+        private DeletePrincipalGroupInterface $deletePrincipalGroup,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(DeletePrincipalGroupRequest $request): Response
+    {
+        try {
+            try {
+                $input = new DeletePrincipalGroupInput(
+                    new PrincipalGroupIdentifier($request->principalGroupId()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->deletePrincipalGroup->process($input);
+                DB::commit();
+            } catch (PrincipalGroupNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('principal_group_not_found', $language), previous: $e);
+            } catch (CannotDeleteDefaultPrincipalGroupException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('cannot_delete_default_principal_group', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DeletePrincipalGroup/DeletePrincipalGroupRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/DeletePrincipalGroup/DeletePrincipalGroupRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DeletePrincipalGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeletePrincipalGroupRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function principalGroupId(): string
+    {
+        return (string) $this->route('principalGroupId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DeleteRole/DeleteRoleAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/DeleteRole/DeleteRoleAction.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DeleteRole;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\CannotDeleteSystemRoleException;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DeleteRole\DeleteRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DeleteRole\DeleteRoleInterface;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class DeleteRoleAction
+{
+    public function __construct(
+        private DeleteRoleInterface $deleteRole,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(DeleteRoleRequest $request): Response
+    {
+        try {
+            try {
+                $input = new DeleteRoleInput(
+                    new RoleIdentifier($request->roleId()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->deleteRole->process($input);
+                DB::commit();
+            } catch (RoleNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('role_not_found', $language), previous: $e);
+            } catch (CannotDeleteSystemRoleException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('cannot_delete_system_role', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DeleteRole/DeleteRoleRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/DeleteRole/DeleteRoleRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DeleteRole;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteRoleRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function roleId(): string
+    {
+        return (string) $this->route('roleId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DetachPolicyFromRole/DetachPolicyFromRoleAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/DetachPolicyFromRole/DetachPolicyFromRoleAction.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DetachPolicyFromRole;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachPolicyFromRole\DetachPolicyFromRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachPolicyFromRole\DetachPolicyFromRoleInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class DetachPolicyFromRoleAction
+{
+    public function __construct(
+        private DetachPolicyFromRoleInterface $detachPolicyFromRole,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(DetachPolicyFromRoleRequest $request): Response
+    {
+        try {
+            try {
+                $input = new DetachPolicyFromRoleInput(
+                    new RoleIdentifier($request->roleId()),
+                    new PolicyIdentifier($request->policyIdentifier()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->detachPolicyFromRole->process($input);
+                DB::commit();
+            } catch (RoleNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('role_not_found', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DetachPolicyFromRole/DetachPolicyFromRoleRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/DetachPolicyFromRole/DetachPolicyFromRoleRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DetachPolicyFromRole;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DetachPolicyFromRoleRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'policyIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function roleId(): string
+    {
+        return (string) $this->route('roleId');
+    }
+
+    public function policyIdentifier(): string
+    {
+        return (string) $this->input('policyIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DetachRoleFromPrincipalGroup/DetachRoleFromPrincipalGroupAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/DetachRoleFromPrincipalGroup/DetachRoleFromPrincipalGroupAction.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class DetachRoleFromPrincipalGroupAction
+{
+    public function __construct(
+        private DetachRoleFromPrincipalGroupInterface $detachRoleFromPrincipalGroup,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(DetachRoleFromPrincipalGroupRequest $request): Response
+    {
+        try {
+            try {
+                $input = new DetachRoleFromPrincipalGroupInput(
+                    new PrincipalGroupIdentifier($request->principalGroupId()),
+                    new RoleIdentifier($request->roleIdentifier()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->detachRoleFromPrincipalGroup->process($input);
+                DB::commit();
+            } catch (PrincipalGroupNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('principal_group_not_found', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/DetachRoleFromPrincipalGroup/DetachRoleFromPrincipalGroupRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/DetachRoleFromPrincipalGroup/DetachRoleFromPrincipalGroupRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DetachRoleFromPrincipalGroupRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'roleIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function principalGroupId(): string
+    {
+        return (string) $this->route('principalGroupId');
+    }
+
+    public function roleIdentifier(): string
+    {
+        return (string) $this->input('roleIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupAction.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Exception\PrincipalNotMemberException;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RemovePrincipalFromPrincipalGroupAction
+{
+    public function __construct(
+        private RemovePrincipalFromPrincipalGroupInterface $removePrincipalFromPrincipalGroup,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RemovePrincipalFromPrincipalGroupRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RemovePrincipalFromPrincipalGroupInput(
+                    new PrincipalGroupIdentifier($request->principalGroupId()),
+                    new PrincipalIdentifier($request->principalIdentifier()),
+                );
+                $output = new RemovePrincipalFromPrincipalGroupOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->removePrincipalFromPrincipalGroup->process($input, $output);
+                DB::commit();
+            } catch (PrincipalGroupNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('principal_group_not_found', $language), previous: $e);
+            } catch (PrincipalNotMemberException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('principal_not_member', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupRequest.php
+++ b/application/Http/Action/Wiki/Principal/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RemovePrincipalFromPrincipalGroupRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function principalGroupId(): string
+    {
+        return (string) $this->route('principalGroupId');
+    }
+
+    public function principalIdentifier(): string
+    {
+        return (string) $this->input('principalIdentifier');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -86,4 +86,16 @@ return [
     'version_mismatch' => 'Version mismatch detected in translation set.',
     'invalid_rollback_target_version' => 'Target version must be less than current version.',
     'invalid_status' => 'The status is invalid for this operation.',
+
+    // Wiki Principal
+    'principal_group_not_found' => 'The specified principal group was not found.',
+    'policy_not_found' => 'The specified policy was not found.',
+    'role_not_found' => 'The specified role was not found.',
+    'principal_already_exists' => 'A principal already exists for this identity.',
+    'cannot_delete_system_policy' => 'System policies cannot be deleted.',
+    'cannot_delete_system_role' => 'System roles cannot be deleted.',
+    'cannot_delete_default_principal_group' => 'The default principal group cannot be deleted.',
+    'principal_already_member' => 'The principal is already a member of this group.',
+    'principal_not_member' => 'The principal is not a member of this group.',
+    'cannot_change_non_delegated_principal' => 'Cannot change the enabled status of a non-delegated principal.',
 ];

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -86,4 +86,16 @@ return [
     'version_mismatch' => 'Se detectó una discrepancia de versión en el conjunto de traducción.',
     'invalid_rollback_target_version' => 'La versión de destino debe ser menor que la versión actual.',
     'invalid_status' => 'El estado no es válido para esta operación.',
+
+    // Wiki Principal
+    'principal_group_not_found' => 'No se encontró el grupo de principal especificado.',
+    'policy_not_found' => 'No se encontró la política especificada.',
+    'role_not_found' => 'No se encontró el rol especificado.',
+    'principal_already_exists' => 'Ya existe un principal para esta identidad.',
+    'cannot_delete_system_policy' => 'Las políticas del sistema no se pueden eliminar.',
+    'cannot_delete_system_role' => 'Los roles del sistema no se pueden eliminar.',
+    'cannot_delete_default_principal_group' => 'El grupo de principal predeterminado no se puede eliminar.',
+    'principal_already_member' => 'El principal ya es miembro de este grupo.',
+    'principal_not_member' => 'El principal no es miembro de este grupo.',
+    'cannot_change_non_delegated_principal' => 'No se puede cambiar el estado habilitado de un principal no delegado.',
 ];

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -86,4 +86,16 @@ return [
     'version_mismatch' => '翻訳セット内でバージョンの不一致が検出されました。',
     'invalid_rollback_target_version' => 'ロールバック先のバージョンが無効です。',
     'invalid_status' => 'ステータスが無効です。',
+
+    // Wiki Principal
+    'principal_group_not_found' => '指定されたプリンシパルグループが見つかりません。',
+    'policy_not_found' => '指定されたポリシーが見つかりません。',
+    'role_not_found' => '指定されたロールが見つかりません。',
+    'principal_already_exists' => 'このアイデンティティにはプリンシパルが既に存在します。',
+    'cannot_delete_system_policy' => 'システムポリシーは削除できません。',
+    'cannot_delete_system_role' => 'システムロールは削除できません。',
+    'cannot_delete_default_principal_group' => 'デフォルトのプリンシパルグループは削除できません。',
+    'principal_already_member' => 'このプリンシパルは既にこのグループのメンバーです。',
+    'principal_not_member' => 'このプリンシパルはこのグループのメンバーではありません。',
+    'cannot_change_non_delegated_principal' => '委任されていないプリンシパルの有効状態は変更できません。',
 ];

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -86,4 +86,16 @@ return [
     'version_mismatch' => '번역 세트에서 버전 불일치가 감지되었습니다.',
     'invalid_rollback_target_version' => '롤백 대상 버전이 유효하지 않습니다.',
     'invalid_status' => '이 작업에 대해 상태가 유효하지 않습니다.',
+
+    // Wiki Principal
+    'principal_group_not_found' => '지정된 프린시펄 그룹을 찾을 수 없습니다.',
+    'policy_not_found' => '지정된 정책을 찾을 수 없습니다.',
+    'role_not_found' => '지정된 역할을 찾을 수 없습니다.',
+    'principal_already_exists' => '이 아이덴티티에는 이미 프린시펄이 존재합니다.',
+    'cannot_delete_system_policy' => '시스템 정책은 삭제할 수 없습니다.',
+    'cannot_delete_system_role' => '시스템 역할은 삭제할 수 없습니다.',
+    'cannot_delete_default_principal_group' => '기본 프린시펄 그룹은 삭제할 수 없습니다.',
+    'principal_already_member' => '이 프린시펄은 이미 이 그룹의 멤버입니다.',
+    'principal_not_member' => '이 프린시펄은 이 그룹의 멤버가 아닙니다.',
+    'cannot_change_non_delegated_principal' => '위임되지 않은 프린시펄의 활성 상태는 변경할 수 없습니다.',
 ];

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -86,4 +86,16 @@ return [
     'version_mismatch' => '翻译集中检测到版本不匹配。',
     'invalid_rollback_target_version' => '目标版本必须小于当前版本。',
     'invalid_status' => '此操作的状态无效。',
+
+    // Wiki Principal
+    'principal_group_not_found' => '未找到指定的主体组。',
+    'policy_not_found' => '未找到指定的策略。',
+    'role_not_found' => '未找到指定的角色。',
+    'principal_already_exists' => '此身份已存在主体。',
+    'cannot_delete_system_policy' => '系统策略不可删除。',
+    'cannot_delete_system_role' => '系统角色不可删除。',
+    'cannot_delete_default_principal_group' => '默认主体组不可删除。',
+    'principal_already_member' => '该主体已是此组的成员。',
+    'principal_not_member' => '该主体不是此组的成员。',
+    'cannot_change_non_delegated_principal' => '无法更改非委托主体的启用状态。',
 ];

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -86,4 +86,16 @@ return [
     'version_mismatch' => '翻譯集中檢測到版本不匹配。',
     'invalid_rollback_target_version' => '目標版本必須小於當前版本。',
     'invalid_status' => '此操作的狀態無效。',
+
+    // Wiki Principal
+    'principal_group_not_found' => '找不到指定的主體群組。',
+    'policy_not_found' => '找不到指定的政策。',
+    'role_not_found' => '找不到指定的角色。',
+    'principal_already_exists' => '此身分已存在主體。',
+    'cannot_delete_system_policy' => '系統政策無法刪除。',
+    'cannot_delete_system_role' => '系統角色無法刪除。',
+    'cannot_delete_default_principal_group' => '預設主體群組無法刪除。',
+    'principal_already_member' => '該主體已是此群組的成員。',
+    'principal_not_member' => '該主體不是此群組的成員。',
+    'cannot_change_non_delegated_principal' => '無法變更非委任主體的啟用狀態。',
 ];

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\CreatePolicy\CreatePolicyAction;
+use Application\Http\Action\Wiki\Principal\Command\CreatePrincipal\CreatePrincipalAction;
+use Application\Http\Action\Wiki\Principal\Command\CreatePrincipalGroup\CreatePrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\CreateRole\CreateRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\DeletePolicy\DeletePolicyAction;
+use Application\Http\Action\Wiki\Principal\Command\DeletePrincipalGroup\DeletePrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\DeleteRole\DeleteRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\DetachPolicyFromRole\DetachPolicyFromRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupAction;
 use Application\Http\Action\Wiki\Wiki\Command\ApproveWiki\ApproveWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\AutoCreateWiki\AutoCreateWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\CreateWiki\CreateWikiAction;
@@ -24,3 +37,18 @@ Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
 Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
 Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
 Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+
+// Principal
+Route::post('/principal/create', CreatePrincipalAction::class);
+Route::post('/principal-group/create', CreatePrincipalGroupAction::class);
+Route::post('/principal-group/{principalGroupId}/add-member', AddPrincipalToPrincipalGroupAction::class);
+Route::post('/principal-group/{principalGroupId}/remove-member', RemovePrincipalFromPrincipalGroupAction::class);
+Route::delete('/principal-group/{principalGroupId}', DeletePrincipalGroupAction::class);
+Route::post('/principal-group/{principalGroupId}/attach-role', AttachRoleToPrincipalGroupAction::class);
+Route::post('/principal-group/{principalGroupId}/detach-role', DetachRoleFromPrincipalGroupAction::class);
+Route::post('/role/create', CreateRoleAction::class);
+Route::delete('/role/{roleId}', DeleteRoleAction::class);
+Route::post('/role/{roleId}/attach-policy', AttachPolicyToRoleAction::class);
+Route::post('/role/{roleId}/detach-policy', DetachPolicyFromRoleAction::class);
+Route::post('/policy/create', CreatePolicyAction::class);
+Route::delete('/policy/{policyId}', DeletePolicyAction::class);

--- a/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroup.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroup.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
 
 use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
-use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 
 readonly class AddPrincipalToPrincipalGroup implements AddPrincipalToPrincipalGroupInterface
@@ -18,7 +17,7 @@ readonly class AddPrincipalToPrincipalGroup implements AddPrincipalToPrincipalGr
     /**
      * @throws PrincipalGroupNotFoundException
      */
-    public function process(AddPrincipalToPrincipalGroupInputPort $input): PrincipalGroup
+    public function process(AddPrincipalToPrincipalGroupInputPort $input, AddPrincipalToPrincipalGroupOutputPort $output): void
     {
         $principalGroup = $this->principalGroupRepository->findById($input->principalGroupIdentifier());
 
@@ -30,6 +29,6 @@ readonly class AddPrincipalToPrincipalGroup implements AddPrincipalToPrincipalGr
 
         $this->principalGroupRepository->save($principalGroup);
 
-        return $principalGroup;
+        $output->setPrincipalGroup($principalGroup);
     }
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupInterface.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
 
 use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
-use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 
 interface AddPrincipalToPrincipalGroupInterface
 {
     /**
      * @throws PrincipalGroupNotFoundException
      */
-    public function process(AddPrincipalToPrincipalGroupInputPort $input): PrincipalGroup;
+    public function process(AddPrincipalToPrincipalGroupInputPort $input, AddPrincipalToPrincipalGroupOutputPort $output): void;
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutput.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutput.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
+
+use DateTimeInterface;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+
+class AddPrincipalToPrincipalGroupOutput implements AddPrincipalToPrincipalGroupOutputPort
+{
+    private ?PrincipalGroup $principalGroup = null;
+
+    public function setPrincipalGroup(PrincipalGroup $principalGroup): void
+    {
+        $this->principalGroup = $principalGroup;
+    }
+
+    /**
+     * @return array{principalGroupIdentifier: ?string, accountIdentifier: ?string, name: ?string, isDefault: ?bool, memberCount: ?int, createdAt: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->principalGroup === null) {
+            return [
+                'principalGroupIdentifier' => null,
+                'accountIdentifier' => null,
+                'name' => null,
+                'isDefault' => null,
+                'memberCount' => null,
+                'createdAt' => null,
+            ];
+        }
+
+        return [
+            'principalGroupIdentifier' => (string) $this->principalGroup->principalGroupIdentifier(),
+            'accountIdentifier' => (string) $this->principalGroup->accountIdentifier(),
+            'name' => $this->principalGroup->name(),
+            'isDefault' => $this->principalGroup->isDefault(),
+            'memberCount' => $this->principalGroup->memberCount(),
+            'createdAt' => $this->principalGroup->createdAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
+
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+
+interface AddPrincipalToPrincipalGroupOutputPort
+{
+    public function setPrincipalGroup(PrincipalGroup $principalGroup): void;
+
+    /**
+     * @return array{principalGroupIdentifier: ?string, accountIdentifier: ?string, name: ?string, isDefault: ?bool, memberCount: ?int, createdAt: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicy.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicy.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy;
 
-use Source\Wiki\Principal\Domain\Entity\Policy;
 use Source\Wiki\Principal\Domain\Factory\PolicyFactoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PolicyRepositoryInterface;
 
@@ -16,7 +15,7 @@ readonly class CreatePolicy implements CreatePolicyInterface
     ) {
     }
 
-    public function process(CreatePolicyInputPort $input): Policy
+    public function process(CreatePolicyInputPort $input, CreatePolicyOutputPort $output): void
     {
         $policy = $this->policyFactory->create(
             $input->name(),
@@ -26,6 +25,6 @@ readonly class CreatePolicy implements CreatePolicyInterface
 
         $this->policyRepository->save($policy);
 
-        return $policy;
+        $output->setPolicy($policy);
     }
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy;
 
-use Source\Wiki\Principal\Domain\Entity\Policy;
-
 interface CreatePolicyInterface
 {
-    public function process(CreatePolicyInputPort $input): Policy;
+    public function process(CreatePolicyInputPort $input, CreatePolicyOutputPort $output): void;
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyOutput.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyOutput.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy;
+
+use DateTimeInterface;
+use Source\Wiki\Principal\Domain\Entity\Policy;
+
+class CreatePolicyOutput implements CreatePolicyOutputPort
+{
+    private ?Policy $policy = null;
+
+    public function setPolicy(Policy $policy): void
+    {
+        $this->policy = $policy;
+    }
+
+    /**
+     * @return array{policyIdentifier: ?string, name: ?string, isSystemPolicy: ?bool, createdAt: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->policy === null) {
+            return [
+                'policyIdentifier' => null,
+                'name' => null,
+                'isSystemPolicy' => null,
+                'createdAt' => null,
+            ];
+        }
+
+        return [
+            'policyIdentifier' => (string) $this->policy->policyIdentifier(),
+            'name' => $this->policy->name(),
+            'isSystemPolicy' => $this->policy->isSystemPolicy(),
+            'createdAt' => $this->policy->createdAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyOutputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy;
+
+use Source\Wiki\Principal\Domain\Entity\Policy;
+
+interface CreatePolicyOutputPort
+{
+    public function setPolicy(Policy $policy): void;
+
+    /**
+     * @return array{policyIdentifier: ?string, name: ?string, isSystemPolicy: ?bool, createdAt: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipal.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipal.php
@@ -7,7 +7,6 @@ namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyExistsException;
 use Source\Wiki\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Wiki\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
@@ -34,10 +33,10 @@ readonly class CreatePrincipal implements CreatePrincipalInterface
 
     /**
      * @param CreatePrincipalInputPort $input
-     * @return Principal
+     * @param CreatePrincipalOutputPort $output
      * @throws PrincipalAlreadyExistsException
      */
-    public function process(CreatePrincipalInputPort $input): Principal
+    public function process(CreatePrincipalInputPort $input, CreatePrincipalOutputPort $output): void
     {
         $existingPrincipal = $this->principalRepository->findByIdentityIdentifier(
             $input->identityIdentifier()
@@ -79,7 +78,7 @@ readonly class CreatePrincipal implements CreatePrincipalInterface
         $defaultPrincipalGroup->addMember($principal->principalIdentifier());
         $this->principalGroupRepository->save($defaultPrincipalGroup);
 
-        return $principal;
+        $output->setPrincipal($principal);
     }
 
     private function determineRoleName(AccountIdentifier $accountIdentifier): string

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalInterface.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal;
 
-use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyExistsException;
 
 interface CreatePrincipalInterface
 {
     /**
      * @param CreatePrincipalInputPort $input
-     * @return Principal
+     * @param CreatePrincipalOutputPort $output
      * @throws PrincipalAlreadyExistsException
      */
-    public function process(CreatePrincipalInputPort $input): Principal;
+    public function process(CreatePrincipalInputPort $input, CreatePrincipalOutputPort $output): void;
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutput.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal;
+
+use Source\Wiki\Principal\Domain\Entity\Principal;
+
+class CreatePrincipalOutput implements CreatePrincipalOutputPort
+{
+    private ?Principal $principal = null;
+
+    public function setPrincipal(Principal $principal): void
+    {
+        $this->principal = $principal;
+    }
+
+    /**
+     * @return array{principalIdentifier: ?string, identityIdentifier: ?string, isDelegatedPrincipal: ?bool, isEnabled: ?bool}
+     */
+    public function toArray(): array
+    {
+        if ($this->principal === null) {
+            return [
+                'principalIdentifier' => null,
+                'identityIdentifier' => null,
+                'isDelegatedPrincipal' => null,
+                'isEnabled' => null,
+            ];
+        }
+
+        return [
+            'principalIdentifier' => (string) $this->principal->principalIdentifier(),
+            'identityIdentifier' => (string) $this->principal->identityIdentifier(),
+            'isDelegatedPrincipal' => $this->principal->isDelegatedPrincipal(),
+            'isEnabled' => $this->principal->isEnabled(),
+        ];
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal;
+
+use Source\Wiki\Principal\Domain\Entity\Principal;
+
+interface CreatePrincipalOutputPort
+{
+    public function setPrincipal(Principal $principal): void;
+
+    /**
+     * @return array{principalIdentifier: ?string, identityIdentifier: ?string, isDelegatedPrincipal: ?bool, isEnabled: ?bool}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroup.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroup.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup;
 
-use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 use Source\Wiki\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 
@@ -16,7 +15,7 @@ readonly class CreatePrincipalGroup implements CreatePrincipalGroupInterface
     ) {
     }
 
-    public function process(CreatePrincipalGroupInputPort $input): PrincipalGroup
+    public function process(CreatePrincipalGroupInputPort $input, CreatePrincipalGroupOutputPort $output): void
     {
         $principalGroup = $this->principalGroupFactory->create(
             $input->accountIdentifier(),
@@ -26,6 +25,6 @@ readonly class CreatePrincipalGroup implements CreatePrincipalGroupInterface
 
         $this->principalGroupRepository->save($principalGroup);
 
-        return $principalGroup;
+        $output->setPrincipalGroup($principalGroup);
     }
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup;
 
-use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
-
 interface CreatePrincipalGroupInterface
 {
-    public function process(CreatePrincipalGroupInputPort $input): PrincipalGroup;
+    public function process(CreatePrincipalGroupInputPort $input, CreatePrincipalGroupOutputPort $output): void;
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupOutput.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupOutput.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup;
+
+use DateTimeInterface;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+
+class CreatePrincipalGroupOutput implements CreatePrincipalGroupOutputPort
+{
+    private ?PrincipalGroup $principalGroup = null;
+
+    public function setPrincipalGroup(PrincipalGroup $principalGroup): void
+    {
+        $this->principalGroup = $principalGroup;
+    }
+
+    /**
+     * @return array{principalGroupIdentifier: ?string, accountIdentifier: ?string, name: ?string, isDefault: ?bool, memberCount: ?int, createdAt: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->principalGroup === null) {
+            return [
+                'principalGroupIdentifier' => null,
+                'accountIdentifier' => null,
+                'name' => null,
+                'isDefault' => null,
+                'memberCount' => null,
+                'createdAt' => null,
+            ];
+        }
+
+        return [
+            'principalGroupIdentifier' => (string) $this->principalGroup->principalGroupIdentifier(),
+            'accountIdentifier' => (string) $this->principalGroup->accountIdentifier(),
+            'name' => $this->principalGroup->name(),
+            'isDefault' => $this->principalGroup->isDefault(),
+            'memberCount' => $this->principalGroup->memberCount(),
+            'createdAt' => $this->principalGroup->createdAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupOutputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup;
+
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+
+interface CreatePrincipalGroupOutputPort
+{
+    public function setPrincipalGroup(PrincipalGroup $principalGroup): void;
+
+    /**
+     * @return array{principalGroupIdentifier: ?string, accountIdentifier: ?string, name: ?string, isDefault: ?bool, memberCount: ?int, createdAt: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRole.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRole.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreateRole;
 
-use Source\Wiki\Principal\Domain\Entity\Role;
 use Source\Wiki\Principal\Domain\Factory\RoleFactoryInterface;
 use Source\Wiki\Principal\Domain\Repository\RoleRepositoryInterface;
 
@@ -16,7 +15,7 @@ readonly class CreateRole implements CreateRoleInterface
     ) {
     }
 
-    public function process(CreateRoleInputPort $input): Role
+    public function process(CreateRoleInputPort $input, CreateRoleOutputPort $output): void
     {
         $role = $this->roleFactory->create(
             $input->name(),
@@ -26,6 +25,6 @@ readonly class CreateRole implements CreateRoleInterface
 
         $this->roleRepository->save($role);
 
-        return $role;
+        $output->setRole($role);
     }
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreateRole;
 
-use Source\Wiki\Principal\Domain\Entity\Role;
-
 interface CreateRoleInterface
 {
-    public function process(CreateRoleInputPort $input): Role;
+    public function process(CreateRoleInputPort $input, CreateRoleOutputPort $output): void;
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleOutput.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleOutput.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreateRole;
+
+use DateTimeInterface;
+use Source\Wiki\Principal\Domain\Entity\Role;
+
+class CreateRoleOutput implements CreateRoleOutputPort
+{
+    private ?Role $role = null;
+
+    public function setRole(Role $role): void
+    {
+        $this->role = $role;
+    }
+
+    /**
+     * @return array{roleIdentifier: ?string, name: ?string, isSystemRole: ?bool, createdAt: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->role === null) {
+            return [
+                'roleIdentifier' => null,
+                'name' => null,
+                'isSystemRole' => null,
+                'createdAt' => null,
+            ];
+        }
+
+        return [
+            'roleIdentifier' => (string) $this->role->roleIdentifier(),
+            'name' => $this->role->name(),
+            'isSystemRole' => $this->role->isSystemRole(),
+            'createdAt' => $this->role->createdAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleOutputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\CreateRole;
+
+use Source\Wiki\Principal\Domain\Entity\Role;
+
+interface CreateRoleOutputPort
+{
+    public function setRole(Role $role): void;
+
+    /**
+     * @return array{roleIdentifier: ?string, name: ?string, isSystemRole: ?bool, createdAt: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroup.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroup.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
 
 use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
-use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 
 readonly class RemovePrincipalFromPrincipalGroup implements RemovePrincipalFromPrincipalGroupInterface
@@ -18,7 +17,7 @@ readonly class RemovePrincipalFromPrincipalGroup implements RemovePrincipalFromP
     /**
      * @throws PrincipalGroupNotFoundException
      */
-    public function process(RemovePrincipalFromPrincipalGroupInputPort $input): PrincipalGroup
+    public function process(RemovePrincipalFromPrincipalGroupInputPort $input, RemovePrincipalFromPrincipalGroupOutputPort $output): void
     {
         $principalGroup = $this->principalGroupRepository->findById($input->principalGroupIdentifier());
 
@@ -30,6 +29,6 @@ readonly class RemovePrincipalFromPrincipalGroup implements RemovePrincipalFromP
 
         $this->principalGroupRepository->save($principalGroup);
 
-        return $principalGroup;
+        $output->setPrincipalGroup($principalGroup);
     }
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupInterface.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
 
 use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
-use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 
 interface RemovePrincipalFromPrincipalGroupInterface
 {
     /**
      * @throws PrincipalGroupNotFoundException
      */
-    public function process(RemovePrincipalFromPrincipalGroupInputPort $input): PrincipalGroup;
+    public function process(RemovePrincipalFromPrincipalGroupInputPort $input, RemovePrincipalFromPrincipalGroupOutputPort $output): void;
 }

--- a/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutput.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutput.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
+
+use DateTimeInterface;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+
+class RemovePrincipalFromPrincipalGroupOutput implements RemovePrincipalFromPrincipalGroupOutputPort
+{
+    private ?PrincipalGroup $principalGroup = null;
+
+    public function setPrincipalGroup(PrincipalGroup $principalGroup): void
+    {
+        $this->principalGroup = $principalGroup;
+    }
+
+    /**
+     * @return array{principalGroupIdentifier: ?string, accountIdentifier: ?string, name: ?string, isDefault: ?bool, memberCount: ?int, createdAt: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->principalGroup === null) {
+            return [
+                'principalGroupIdentifier' => null,
+                'accountIdentifier' => null,
+                'name' => null,
+                'isDefault' => null,
+                'memberCount' => null,
+                'createdAt' => null,
+            ];
+        }
+
+        return [
+            'principalGroupIdentifier' => (string) $this->principalGroup->principalGroupIdentifier(),
+            'accountIdentifier' => (string) $this->principalGroup->accountIdentifier(),
+            'name' => $this->principalGroup->name(),
+            'isDefault' => $this->principalGroup->isDefault(),
+            'memberCount' => $this->principalGroup->memberCount(),
+            'createdAt' => $this->principalGroup->createdAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
+
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+
+interface RemovePrincipalFromPrincipalGroupOutputPort
+{
+    public function setPrincipalGroup(PrincipalGroup $principalGroup): void;
+
+    /**
+     * @return array{principalGroupIdentifier: ?string, accountIdentifier: ?string, name: ?string, isDefault: ?bool, memberCount: ?int, createdAt: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Principal/Domain/Entity/Principal.php
+++ b/src/Wiki/Principal/Domain/Entity/Principal.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Domain\Entity;
 
-use DomainException;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Domain\Exception\CannotChangeNonDelegatedPrincipalException;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 
 class Principal
@@ -80,7 +80,7 @@ class Principal
     public function setEnabled(bool $enabled): void
     {
         if (! $this->isDelegatedPrincipal()) {
-            throw new DomainException('Cannot change enabled status of non-delegated principal.');
+            throw new CannotChangeNonDelegatedPrincipalException();
         }
 
         $this->enabled = $enabled;

--- a/src/Wiki/Principal/Domain/Entity/PrincipalGroup.php
+++ b/src/Wiki/Principal/Domain/Entity/PrincipalGroup.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Source\Wiki\Principal\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyMemberException;
+use Source\Wiki\Principal\Domain\Exception\PrincipalNotMemberException;
 use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
@@ -74,7 +75,7 @@ class PrincipalGroup
     public function addMember(PrincipalIdentifier $principalIdentifier): void
     {
         if ($this->hasMember($principalIdentifier)) {
-            throw new DomainException('Principal is already a member of this group.');
+            throw new PrincipalAlreadyMemberException();
         }
 
         $this->members[(string) $principalIdentifier] = $principalIdentifier;
@@ -83,7 +84,7 @@ class PrincipalGroup
     public function removeMember(PrincipalIdentifier $principalIdentifier): void
     {
         if (! $this->hasMember($principalIdentifier)) {
-            throw new DomainException('Principal is not a member of this group.');
+            throw new PrincipalNotMemberException();
         }
 
         unset($this->members[(string) $principalIdentifier]);

--- a/src/Wiki/Principal/Domain/Exception/CannotChangeNonDelegatedPrincipalException.php
+++ b/src/Wiki/Principal/Domain/Exception/CannotChangeNonDelegatedPrincipalException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Domain\Exception;
+
+use Exception;
+
+class CannotChangeNonDelegatedPrincipalException extends Exception
+{
+    public function __construct(
+        string $message = 'Cannot change enabled status of non-delegated principal.',
+    ) {
+        parent::__construct($message, 0);
+    }
+}

--- a/src/Wiki/Principal/Domain/Exception/PrincipalAlreadyMemberException.php
+++ b/src/Wiki/Principal/Domain/Exception/PrincipalAlreadyMemberException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Domain\Exception;
+
+use Exception;
+
+class PrincipalAlreadyMemberException extends Exception
+{
+    public function __construct(
+        string $message = 'Principal is already a member of this group.',
+    ) {
+        parent::__construct($message, 0);
+    }
+}

--- a/src/Wiki/Principal/Domain/Exception/PrincipalNotMemberException.php
+++ b/src/Wiki/Principal/Domain/Exception/PrincipalNotMemberException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Domain\Exception;
+
+use Exception;
+
+class PrincipalNotMemberException extends Exception
+{
+    public function __construct(
+        string $message = 'Principal is not a member of this group.',
+    ) {
+        parent::__construct($message, 0);
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutputTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AddPrincipalToPrincipalGroupOutputTest extends TestCase
+{
+    /**
+     * 正常系: PrincipalGroupがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithPrincipalGroup(): void
+    {
+        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $name = 'Test Group';
+        $isDefault = false;
+        $createdAt = new DateTimeImmutable();
+
+        $principalGroup = new PrincipalGroup(
+            $principalGroupIdentifier,
+            $accountIdentifier,
+            $name,
+            $isDefault,
+            $createdAt,
+        );
+
+        $output = new AddPrincipalToPrincipalGroupOutput();
+        $output->setPrincipalGroup($principalGroup);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $principalGroupIdentifier, $result['principalGroupIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result['accountIdentifier']);
+        $this->assertSame($name, $result['name']);
+        $this->assertSame($isDefault, $result['isDefault']);
+        $this->assertSame(0, $result['memberCount']);
+        $this->assertSame($createdAt->format('Y-m-d\TH:i:sP'), $result['createdAt']);
+    }
+
+    /**
+     * 正常系: PrincipalGroupが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutPrincipalGroup(): void
+    {
+        $output = new AddPrincipalToPrincipalGroupOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['principalGroupIdentifier']);
+        $this->assertNull($result['accountIdentifier']);
+        $this->assertNull($result['name']);
+        $this->assertNull($result['isDefault']);
+        $this->assertNull($result['memberCount']);
+        $this->assertNull($result['createdAt']);
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
 
 use DateTimeImmutable;
-use DomainException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
@@ -13,7 +12,9 @@ use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
 use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroup;
 use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupInput;
 use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupOutput;
 use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyMemberException;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
@@ -66,10 +67,12 @@ class AddPrincipalToPrincipalGroupTest extends TestCase
 
         $useCase = $this->app->make(AddPrincipalToPrincipalGroupInterface::class);
         $input = new AddPrincipalToPrincipalGroupInput($principalGroupIdentifier, $principalIdentifier);
+        $output = new AddPrincipalToPrincipalGroupOutput();
 
-        $result = $useCase->process($input);
+        $useCase->process($input, $output);
 
-        $this->assertTrue($result->hasMember($principalIdentifier));
+        $result = $output->toArray();
+        $this->assertSame((string) $principalGroupIdentifier, $result['principalGroupIdentifier']);
     }
 
     /**
@@ -95,7 +98,8 @@ class AddPrincipalToPrincipalGroupTest extends TestCase
 
         $this->expectException(PrincipalGroupNotFoundException::class);
 
-        $useCase->process($input);
+        $output = new AddPrincipalToPrincipalGroupOutput();
+        $useCase->process($input, $output);
     }
 
     /**
@@ -129,9 +133,10 @@ class AddPrincipalToPrincipalGroupTest extends TestCase
         $useCase = $this->app->make(AddPrincipalToPrincipalGroupInterface::class);
         $input = new AddPrincipalToPrincipalGroupInput($principalGroupIdentifier, $principalIdentifier);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(PrincipalAlreadyMemberException::class);
         $this->expectExceptionMessage('Principal is already a member of this group.');
 
-        $useCase->process($input);
+        $output = new AddPrincipalToPrincipalGroupOutput();
+        $useCase->process($input, $output);
     }
 }

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyOutputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyOutputTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Command\CreatePolicy;
+
+use DateTimeImmutable;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyOutput;
+use Source\Wiki\Principal\Domain\Entity\Policy;
+use Source\Wiki\Principal\Domain\ValueObject\Effect;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\Statement;
+use Source\Wiki\Shared\Domain\ValueObject\Action;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreatePolicyOutputTest extends TestCase
+{
+    /**
+     * 正常系: PolicyがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithPolicy(): void
+    {
+        $policyIdentifier = new PolicyIdentifier(StrTestHelper::generateUuid());
+        $name = 'Test Policy';
+        $isSystemPolicy = false;
+        $createdAt = new DateTimeImmutable();
+
+        $policy = new Policy(
+            $policyIdentifier,
+            $name,
+            [
+                new Statement(
+                    Effect::ALLOW,
+                    [Action::CREATE],
+                    ResourceType::cases(),
+                    null,
+                ),
+            ],
+            $isSystemPolicy,
+            $createdAt,
+        );
+
+        $output = new CreatePolicyOutput();
+        $output->setPolicy($policy);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $policyIdentifier, $result['policyIdentifier']);
+        $this->assertSame($name, $result['name']);
+        $this->assertSame($isSystemPolicy, $result['isSystemPolicy']);
+        $this->assertSame($createdAt->format('Y-m-d\TH:i:sP'), $result['createdAt']);
+    }
+
+    /**
+     * 正常系: Policyが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutPolicy(): void
+    {
+        $output = new CreatePolicyOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['policyIdentifier']);
+        $this->assertNull($result['name']);
+        $this->assertNull($result['isSystemPolicy']);
+        $this->assertNull($result['createdAt']);
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePolicy/CreatePolicyTest.php
@@ -10,6 +10,7 @@ use Mockery;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicy;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyInput;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyOutput;
 use Source\Wiki\Principal\Domain\Entity\Policy;
 use Source\Wiki\Principal\Domain\Factory\PolicyFactoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PolicyRepositoryInterface;
@@ -63,13 +64,14 @@ class CreatePolicyTest extends TestCase
         $this->app->instance(PolicyFactoryInterface::class, $factory);
 
         $useCase = $this->app->make(CreatePolicyInterface::class);
+        $output = new CreatePolicyOutput();
 
-        $policy = $useCase->process($testData->input);
+        $useCase->process($testData->input, $output);
 
-        $this->assertSame((string) $testData->policyIdentifier, (string) $policy->policyIdentifier());
-        $this->assertSame($testData->name, $policy->name());
-        $this->assertSame($testData->statements, $policy->statements());
-        $this->assertSame($testData->isSystemPolicy, $policy->isSystemPolicy());
+        $result = $output->toArray();
+        $this->assertSame((string) $testData->policyIdentifier, $result['policyIdentifier']);
+        $this->assertSame($testData->name, $result['name']);
+        $this->assertSame($testData->isSystemPolicy, $result['isSystemPolicy']);
     }
 
     private function createDummyTestData(): CreatePolicyTestData

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutputTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Command\CreatePrincipal;
+
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalOutput;
+use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreatePrincipalOutputTest extends TestCase
+{
+    /**
+     * 正常系: PrincipalがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithPrincipal(): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+
+        $principal = new Principal(
+            $principalIdentifier,
+            $identityIdentifier,
+            null,
+            [],
+            [],
+        );
+
+        $output = new CreatePrincipalOutput();
+        $output->setPrincipal($principal);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
+        $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
+        $this->assertFalse($result['isDelegatedPrincipal']);
+        $this->assertTrue($result['isEnabled']);
+    }
+
+    /**
+     * 正常系: Principalが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutPrincipal(): void
+    {
+        $output = new CreatePrincipalOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['principalIdentifier']);
+        $this->assertNull($result['identityIdentifier']);
+        $this->assertNull($result['isDelegatedPrincipal']);
+        $this->assertNull($result['isEnabled']);
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalTest.php
@@ -19,6 +19,7 @@ use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInput;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalOutput;
 use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 use Source\Wiki\Principal\Domain\Entity\Role;
@@ -122,10 +123,12 @@ class CreatePrincipalTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $result = $useCase->process($input);
+        $output = new CreatePrincipalOutput();
+        $useCase->process($input, $output);
 
-        $this->assertSame((string) $principalIdentifier, (string) $result->principalIdentifier());
-        $this->assertSame((string) $identityIdentifier, (string) $result->identityIdentifier());
+        $result = $output->toArray();
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
+        $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
         $this->assertTrue($defaultPrincipalGroup->hasMember($principalIdentifier));
     }
 
@@ -206,10 +209,12 @@ class CreatePrincipalTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $result = $useCase->process($input);
+        $output = new CreatePrincipalOutput();
+        $useCase->process($input, $output);
 
-        $this->assertSame((string) $principalIdentifier, (string) $result->principalIdentifier());
-        $this->assertSame((string) $identityIdentifier, (string) $result->identityIdentifier());
+        $result = $output->toArray();
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
+        $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
         $this->assertTrue($existingDefaultPrincipalGroup->hasMember($principalIdentifier));
     }
 
@@ -269,7 +274,8 @@ class CreatePrincipalTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $useCase->process($input);
+        $output = new CreatePrincipalOutput();
+        $useCase->process($input, $output);
     }
 
     /**
@@ -362,9 +368,11 @@ class CreatePrincipalTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $result = $useCase->process($input);
+        $output = new CreatePrincipalOutput();
+        $useCase->process($input, $output);
 
-        $this->assertSame((string) $principalIdentifier, (string) $result->principalIdentifier());
+        $result = $output->toArray();
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
         $this->assertTrue($defaultPrincipalGroup->hasRole($roleIdentifier));
     }
 
@@ -458,9 +466,11 @@ class CreatePrincipalTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $result = $useCase->process($input);
+        $output = new CreatePrincipalOutput();
+        $useCase->process($input, $output);
 
-        $this->assertSame((string) $principalIdentifier, (string) $result->principalIdentifier());
+        $result = $output->toArray();
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
         $this->assertTrue($defaultPrincipalGroup->hasRole($roleIdentifier));
     }
 
@@ -554,9 +564,11 @@ class CreatePrincipalTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $result = $useCase->process($input);
+        $output = new CreatePrincipalOutput();
+        $useCase->process($input, $output);
 
-        $this->assertSame((string) $principalIdentifier, (string) $result->principalIdentifier());
+        $result = $output->toArray();
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
         $this->assertTrue($defaultPrincipalGroup->hasRole($roleIdentifier));
     }
 
@@ -648,9 +660,11 @@ class CreatePrincipalTest extends TestCase
         $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $result = $useCase->process($input);
+        $output = new CreatePrincipalOutput();
+        $useCase->process($input, $output);
 
-        $this->assertSame((string) $principalIdentifier, (string) $result->principalIdentifier());
+        $result = $output->toArray();
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
         $this->assertEmpty($defaultPrincipalGroup->roles());
     }
 

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupOutputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupOutputTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreatePrincipalGroupOutputTest extends TestCase
+{
+    /**
+     * 正常系: PrincipalGroupがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithPrincipalGroup(): void
+    {
+        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $name = 'Test Group';
+        $isDefault = false;
+        $createdAt = new DateTimeImmutable();
+
+        $principalGroup = new PrincipalGroup(
+            $principalGroupIdentifier,
+            $accountIdentifier,
+            $name,
+            $isDefault,
+            $createdAt,
+        );
+
+        $output = new CreatePrincipalGroupOutput();
+        $output->setPrincipalGroup($principalGroup);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $principalGroupIdentifier, $result['principalGroupIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result['accountIdentifier']);
+        $this->assertSame($name, $result['name']);
+        $this->assertSame($isDefault, $result['isDefault']);
+        $this->assertSame(0, $result['memberCount']);
+        $this->assertSame($createdAt->format('Y-m-d\TH:i:sP'), $result['createdAt']);
+    }
+
+    /**
+     * 正常系: PrincipalGroupが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutPrincipalGroup(): void
+    {
+        $output = new CreatePrincipalGroupOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['principalGroupIdentifier']);
+        $this->assertNull($result['accountIdentifier']);
+        $this->assertNull($result['name']);
+        $this->assertNull($result['isDefault']);
+        $this->assertNull($result['memberCount']);
+        $this->assertNull($result['createdAt']);
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipalGroup/CreatePrincipalGroupTest.php
@@ -11,6 +11,7 @@ use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroup;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupInput;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupOutput;
 use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 use Source\Wiki\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
@@ -62,13 +63,15 @@ class CreatePrincipalGroupTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $factory);
 
         $useCase = $this->app->make(CreatePrincipalGroupInterface::class);
+        $output = new CreatePrincipalGroupOutput();
 
-        $principalGroup = $useCase->process($testData->input);
+        $useCase->process($testData->input, $output);
 
-        $this->assertSame((string) $testData->principalGroupIdentifier, (string) $principalGroup->principalGroupIdentifier());
-        $this->assertSame((string) $testData->accountIdentifier, (string) $principalGroup->accountIdentifier());
-        $this->assertSame($testData->name, $principalGroup->name());
-        $this->assertFalse($principalGroup->isDefault());
+        $result = $output->toArray();
+        $this->assertSame((string) $testData->principalGroupIdentifier, $result['principalGroupIdentifier']);
+        $this->assertSame((string) $testData->accountIdentifier, $result['accountIdentifier']);
+        $this->assertSame($testData->name, $result['name']);
+        $this->assertFalse($result['isDefault']);
     }
 
     private function createDummyTestData(): CreatePrincipalGroupTestData

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleOutputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleOutputTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Command\CreateRole;
+
+use DateTimeImmutable;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleOutput;
+use Source\Wiki\Principal\Domain\Entity\Role;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreateRoleOutputTest extends TestCase
+{
+    /**
+     * 正常系: RoleがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithRole(): void
+    {
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        $name = 'Test Role';
+        $isSystemRole = false;
+        $createdAt = new DateTimeImmutable();
+
+        $role = new Role(
+            $roleIdentifier,
+            $name,
+            [new PolicyIdentifier(StrTestHelper::generateUuid())],
+            $isSystemRole,
+            $createdAt,
+        );
+
+        $output = new CreateRoleOutput();
+        $output->setRole($role);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $roleIdentifier, $result['roleIdentifier']);
+        $this->assertSame($name, $result['name']);
+        $this->assertSame($isSystemRole, $result['isSystemRole']);
+        $this->assertSame($createdAt->format('Y-m-d\TH:i:sP'), $result['createdAt']);
+    }
+
+    /**
+     * 正常系: Roleが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutRole(): void
+    {
+        $output = new CreateRoleOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['roleIdentifier']);
+        $this->assertNull($result['name']);
+        $this->assertNull($result['isSystemRole']);
+        $this->assertNull($result['createdAt']);
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreateRole/CreateRoleTest.php
@@ -10,6 +10,7 @@ use Mockery;
 use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRole;
 use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleInput;
 use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleOutput;
 use Source\Wiki\Principal\Domain\Entity\Role;
 use Source\Wiki\Principal\Domain\Factory\RoleFactoryInterface;
 use Source\Wiki\Principal\Domain\Repository\RoleRepositoryInterface;
@@ -60,13 +61,14 @@ class CreateRoleTest extends TestCase
         $this->app->instance(RoleFactoryInterface::class, $factory);
 
         $useCase = $this->app->make(CreateRoleInterface::class);
+        $output = new CreateRoleOutput();
 
-        $role = $useCase->process($testData->input);
+        $useCase->process($testData->input, $output);
 
-        $this->assertSame((string) $testData->roleIdentifier, (string) $role->roleIdentifier());
-        $this->assertSame($testData->name, $role->name());
-        $this->assertSame($testData->policies, $role->policies());
-        $this->assertSame($testData->isSystemRole, $role->isSystemRole());
+        $result = $output->toArray();
+        $this->assertSame((string) $testData->roleIdentifier, $result['roleIdentifier']);
+        $this->assertSame($testData->name, $result['name']);
+        $this->assertSame($testData->isSystemRole, $result['isSystemRole']);
     }
 
     private function createDummyTestData(): CreateRoleTestData

--- a/tests/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutputTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RemovePrincipalFromPrincipalGroupOutputTest extends TestCase
+{
+    /**
+     * 正常系: PrincipalGroupがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithPrincipalGroup(): void
+    {
+        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $name = 'Test Group';
+        $isDefault = false;
+        $createdAt = new DateTimeImmutable();
+
+        $principalGroup = new PrincipalGroup(
+            $principalGroupIdentifier,
+            $accountIdentifier,
+            $name,
+            $isDefault,
+            $createdAt,
+        );
+
+        $output = new RemovePrincipalFromPrincipalGroupOutput();
+        $output->setPrincipalGroup($principalGroup);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $principalGroupIdentifier, $result['principalGroupIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result['accountIdentifier']);
+        $this->assertSame($name, $result['name']);
+        $this->assertSame($isDefault, $result['isDefault']);
+        $this->assertSame(0, $result['memberCount']);
+        $this->assertSame($createdAt->format('Y-m-d\TH:i:sP'), $result['createdAt']);
+    }
+
+    /**
+     * 正常系: PrincipalGroupが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutPrincipalGroup(): void
+    {
+        $output = new RemovePrincipalFromPrincipalGroupOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['principalGroupIdentifier']);
+        $this->assertNull($result['accountIdentifier']);
+        $this->assertNull($result['name']);
+        $this->assertNull($result['isDefault']);
+        $this->assertNull($result['memberCount']);
+        $this->assertNull($result['createdAt']);
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
 
 use DateTimeImmutable;
-use DomainException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
@@ -13,7 +12,9 @@ use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
 use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroup;
 use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInput;
 use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupOutput;
 use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\Exception\PrincipalNotMemberException;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
@@ -67,10 +68,12 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
 
         $useCase = $this->app->make(RemovePrincipalFromPrincipalGroupInterface::class);
         $input = new RemovePrincipalFromPrincipalGroupInput($principalGroupIdentifier, $principalIdentifier);
+        $output = new RemovePrincipalFromPrincipalGroupOutput();
 
-        $result = $useCase->process($input);
+        $useCase->process($input, $output);
 
-        $this->assertFalse($result->hasMember($principalIdentifier));
+        $result = $output->toArray();
+        $this->assertSame((string) $principalGroupIdentifier, $result['principalGroupIdentifier']);
     }
 
     /**
@@ -96,7 +99,8 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
 
         $this->expectException(PrincipalGroupNotFoundException::class);
 
-        $useCase->process($input);
+        $output = new RemovePrincipalFromPrincipalGroupOutput();
+        $useCase->process($input, $output);
     }
 
     /**
@@ -129,9 +133,10 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
         $useCase = $this->app->make(RemovePrincipalFromPrincipalGroupInterface::class);
         $input = new RemovePrincipalFromPrincipalGroupInput($principalGroupIdentifier, $principalIdentifier);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(PrincipalNotMemberException::class);
         $this->expectExceptionMessage('Principal is not a member of this group.');
 
-        $useCase->process($input);
+        $output = new RemovePrincipalFromPrincipalGroupOutput();
+        $useCase->process($input, $output);
     }
 }

--- a/tests/Wiki/Principal/Domain/Entity/PrincipalGroupTest.php
+++ b/tests/Wiki/Principal/Domain/Entity/PrincipalGroupTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\Wiki\Principal\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use PHPUnit\Framework\TestCase;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyMemberException;
+use Source\Wiki\Principal\Domain\Exception\PrincipalNotMemberException;
 use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
@@ -117,7 +118,7 @@ class PrincipalGroupTest extends TestCase
 
         $principalGroup->addMember($principalIdentifier);
 
-        $this->expectException(DomainException::class);
+        $this->expectException(PrincipalAlreadyMemberException::class);
         $this->expectExceptionMessage('Principal is already a member of this group.');
 
         $principalGroup->addMember($principalIdentifier);
@@ -146,7 +147,7 @@ class PrincipalGroupTest extends TestCase
         $principalGroup = $this->createPrincipalGroup();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
-        $this->expectException(DomainException::class);
+        $this->expectException(PrincipalNotMemberException::class);
         $this->expectExceptionMessage('Principal is not a member of this group.');
 
         $principalGroup->removeMember($principalIdentifier);

--- a/tests/Wiki/Principal/Domain/Entity/PrincipalTest.php
+++ b/tests/Wiki/Principal/Domain/Entity/PrincipalTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Wiki\Principal\Domain\Entity;
 
-use DomainException;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Principal\Domain\Exception\CannotChangeNonDelegatedPrincipalException;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
@@ -131,7 +131,7 @@ class PrincipalTest extends TestCase
             [],
         );
 
-        $this->expectException(DomainException::class);
+        $this->expectException(CannotChangeNonDelegatedPrincipalException::class);
         $this->expectExceptionMessage('Cannot change enabled status of non-delegated principal.');
 
         $principal->setEnabled(false);

--- a/tests/Wiki/Principal/Http/Action/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupActionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\AddPrincipalToPrincipalGroup;
+
+use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyMemberException;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AddPrincipalToPrincipalGroupActionTest extends TestCase
+{
+    public function testInvokeReturnsOkResponse(): void
+    {
+        $principalGroupIdentifier = StrTestHelper::generateUuid();
+
+        /** @var AddPrincipalToPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AddPrincipalToPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn($principalGroupIdentifier);
+        $request->shouldReceive('principalIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var AddPrincipalToPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AddPrincipalToPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(AddPrincipalToPrincipalGroupInput::class),
+                Mockery::on(function ($output) use ($principalGroupIdentifier): bool {
+                    if (! $output instanceof AddPrincipalToPrincipalGroupOutput) {
+                        return false;
+                    }
+
+                    $output->setPrincipalGroup(new PrincipalGroup(
+                        new PrincipalGroupIdentifier($principalGroupIdentifier),
+                        new AccountIdentifier(StrTestHelper::generateUuid()),
+                        'Test Group',
+                        false,
+                        new DateTimeImmutable(),
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new AddPrincipalToPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($principalGroupIdentifier, $payload['principalGroupIdentifier']);
+    }
+
+    public function testInvokeReturnsNotFoundResponse(): void
+    {
+        /** @var AddPrincipalToPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AddPrincipalToPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('principalIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var AddPrincipalToPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AddPrincipalToPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalGroupNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new AddPrincipalToPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('principal_group_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsConflictResponseWhenAlreadyMember(): void
+    {
+        /** @var AddPrincipalToPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AddPrincipalToPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('principalIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var AddPrincipalToPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AddPrincipalToPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalAlreadyMemberException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new AddPrincipalToPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('principal_already_member', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/AttachPolicyToRole/AttachPolicyToRoleActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/AttachPolicyToRole/AttachPolicyToRoleActionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\AttachPolicyToRole;
+
+use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PolicyNotFoundException;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachPolicyToRole\AttachPolicyToRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachPolicyToRole\AttachPolicyToRoleInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AttachPolicyToRoleActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var AttachPolicyToRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AttachPolicyToRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('policyIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var AttachPolicyToRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AttachPolicyToRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(AttachPolicyToRoleInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new AttachPolicyToRoleAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsNotFoundResponseWhenRoleNotFound(): void
+    {
+        /** @var AttachPolicyToRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AttachPolicyToRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('policyIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var AttachPolicyToRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AttachPolicyToRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new RoleNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new AttachPolicyToRoleAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('role_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsNotFoundResponseWhenPolicyNotFound(): void
+    {
+        /** @var AttachPolicyToRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AttachPolicyToRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('policyIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var AttachPolicyToRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AttachPolicyToRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PolicyNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new AttachPolicyToRoleAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('policy_not_found', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/AttachRoleToPrincipalGroup/AttachRoleToPrincipalGroupActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/AttachRoleToPrincipalGroup/AttachRoleToPrincipalGroupActionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\AttachRoleToPrincipalGroup;
+
+use Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AttachRoleToPrincipalGroupActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var AttachRoleToPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AttachRoleToPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('roleIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var AttachRoleToPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AttachRoleToPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(AttachRoleToPrincipalGroupInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new AttachRoleToPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsNotFoundResponseWhenPrincipalGroupNotFound(): void
+    {
+        /** @var AttachRoleToPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AttachRoleToPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('roleIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var AttachRoleToPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AttachRoleToPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalGroupNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new AttachRoleToPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('principal_group_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsNotFoundResponseWhenRoleNotFound(): void
+    {
+        /** @var AttachRoleToPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(AttachRoleToPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('roleIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var AttachRoleToPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(AttachRoleToPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new RoleNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new AttachRoleToPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('role_not_found', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/CreatePolicy/CreatePolicyActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/CreatePolicy/CreatePolicyActionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\CreatePolicy;
+
+use Application\Http\Action\Wiki\Principal\Command\CreatePolicy\CreatePolicyAction;
+use Application\Http\Action\Wiki\Principal\Command\CreatePolicy\CreatePolicyRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePolicy\CreatePolicyOutput;
+use Source\Wiki\Principal\Domain\Entity\Policy;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreatePolicyActionTest extends TestCase
+{
+    public function testInvokeReturnsCreatedResponse(): void
+    {
+        $policyIdentifier = StrTestHelper::generateUuid();
+
+        /** @var CreatePolicyRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(CreatePolicyRequest::class);
+        $request->shouldReceive('name')->andReturn('Test Policy');
+        $request->shouldReceive('statements')->andReturn([
+            [
+                'effect' => 'allow',
+                'actions' => ['create'],
+                'resourceTypes' => ['agency'],
+            ],
+        ]);
+        $request->shouldReceive('isSystemPolicy')->andReturn(false);
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var CreatePolicyInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(CreatePolicyInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(CreatePolicyInput::class),
+                Mockery::on(function ($output) use ($policyIdentifier): bool {
+                    if (! $output instanceof CreatePolicyOutput) {
+                        return false;
+                    }
+
+                    $output->setPolicy(new Policy(
+                        new PolicyIdentifier($policyIdentifier),
+                        'Test Policy',
+                        [],
+                        false,
+                        new DateTimeImmutable(),
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new CreatePolicyAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($policyIdentifier, $payload['policyIdentifier']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/CreatePrincipal/CreatePrincipalActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/CreatePrincipal/CreatePrincipalActionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\CreatePrincipal;
+
+use Application\Http\Action\Wiki\Principal\Command\CreatePrincipal\CreatePrincipalAction;
+use Application\Http\Action\Wiki\Principal\Command\CreatePrincipal\CreatePrincipalRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalOutput;
+use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyExistsException;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreatePrincipalActionTest extends TestCase
+{
+    public function testInvokeReturnsCreatedResponse(): void
+    {
+        $identityIdentifier = StrTestHelper::generateUuid();
+        $principalIdentifier = StrTestHelper::generateUuid();
+
+        /** @var CreatePrincipalRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(CreatePrincipalRequest::class);
+        $request->shouldReceive('identityIdentifier')->andReturn($identityIdentifier);
+        $request->shouldReceive('accountIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var CreatePrincipalInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(CreatePrincipalInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(CreatePrincipalInput::class),
+                Mockery::on(function ($output) use ($principalIdentifier, $identityIdentifier): bool {
+                    if (! $output instanceof CreatePrincipalOutput) {
+                        return false;
+                    }
+
+                    $output->setPrincipal(new \Source\Wiki\Principal\Domain\Entity\Principal(
+                        new \Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier($principalIdentifier),
+                        new \Source\Shared\Domain\ValueObject\IdentityIdentifier($identityIdentifier),
+                        null,
+                        [],
+                        [],
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new CreatePrincipalAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($principalIdentifier, $payload['principalIdentifier']);
+        $this->assertSame($identityIdentifier, $payload['identityIdentifier']);
+    }
+
+    public function testInvokeReturnsConflictResponseWhenPrincipalAlreadyExists(): void
+    {
+        /** @var CreatePrincipalRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(CreatePrincipalRequest::class);
+        $request->shouldReceive('identityIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('accountIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var CreatePrincipalInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(CreatePrincipalInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalAlreadyExistsException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new CreatePrincipalAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('principal_already_exists', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/CreatePrincipalGroup/CreatePrincipalGroupActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/CreatePrincipalGroup/CreatePrincipalGroupActionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\CreatePrincipalGroup;
+
+use Application\Http\Action\Wiki\Principal\Command\CreatePrincipalGroup\CreatePrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\CreatePrincipalGroup\CreatePrincipalGroupRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipalGroup\CreatePrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreatePrincipalGroupActionTest extends TestCase
+{
+    public function testInvokeReturnsCreatedResponse(): void
+    {
+        $principalGroupIdentifier = StrTestHelper::generateUuid();
+        $accountIdentifier = StrTestHelper::generateUuid();
+
+        /** @var CreatePrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(CreatePrincipalGroupRequest::class);
+        $request->shouldReceive('accountIdentifier')->andReturn($accountIdentifier);
+        $request->shouldReceive('name')->andReturn('Test Group');
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var CreatePrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(CreatePrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(CreatePrincipalGroupInput::class),
+                Mockery::on(function ($output) use ($principalGroupIdentifier, $accountIdentifier): bool {
+                    if (! $output instanceof CreatePrincipalGroupOutput) {
+                        return false;
+                    }
+
+                    $output->setPrincipalGroup(new PrincipalGroup(
+                        new PrincipalGroupIdentifier($principalGroupIdentifier),
+                        new AccountIdentifier($accountIdentifier),
+                        'Test Group',
+                        false,
+                        new DateTimeImmutable(),
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new CreatePrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($principalGroupIdentifier, $payload['principalGroupIdentifier']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/CreateRole/CreateRoleActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/CreateRole/CreateRoleActionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\CreateRole;
+
+use Application\Http\Action\Wiki\Principal\Command\CreateRole\CreateRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\CreateRole\CreateRoleRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\CreateRole\CreateRoleOutput;
+use Source\Wiki\Principal\Domain\Entity\Role;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class CreateRoleActionTest extends TestCase
+{
+    public function testInvokeReturnsCreatedResponse(): void
+    {
+        $roleIdentifier = StrTestHelper::generateUuid();
+
+        /** @var CreateRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(CreateRoleRequest::class);
+        $request->shouldReceive('name')->andReturn('Test Role');
+        $request->shouldReceive('policies')->andReturn(null);
+        $request->shouldReceive('isSystemRole')->andReturn(false);
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var CreateRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(CreateRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(CreateRoleInput::class),
+                Mockery::on(function ($output) use ($roleIdentifier): bool {
+                    if (! $output instanceof CreateRoleOutput) {
+                        return false;
+                    }
+
+                    $output->setRole(new Role(
+                        new RoleIdentifier($roleIdentifier),
+                        'Test Role',
+                        [],
+                        false,
+                        new DateTimeImmutable(),
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new CreateRoleAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($roleIdentifier, $payload['roleIdentifier']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/DeletePolicy/DeletePolicyActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/DeletePolicy/DeletePolicyActionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\DeletePolicy;
+
+use Application\Http\Action\Wiki\Principal\Command\DeletePolicy\DeletePolicyAction;
+use Application\Http\Action\Wiki\Principal\Command\DeletePolicy\DeletePolicyRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\CannotDeleteSystemPolicyException;
+use Source\Wiki\Principal\Application\Exception\PolicyNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePolicy\DeletePolicyInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePolicy\DeletePolicyInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class DeletePolicyActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var DeletePolicyRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeletePolicyRequest::class);
+        $request->shouldReceive('policyId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var DeletePolicyInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeletePolicyInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(DeletePolicyInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new DeletePolicyAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsNotFoundResponse(): void
+    {
+        /** @var DeletePolicyRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeletePolicyRequest::class);
+        $request->shouldReceive('policyId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DeletePolicyInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeletePolicyInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PolicyNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DeletePolicyAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('policy_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsConflictResponseWhenSystemPolicy(): void
+    {
+        /** @var DeletePolicyRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeletePolicyRequest::class);
+        $request->shouldReceive('policyId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DeletePolicyInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeletePolicyInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new CannotDeleteSystemPolicyException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DeletePolicyAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('cannot_delete_system_policy', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/DeletePrincipalGroup/DeletePrincipalGroupActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/DeletePrincipalGroup/DeletePrincipalGroupActionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\DeletePrincipalGroup;
+
+use Application\Http\Action\Wiki\Principal\Command\DeletePrincipalGroup\DeletePrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\DeletePrincipalGroup\DeletePrincipalGroupRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\CannotDeleteDefaultPrincipalGroupException;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePrincipalGroup\DeletePrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DeletePrincipalGroup\DeletePrincipalGroupInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class DeletePrincipalGroupActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var DeletePrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeletePrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var DeletePrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeletePrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(DeletePrincipalGroupInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new DeletePrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsNotFoundResponse(): void
+    {
+        /** @var DeletePrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeletePrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DeletePrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeletePrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalGroupNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DeletePrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('principal_group_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsConflictResponseWhenDefaultGroup(): void
+    {
+        /** @var DeletePrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeletePrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DeletePrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeletePrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new CannotDeleteDefaultPrincipalGroupException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DeletePrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('cannot_delete_default_principal_group', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/DeleteRole/DeleteRoleActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/DeleteRole/DeleteRoleActionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\DeleteRole;
+
+use Application\Http\Action\Wiki\Principal\Command\DeleteRole\DeleteRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\DeleteRole\DeleteRoleRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\CannotDeleteSystemRoleException;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DeleteRole\DeleteRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DeleteRole\DeleteRoleInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class DeleteRoleActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var DeleteRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeleteRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var DeleteRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeleteRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(DeleteRoleInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new DeleteRoleAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsNotFoundResponse(): void
+    {
+        /** @var DeleteRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeleteRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DeleteRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeleteRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new RoleNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DeleteRoleAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('role_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsConflictResponseWhenSystemRole(): void
+    {
+        /** @var DeleteRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DeleteRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DeleteRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DeleteRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new CannotDeleteSystemRoleException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DeleteRoleAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('cannot_delete_system_role', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/DetachPolicyFromRole/DetachPolicyFromRoleActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/DetachPolicyFromRole/DetachPolicyFromRoleActionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\DetachPolicyFromRole;
+
+use Application\Http\Action\Wiki\Principal\Command\DetachPolicyFromRole\DetachPolicyFromRoleAction;
+use Application\Http\Action\Wiki\Principal\Command\DetachPolicyFromRole\DetachPolicyFromRoleRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\RoleNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachPolicyFromRole\DetachPolicyFromRoleInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachPolicyFromRole\DetachPolicyFromRoleInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class DetachPolicyFromRoleActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var DetachPolicyFromRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DetachPolicyFromRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('policyIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var DetachPolicyFromRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DetachPolicyFromRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(DetachPolicyFromRoleInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new DetachPolicyFromRoleAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsNotFoundResponseWhenRoleNotFound(): void
+    {
+        /** @var DetachPolicyFromRoleRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DetachPolicyFromRoleRequest::class);
+        $request->shouldReceive('roleId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('policyIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DetachPolicyFromRoleInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DetachPolicyFromRoleInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new RoleNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DetachPolicyFromRoleAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('role_not_found', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/DetachRoleFromPrincipalGroup/DetachRoleFromPrincipalGroupActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/DetachRoleFromPrincipalGroup/DetachRoleFromPrincipalGroupActionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\DetachRoleFromPrincipalGroup;
+
+use Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class DetachRoleFromPrincipalGroupActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var DetachRoleFromPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DetachRoleFromPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('roleIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var DetachRoleFromPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DetachRoleFromPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(DetachRoleFromPrincipalGroupInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new DetachRoleFromPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsNotFoundResponseWhenPrincipalGroupNotFound(): void
+    {
+        /** @var DetachRoleFromPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(DetachRoleFromPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('roleIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var DetachRoleFromPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(DetachRoleFromPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalGroupNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new DetachRoleFromPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('principal_group_not_found', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/Principal/Http/Action/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupActionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Http\Action\Command\RemovePrincipalFromPrincipalGroup;
+
+use Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInput;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupOutput;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\Exception\PrincipalNotMemberException;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RemovePrincipalFromPrincipalGroupActionTest extends TestCase
+{
+    public function testInvokeReturnsOkResponse(): void
+    {
+        $principalGroupIdentifier = StrTestHelper::generateUuid();
+
+        /** @var RemovePrincipalFromPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RemovePrincipalFromPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn($principalGroupIdentifier);
+        $request->shouldReceive('principalIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var RemovePrincipalFromPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RemovePrincipalFromPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(RemovePrincipalFromPrincipalGroupInput::class),
+                Mockery::on(function ($output) use ($principalGroupIdentifier): bool {
+                    if (! $output instanceof RemovePrincipalFromPrincipalGroupOutput) {
+                        return false;
+                    }
+
+                    $output->setPrincipalGroup(new PrincipalGroup(
+                        new PrincipalGroupIdentifier($principalGroupIdentifier),
+                        new AccountIdentifier(StrTestHelper::generateUuid()),
+                        'Test Group',
+                        false,
+                        new DateTimeImmutable(),
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new RemovePrincipalFromPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($principalGroupIdentifier, $payload['principalGroupIdentifier']);
+    }
+
+    public function testInvokeReturnsNotFoundResponse(): void
+    {
+        /** @var RemovePrincipalFromPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RemovePrincipalFromPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('principalIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var RemovePrincipalFromPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RemovePrincipalFromPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalGroupNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new RemovePrincipalFromPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('principal_group_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsConflictResponseWhenNotMember(): void
+    {
+        /** @var RemovePrincipalFromPrincipalGroupRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RemovePrincipalFromPrincipalGroupRequest::class);
+        $request->shouldReceive('principalGroupId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('principalIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var RemovePrincipalFromPrincipalGroupInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RemovePrincipalFromPrincipalGroupInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new PrincipalNotMemberException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new RemovePrincipalFromPrincipalGroupAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('principal_not_member', 'en'), $payload['detail']);
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

- PrincipalサブドメインのUseCase（CreatePrincipal, CreatePrincipalGroup, CreatePolicy, CreateRole, AddPrincipalToPrincipalGroup, RemovePrincipalFromPrincipalGroup）にOutputPort/Outputパターンを導入
- ドメイン独自例外（CannotChangeNonDelegatedPrincipalException, PrincipalAlreadyMemberException, PrincipalNotMemberException）を作成し、エンティティで使用
- 全Command操作用のAction/Requestクラス（エンドポイント）を作成（Create/Delete/Attach/Detach系）
- 6言語（en, ja, ko, zh_CN, zh_TW, es）のエラーメッセージを追加
- 全てのOutput・Actionに対するユニットテストを作成

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

PrincipalサブドメインのUseCase層にOutputパターンを導入し、プレゼンテーション層との依存を適切に分離する。また、汎用例外からドメイン固有の例外に移行することで、エラーハンドリングの精度を向上させる。エンドポイントを追加し、API経由での操作を可能にする。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- OutputPort/Outputパターンの設計が他サブドメイン（Invitationなど）と一貫しているか
- ドメイン独自例外のメッセージキーと多言語対応の整合性
- Action（Controller）のバリデーションとエラーハンドリング
- ルーティング定義（wiki_private_api.php）の構成

## 📖 関連情報

### 関連Issue・タスク

Closes #271

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した