### PR TITLE
add: ImageサブドメインにOutputパターン導入・エンドポイント作成

### DIFF
--- a/application/Http/Action/Wiki/Image/Command/ApproveImage/ApproveImageAction.php
+++ b/application/Http/Action/Wiki/Image/Command/ApproveImage/ApproveImageAction.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\ApproveImage;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
+use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImageInput;
+use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImageOutput;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ApproveImageAction
+{
+    public function __construct(
+        private ApproveImageInterface $approveImage,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param ApproveImageRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ApproveImageRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ApproveImageInput(
+                    new ImageIdentifier($request->imageId()),
+                    new PrincipalIdentifier($request->principalId()),
+                );
+                $output = new ApproveImageOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->approveImage->process($input, $output);
+                DB::commit();
+            } catch (ImageNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (InvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('allow_only_under_review_image_status', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/ApproveImage/ApproveImageRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/ApproveImage/ApproveImageRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\ApproveImage;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveImageRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+        ];
+    }
+
+    public function imageId(): string
+    {
+        return (string) $this->route('imageId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/DeleteImage/DeleteImageAction.php
+++ b/application/Http/Action/Wiki/Image/Command/DeleteImage/DeleteImageAction.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\DeleteImage;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
+use Source\Wiki\Image\Application\UseCase\Command\DeleteImage\DeleteImageInput;
+use Source\Wiki\Image\Application\UseCase\Command\DeleteImage\DeleteImageInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class DeleteImageAction
+{
+    public function __construct(
+        private DeleteImageInterface $deleteImage,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(DeleteImageRequest $request): Response
+    {
+        try {
+            try {
+                $input = new DeleteImageInput(
+                    new ImageIdentifier($request->imageId()),
+                    new PrincipalIdentifier($request->principalId()),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->deleteImage->process($input);
+                DB::commit();
+            } catch (ImageNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/DeleteImage/DeleteImageRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/DeleteImage/DeleteImageRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\DeleteImage;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteImageRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+        ];
+    }
+
+    public function imageId(): string
+    {
+        return (string) $this->route('imageId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/RejectImage/RejectImageAction.php
+++ b/application/Http/Action/Wiki/Image/Command/RejectImage/RejectImageAction.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\RejectImage;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
+use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImageInput;
+use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImageOutput;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RejectImageAction
+{
+    public function __construct(
+        private RejectImageInterface $rejectImage,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RejectImageRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RejectImageRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RejectImageInput(
+                    new ImageIdentifier($request->imageId()),
+                    new PrincipalIdentifier($request->principalId()),
+                );
+                $output = new RejectImageOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->rejectImage->process($input, $output);
+                DB::commit();
+            } catch (ImageNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (InvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('allow_only_under_review_image_status', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/RejectImage/RejectImageRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/RejectImage/RejectImageRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\RejectImage;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectImageRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+        ];
+    }
+
+    public function imageId(): string
+    {
+        return (string) $this->route('imageId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/UnhideImage/UnhideImageAction.php
+++ b/application/Http/Action/Wiki/Image/Command/UnhideImage/UnhideImageAction.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\UnhideImage;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
+use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageInput;
+use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageOutput;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class UnhideImageAction
+{
+    public function __construct(
+        private UnhideImageInterface $unhideImage,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param UnhideImageRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(UnhideImageRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new UnhideImageInput(
+                    new ImageIdentifier($request->imageId()),
+                    new PrincipalIdentifier($request->principalId()),
+                );
+                $output = new UnhideImageOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->unhideImage->process($input, $output);
+                DB::commit();
+            } catch (ImageNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/UnhideImage/UnhideImageRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/UnhideImage/UnhideImageRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\UnhideImage;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UnhideImageRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+        ];
+    }
+
+    public function imageId(): string
+    {
+        return (string) $this->route('imageId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/UploadImage/UploadImageAction.php
+++ b/application/Http/Action/Wiki/Image/Command/UploadImage/UploadImageAction.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\UploadImage;
+
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use DateTimeImmutable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Application\Exception\InvalidBase64ImageException;
+use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageInput;
+use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageOutput;
+use Source\Wiki\Image\Domain\ValueObject\ImageUsage;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class UploadImageAction
+{
+    public function __construct(
+        private UploadImageInterface $uploadImage,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param UploadImageRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(UploadImageRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new UploadImageInput(
+                    new PrincipalIdentifier($request->principalId()),
+                    $request->publishedImageIdentifier() !== null ? new ImageIdentifier($request->publishedImageIdentifier()) : null,
+                    ResourceType::from($request->resourceType()),
+                    new WikiIdentifier($request->wikiIdentifier()),
+                    $request->base64EncodedImage(),
+                    ImageUsage::from($request->imageUsage()),
+                    (int) $request->displayOrder(),
+                    $request->sourceUrl(),
+                    $request->sourceName(),
+                    $request->altText(),
+                    new DateTimeImmutable($request->agreedToTermsAt()),
+                );
+                $output = new UploadImageOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->uploadImage->process($input, $output);
+                DB::commit();
+            } catch (InvalidBase64ImageException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_base64_image', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/UploadImage/UploadImageRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/UploadImage/UploadImageRequest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Command\UploadImage;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadImageRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+            'publishedImageIdentifier' => ['nullable', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'wikiIdentifier' => ['required', 'uuid'],
+            'base64EncodedImage' => ['required', 'string'],
+            'imageUsage' => ['required', 'string'],
+            'displayOrder' => ['required', 'integer'],
+            'sourceUrl' => ['required', 'string'],
+            'sourceName' => ['required', 'string'],
+            'altText' => ['required', 'string'],
+            'agreedToTermsAt' => ['required', 'date'],
+        ];
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function publishedImageIdentifier(): ?string
+    {
+        $value = $this->input('publishedImageIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return (string) $this->input('wikiIdentifier');
+    }
+
+    public function base64EncodedImage(): string
+    {
+        return (string) $this->input('base64EncodedImage');
+    }
+
+    public function imageUsage(): string
+    {
+        return (string) $this->input('imageUsage');
+    }
+
+    public function displayOrder(): string
+    {
+        return (string) $this->input('displayOrder');
+    }
+
+    public function sourceUrl(): string
+    {
+        return (string) $this->input('sourceUrl');
+    }
+
+    public function sourceName(): string
+    {
+        return (string) $this->input('sourceName');
+    }
+
+    public function altText(): string
+    {
+        return (string) $this->input('altText');
+    }
+
+    public function agreedToTermsAt(): string
+    {
+        return (string) $this->input('agreedToTermsAt');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -87,6 +87,10 @@ return [
     'invalid_rollback_target_version' => 'Target version must be less than current version.',
     'invalid_status' => 'The status is invalid for this operation.',
 
+    // Wiki Image
+    'image_not_found' => 'The specified image was not found.',
+    'allow_only_under_review_image_status' => 'Only images with submitted status can be approved or rejected.',
+
     // Wiki Principal
     'principal_group_not_found' => 'The specified principal group was not found.',
     'policy_not_found' => 'The specified policy was not found.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -87,6 +87,10 @@ return [
     'invalid_rollback_target_version' => 'La versión de destino debe ser menor que la versión actual.',
     'invalid_status' => 'El estado no es válido para esta operación.',
 
+    // Wiki Image
+    'image_not_found' => 'No se encontró la imagen especificada.',
+    'allow_only_under_review_image_status' => 'Solo se pueden aprobar o rechazar imágenes con estado enviado.',
+
     // Wiki Principal
     'principal_group_not_found' => 'No se encontró el grupo de principal especificado.',
     'policy_not_found' => 'No se encontró la política especificada.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -87,6 +87,10 @@ return [
     'invalid_rollback_target_version' => 'ロールバック先のバージョンが無効です。',
     'invalid_status' => 'ステータスが無効です。',
 
+    // Wiki Image
+    'image_not_found' => '指定された画像が見つかりません。',
+    'allow_only_under_review_image_status' => '提出済みステータス以外の画像の承認・却下はできません。',
+
     // Wiki Principal
     'principal_group_not_found' => '指定されたプリンシパルグループが見つかりません。',
     'policy_not_found' => '指定されたポリシーが見つかりません。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -87,6 +87,10 @@ return [
     'invalid_rollback_target_version' => '롤백 대상 버전이 유효하지 않습니다.',
     'invalid_status' => '이 작업에 대해 상태가 유효하지 않습니다.',
 
+    // Wiki Image
+    'image_not_found' => '지정된 이미지를 찾을 수 없습니다.',
+    'allow_only_under_review_image_status' => '제출된 상태의 이미지만 승인 또는 거부할 수 있습니다.',
+
     // Wiki Principal
     'principal_group_not_found' => '지정된 프린시펄 그룹을 찾을 수 없습니다.',
     'policy_not_found' => '지정된 정책을 찾을 수 없습니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -87,6 +87,10 @@ return [
     'invalid_rollback_target_version' => '目标版本必须小于当前版本。',
     'invalid_status' => '此操作的状态无效。',
 
+    // Wiki Image
+    'image_not_found' => '未找到指定的图片。',
+    'allow_only_under_review_image_status' => '只有已提交状态的图片才能被批准或拒绝。',
+
     // Wiki Principal
     'principal_group_not_found' => '未找到指定的主体组。',
     'policy_not_found' => '未找到指定的策略。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -87,6 +87,10 @@ return [
     'invalid_rollback_target_version' => '目標版本必須小於當前版本。',
     'invalid_status' => '此操作的狀態無效。',
 
+    // Wiki Image
+    'image_not_found' => '找不到指定的圖片。',
+    'allow_only_under_review_image_status' => '只有已提交狀態的圖片才能被批准或拒絕。',
+
     // Wiki Principal
     'principal_group_not_found' => '找不到指定的主體群組。',
     'policy_not_found' => '找不到指定的政策。',

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Application\Http\Action\Wiki\Image\Command\ApproveImage\ApproveImageAction;
+use Application\Http\Action\Wiki\Image\Command\DeleteImage\DeleteImageAction;
+use Application\Http\Action\Wiki\Image\Command\RejectImage\RejectImageAction;
+use Application\Http\Action\Wiki\Image\Command\UnhideImage\UnhideImageAction;
+use Application\Http\Action\Wiki\Image\Command\UploadImage\UploadImageAction;
 use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupAction;
@@ -37,6 +42,13 @@ Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
 Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
 Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
 Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+
+// Image
+Route::post('/image/{imageId}/approve', ApproveImageAction::class);
+Route::delete('/image/{imageId}', DeleteImageAction::class);
+Route::post('/image/{imageId}/reject', RejectImageAction::class);
+Route::post('/image/{imageId}/unhide', UnhideImageAction::class);
+Route::post('/image/upload', UploadImageAction::class);
 
 // Principal
 Route::post('/principal/create', CreatePrincipalAction::class);

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImage.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImage.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Image\Application\UseCase\Command\ApproveImage;
 
 use DateTimeImmutable;
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\Image\Domain\Entity\Image;
 use Source\Wiki\Image\Domain\Factory\ImageFactoryInterface;
 use Source\Wiki\Image\Domain\Factory\ImageSnapshotFactoryInterface;
 use Source\Wiki\Image\Domain\Repository\DraftImageRepositoryInterface;
@@ -37,13 +36,14 @@ readonly class ApproveImage implements ApproveImageInterface
 
     /**
      * @param ApproveImageInputPort $input
-     * @return Image
+     * @param ApproveImageOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws InvalidStatusException
      * @throws PrincipalNotFoundException
      */
-    public function process(ApproveImageInputPort $input): Image
+    public function process(ApproveImageInputPort $input, ApproveImageOutputPort $output): void
     {
         $draftImage = $this->draftImageRepository->findById($input->imageIdentifier());
         if ($draftImage === null) {
@@ -94,7 +94,9 @@ readonly class ApproveImage implements ApproveImageInterface
                 $this->imageRepository->save($existingImage);
                 $this->draftImageRepository->delete($draftImage->imageIdentifier());
 
-                return $existingImage;
+                $output->setImage($existingImage);
+
+                return;
             }
         }
 
@@ -116,6 +118,6 @@ readonly class ApproveImage implements ApproveImageInterface
         $this->imageRepository->save($image);
         $this->draftImageRepository->delete($draftImage->imageIdentifier());
 
-        return $image;
+        $output->setImage($image);
     }
 }

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageInterface.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Application\UseCase\Command\ApproveImage;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\Image\Domain\Entity\Image;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
@@ -14,11 +13,12 @@ interface ApproveImageInterface
 {
     /**
      * @param ApproveImageInputPort $input
-     * @return Image
+     * @param ApproveImageOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws InvalidStatusException
      * @throws PrincipalNotFoundException
      */
-    public function process(ApproveImageInputPort $input): Image;
+    public function process(ApproveImageInputPort $input, ApproveImageOutputPort $output): void;
 }

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\ApproveImage;
+
+use Source\Wiki\Image\Domain\Entity\Image;
+
+class ApproveImageOutput implements ApproveImageOutputPort
+{
+    private ?Image $image = null;
+
+    public function setImage(Image $image): void
+    {
+        $this->image = $image;
+    }
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, isHidden: ?bool}
+     */
+    public function toArray(): array
+    {
+        if ($this->image === null) {
+            return [
+                'imageIdentifier' => null,
+                'resourceType' => null,
+                'imageUsage' => null,
+                'isHidden' => null,
+            ];
+        }
+
+        return [
+            'imageIdentifier' => (string) $this->image->imageIdentifier(),
+            'resourceType' => $this->image->resourceType()->value,
+            'imageUsage' => $this->image->imageUsage()->value,
+            'isHidden' => $this->image->isHidden(),
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\ApproveImage;
+
+use Source\Wiki\Image\Domain\Entity\Image;
+
+interface ApproveImageOutputPort
+{
+    public function setImage(Image $image): void;
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, isHidden: ?bool}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImage.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImage.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Application\UseCase\Command\RejectImage;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\Image\Domain\Entity\DraftImage;
 use Source\Wiki\Image\Domain\Repository\DraftImageRepositoryInterface;
 use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
@@ -28,13 +27,14 @@ readonly class RejectImage implements RejectImageInterface
 
     /**
      * @param RejectImageInputPort $input
-     * @return DraftImage
+     * @param RejectImageOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws InvalidStatusException
      * @throws PrincipalNotFoundException
      */
-    public function process(RejectImageInputPort $input): DraftImage
+    public function process(RejectImageInputPort $input, RejectImageOutputPort $output): void
     {
         $principal = $this->principalRepository->findById($input->principalIdentifier());
         if ($principal === null) {
@@ -58,6 +58,6 @@ readonly class RejectImage implements RejectImageInterface
         $draftImage->setStatus(ApprovalStatus::Rejected);
         $this->draftImageRepository->save($draftImage);
 
-        return $draftImage;
+        $output->setDraftImage($draftImage);
     }
 }

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageInterface.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Application\UseCase\Command\RejectImage;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\Image\Domain\Entity\DraftImage;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
@@ -14,11 +13,12 @@ interface RejectImageInterface
 {
     /**
      * @param RejectImageInputPort $input
-     * @return DraftImage
+     * @param RejectImageOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws InvalidStatusException
      * @throws PrincipalNotFoundException
      */
-    public function process(RejectImageInputPort $input): DraftImage;
+    public function process(RejectImageInputPort $input, RejectImageOutputPort $output): void;
 }

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\RejectImage;
+
+use Source\Wiki\Image\Domain\Entity\DraftImage;
+
+class RejectImageOutput implements RejectImageOutputPort
+{
+    private ?DraftImage $draftImage = null;
+
+    public function setDraftImage(DraftImage $draftImage): void
+    {
+        $this->draftImage = $draftImage;
+    }
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftImage === null) {
+            return [
+                'imageIdentifier' => null,
+                'resourceType' => null,
+                'imageUsage' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'imageIdentifier' => (string) $this->draftImage->imageIdentifier(),
+            'resourceType' => $this->draftImage->resourceType()->value,
+            'imageUsage' => $this->draftImage->imageUsage()->value,
+            'status' => $this->draftImage->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\RejectImage;
+
+use Source\Wiki\Image\Domain\Entity\DraftImage;
+
+interface RejectImageOutputPort
+{
+    public function setDraftImage(DraftImage $draftImage): void;
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImage.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImage.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Application\UseCase\Command\UnhideImage;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\Image\Domain\Entity\Image;
 use Source\Wiki\Image\Domain\Repository\ImageRepositoryInterface;
 use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
@@ -26,12 +25,13 @@ readonly class UnhideImage implements UnhideImageInterface
 
     /**
      * @param UnhideImageInputPort $input
-     * @return Image
+     * @param UnhideImageOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws PrincipalNotFoundException
      */
-    public function process(UnhideImageInputPort $input): Image
+    public function process(UnhideImageInputPort $input, UnhideImageOutputPort $output): void
     {
         $image = $this->imageRepository->findById($input->imageIdentifier());
         if ($image === null) {
@@ -51,6 +51,6 @@ readonly class UnhideImage implements UnhideImageInterface
         $image->unhide();
         $this->imageRepository->save($image);
 
-        return $image;
+        $output->setImage($image);
     }
 }

--- a/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageInterface.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Application\UseCase\Command\UnhideImage;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\Image\Domain\Entity\Image;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 
@@ -13,10 +12,11 @@ interface UnhideImageInterface
 {
     /**
      * @param UnhideImageInputPort $input
-     * @return Image
+     * @param UnhideImageOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws PrincipalNotFoundException
      */
-    public function process(UnhideImageInputPort $input): Image;
+    public function process(UnhideImageInputPort $input, UnhideImageOutputPort $output): void;
 }

--- a/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\UnhideImage;
+
+use Source\Wiki\Image\Domain\Entity\Image;
+
+class UnhideImageOutput implements UnhideImageOutputPort
+{
+    private ?Image $image = null;
+
+    public function setImage(Image $image): void
+    {
+        $this->image = $image;
+    }
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, isHidden: ?bool}
+     */
+    public function toArray(): array
+    {
+        if ($this->image === null) {
+            return [
+                'imageIdentifier' => null,
+                'resourceType' => null,
+                'imageUsage' => null,
+                'isHidden' => null,
+            ];
+        }
+
+        return [
+            'imageIdentifier' => (string) $this->image->imageIdentifier(),
+            'resourceType' => $this->image->resourceType()->value,
+            'imageUsage' => $this->image->imageUsage()->value,
+            'isHidden' => $this->image->isHidden(),
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\UnhideImage;
+
+use Source\Wiki\Image\Domain\Entity\Image;
+
+interface UnhideImageOutputPort
+{
+    public function setImage(Image $image): void;
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, isHidden: ?bool}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImage.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImage.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Image\Application\UseCase\Command\UploadImage;
 
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
 use Source\Shared\Application\Service\ImageServiceInterface;
-use Source\Wiki\Image\Domain\Entity\DraftImage;
 use Source\Wiki\Image\Domain\Factory\DraftImageFactoryInterface;
 use Source\Wiki\Image\Domain\Repository\DraftImageRepositoryInterface;
 use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
@@ -30,12 +29,13 @@ readonly class UploadImage implements UploadImageInterface
 
     /**
      * @param UploadImageInputPort $input
-     * @return DraftImage
+     * @param UploadImageOutputPort $output
+     * @return void
      * @throws InvalidBase64ImageException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(UploadImageInputPort $input): DraftImage
+    public function process(UploadImageInputPort $input, UploadImageOutputPort $output): void
     {
         $principal = $this->principalRepository->findById($input->principalIdentifier());
 
@@ -71,6 +71,6 @@ readonly class UploadImage implements UploadImageInterface
 
         $this->draftImageRepository->save($draftImage);
 
-        return $draftImage;
+        $output->setDraftImage($draftImage);
     }
 }

--- a/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageInterface.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Application\UseCase\Command\UploadImage;
 
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
-use Source\Wiki\Image\Domain\Entity\DraftImage;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 
@@ -13,10 +12,11 @@ interface UploadImageInterface
 {
     /**
      * @param UploadImageInputPort $input
-     * @return DraftImage
+     * @param UploadImageOutputPort $output
+     * @return void
      * @throws InvalidBase64ImageException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */
-    public function process(UploadImageInputPort $input): DraftImage;
+    public function process(UploadImageInputPort $input, UploadImageOutputPort $output): void;
 }

--- a/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\UploadImage;
+
+use Source\Wiki\Image\Domain\Entity\DraftImage;
+
+class UploadImageOutput implements UploadImageOutputPort
+{
+    private ?DraftImage $draftImage = null;
+
+    public function setDraftImage(DraftImage $draftImage): void
+    {
+        $this->draftImage = $draftImage;
+    }
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftImage === null) {
+            return [
+                'imageIdentifier' => null,
+                'resourceType' => null,
+                'imageUsage' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'imageIdentifier' => (string) $this->draftImage->imageIdentifier(),
+            'resourceType' => $this->draftImage->resourceType()->value,
+            'imageUsage' => $this->draftImage->imageUsage()->value,
+            'status' => $this->draftImage->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Command\UploadImage;
+
+use Source\Wiki\Image\Domain\Entity\DraftImage;
+
+interface UploadImageOutputPort
+{
+    public function setDraftImage(DraftImage $draftImage): void;
+
+    /**
+     * @return array{imageIdentifier: ?string, resourceType: ?string, imageUsage: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/tests/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageOutputTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Command\ApproveImage;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\ImagePath;
+use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImageOutput;
+use Source\Wiki\Image\Domain\Entity\Image;
+use Source\Wiki\Image\Domain\ValueObject\ImageUsage;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ApproveImageOutputTest extends TestCase
+{
+    /**
+     * 正常系: Imageがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithImage(): void
+    {
+        $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
+        $image = new Image(
+            $imageIdentifier,
+            ResourceType::TALENT,
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new ImagePath('images/test.png'),
+            ImageUsage::PROFILE,
+            1,
+            'https://example.com/source',
+            'Example Source',
+            'Alt text',
+            false,
+            null,
+            null,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new DateTimeImmutable(),
+            null,
+            null,
+            null,
+            null,
+        );
+
+        $output = new ApproveImageOutput();
+        $output->setImage($image);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
+        $this->assertSame('talent', $result['resourceType']);
+        $this->assertSame('profile', $result['imageUsage']);
+        $this->assertFalse($result['isHidden']);
+    }
+
+    /**
+     * 正常系: Imageがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutImage(): void
+    {
+        $output = new ApproveImageOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'imageIdentifier' => null,
+            'resourceType' => null,
+            'imageUsage' => null,
+            'isHidden' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageTest.php
@@ -7,13 +7,13 @@ namespace Tests\Wiki\Image\Application\UseCase\Command\ApproveImage;
 use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
-use Source\Shared\Application\Service\Uuid\UuidValidator;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\ImagePath;
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
 use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImage;
 use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImageInput;
 use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\ApproveImage\ApproveImageOutput;
 use Source\Wiki\Image\Domain\Entity\DraftImage;
 use Source\Wiki\Image\Domain\Entity\Image;
 use Source\Wiki\Image\Domain\Entity\ImageSnapshot;
@@ -151,17 +151,14 @@ class ApproveImageTest extends TestCase
         $this->app->instance(ImageAuthorizationResourceBuilderInterface::class, $imageAuthorizationResourceBuilder);
 
         $approveImage = $this->app->make(ApproveImageInterface::class);
-        $result = $approveImage->process($input);
+        $output = new ApproveImageOutput();
+        $approveImage->process($input, $output);
 
-        $this->assertTrue(UuidValidator::isValid((string)$result->imageIdentifier()));
-        $this->assertSame($testData->resourceType, $result->resourceType());
-        $this->assertSame((string)$testData->wikiIdentifier, (string)$result->wikiIdentifier());
-        $this->assertSame((string)$testData->imagePath, (string)$result->imagePath());
-        $this->assertSame($testData->imageUsage, $result->imageUsage());
-        $this->assertSame($testData->displayOrder, $result->displayOrder());
-        $this->assertSame($testData->sourceUrl, $result->sourceUrl());
-        $this->assertSame($testData->sourceName, $result->sourceName());
-        $this->assertSame($testData->altText, $result->altText());
+        $result = $output->toArray();
+        $this->assertNotNull($result['imageIdentifier']);
+        $this->assertSame($testData->resourceType->value, $result['resourceType']);
+        $this->assertSame($testData->imageUsage->value, $result['imageUsage']);
+        $this->assertFalse($result['isHidden']);
     }
 
     /**
@@ -202,7 +199,8 @@ class ApproveImageTest extends TestCase
 
         $this->expectException(ImageNotFoundException::class);
         $approveImage = $this->app->make(ApproveImageInterface::class);
-        $approveImage->process($input);
+        $output = new ApproveImageOutput();
+        $approveImage->process($input, $output);
     }
 
     /**
@@ -259,7 +257,8 @@ class ApproveImageTest extends TestCase
 
         $this->expectException(InvalidStatusException::class);
         $approveImage = $this->app->make(ApproveImageInterface::class);
-        $approveImage->process($input);
+        $output = new ApproveImageOutput();
+        $approveImage->process($input, $output);
     }
 
     /**
@@ -358,16 +357,15 @@ class ApproveImageTest extends TestCase
         $this->app->instance(ImageAuthorizationResourceBuilderInterface::class, $imageAuthorizationResourceBuilder);
 
         $approveImage = $this->app->make(ApproveImageInterface::class);
-        $result = $approveImage->process($input);
+        $output = new ApproveImageOutput();
+        $approveImage->process($input, $output);
 
         // 更新後の値が反映されていることを確認
-        $this->assertSame((string)$testData->publishedImageIdentifier, (string)$result->imageIdentifier());
-        $this->assertSame((string)$testData->newImagePath, (string)$result->imagePath());
-        $this->assertSame($testData->newImageUsage, $result->imageUsage());
-        $this->assertSame($testData->newDisplayOrder, $result->displayOrder());
-        $this->assertSame($testData->newSourceUrl, $result->sourceUrl());
-        $this->assertSame($testData->newSourceName, $result->sourceName());
-        $this->assertSame($testData->newAltText, $result->altText());
+        $result = $output->toArray();
+        $this->assertSame((string) $testData->publishedImageIdentifier, $result['imageIdentifier']);
+        $this->assertSame($testData->existingImage->resourceType()->value, $result['resourceType']);
+        $this->assertSame($testData->newImageUsage->value, $result['imageUsage']);
+        $this->assertFalse($result['isHidden']);
     }
 
     /**
@@ -425,7 +423,8 @@ class ApproveImageTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $approveImage = $this->app->make(ApproveImageInterface::class);
-        $approveImage->process($input);
+        $output = new ApproveImageOutput();
+        $approveImage->process($input, $output);
     }
 
     /**
@@ -473,7 +472,8 @@ class ApproveImageTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $approveImage = $this->app->make(ApproveImageInterface::class);
-        $approveImage->process($input);
+        $output = new ApproveImageOutput();
+        $approveImage->process($input, $output);
     }
 
     /**

--- a/tests/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageOutputTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Command\RejectImage;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\ImagePath;
+use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImageOutput;
+use Source\Wiki\Image\Domain\Entity\DraftImage;
+use Source\Wiki\Image\Domain\ValueObject\ImageUsage;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RejectImageOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftImageがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftImage(): void
+    {
+        $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
+        $draftImage = new DraftImage(
+            $imageIdentifier,
+            null,
+            ResourceType::TALENT,
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new ImagePath('images/test.png'),
+            ImageUsage::PROFILE,
+            1,
+            'https://example.com/source',
+            'Example Source',
+            'Alt text',
+            ApprovalStatus::Rejected,
+            new DateTimeImmutable(),
+            new DateTimeImmutable(),
+        );
+
+        $output = new RejectImageOutput();
+        $output->setDraftImage($draftImage);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
+        $this->assertSame('talent', $result['resourceType']);
+        $this->assertSame('profile', $result['imageUsage']);
+        $this->assertSame('rejected', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftImageがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftImage(): void
+    {
+        $output = new RejectImageOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'imageIdentifier' => null,
+            'resourceType' => null,
+            'imageUsage' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageTest.php
@@ -13,6 +13,7 @@ use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
 use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImage;
 use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImageInput;
 use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\RejectImage\RejectImageOutput;
 use Source\Wiki\Image\Domain\Entity\DraftImage;
 use Source\Wiki\Image\Domain\Repository\DraftImageRepositoryInterface;
 use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
@@ -103,9 +104,11 @@ class RejectImageTest extends TestCase
         $this->app->instance(ImageAuthorizationResourceBuilderInterface::class, $imageAuthorizationResourceBuilder);
 
         $rejectImage = $this->app->make(RejectImageInterface::class);
-        $result = $rejectImage->process($input);
+        $output = new RejectImageOutput();
+        $rejectImage->process($input, $output);
 
-        $this->assertSame(ApprovalStatus::Rejected, $result->status());
+        $result = $output->toArray();
+        $this->assertSame('rejected', $result['status']);
     }
 
     /**
@@ -146,7 +149,8 @@ class RejectImageTest extends TestCase
 
         $this->expectException(ImageNotFoundException::class);
         $rejectImage = $this->app->make(RejectImageInterface::class);
-        $rejectImage->process($input);
+        $output = new RejectImageOutput();
+        $rejectImage->process($input, $output);
     }
 
     /**
@@ -194,7 +198,8 @@ class RejectImageTest extends TestCase
 
         $this->expectException(InvalidStatusException::class);
         $rejectImage = $this->app->make(RejectImageInterface::class);
-        $rejectImage->process($input);
+        $output = new RejectImageOutput();
+        $rejectImage->process($input, $output);
     }
 
     /**
@@ -243,7 +248,8 @@ class RejectImageTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $rejectImage = $this->app->make(RejectImageInterface::class);
-        $rejectImage->process($input);
+        $output = new RejectImageOutput();
+        $rejectImage->process($input, $output);
     }
 
     /**
@@ -279,7 +285,8 @@ class RejectImageTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $rejectImage = $this->app->make(RejectImageInterface::class);
-        $rejectImage->process($input);
+        $output = new RejectImageOutput();
+        $rejectImage->process($input, $output);
     }
 
     /**

--- a/tests/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageOutputTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Command\UnhideImage;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\ImagePath;
+use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageOutput;
+use Source\Wiki\Image\Domain\Entity\Image;
+use Source\Wiki\Image\Domain\ValueObject\ImageUsage;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UnhideImageOutputTest extends TestCase
+{
+    /**
+     * 正常系: Imageがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithImage(): void
+    {
+        $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
+        $image = new Image(
+            $imageIdentifier,
+            ResourceType::TALENT,
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new ImagePath('images/test.png'),
+            ImageUsage::PROFILE,
+            1,
+            'https://example.com/source',
+            'Example Source',
+            'Alt text',
+            false,
+            null,
+            null,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new DateTimeImmutable(),
+            null,
+            null,
+            null,
+            null,
+        );
+
+        $output = new UnhideImageOutput();
+        $output->setImage($image);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
+        $this->assertSame('talent', $result['resourceType']);
+        $this->assertSame('profile', $result['imageUsage']);
+        $this->assertFalse($result['isHidden']);
+    }
+
+    /**
+     * 正常系: Imageがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutImage(): void
+    {
+        $output = new UnhideImageOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'imageIdentifier' => null,
+            'resourceType' => null,
+            'imageUsage' => null,
+            'isHidden' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageTest.php
@@ -13,6 +13,7 @@ use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
 use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImage;
 use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageInput;
 use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageOutput;
 use Source\Wiki\Image\Domain\Entity\Image;
 use Source\Wiki\Image\Domain\Repository\ImageRepositoryInterface;
 use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
@@ -100,11 +101,11 @@ class UnhideImageTest extends TestCase
         $this->app->instance(ImageAuthorizationResourceBuilderInterface::class, $imageAuthorizationResourceBuilder);
 
         $unhideImage = $this->app->make(UnhideImageInterface::class);
-        $result = $unhideImage->process($input);
+        $output = new UnhideImageOutput();
+        $unhideImage->process($input, $output);
 
-        $this->assertFalse($result->isHidden());
-        $this->assertNull($result->hiddenBy());
-        $this->assertNull($result->hiddenAt());
+        $result = $output->toArray();
+        $this->assertFalse($result['isHidden']);
     }
 
     /**
@@ -140,7 +141,8 @@ class UnhideImageTest extends TestCase
 
         $this->expectException(ImageNotFoundException::class);
         $unhideImage = $this->app->make(UnhideImageInterface::class);
-        $unhideImage->process($input);
+        $output = new UnhideImageOutput();
+        $unhideImage->process($input, $output);
     }
 
     /**
@@ -179,7 +181,8 @@ class UnhideImageTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $unhideImage = $this->app->make(UnhideImageInterface::class);
-        $unhideImage->process($input);
+        $output = new UnhideImageOutput();
+        $unhideImage->process($input, $output);
     }
 
     /**
@@ -228,7 +231,8 @@ class UnhideImageTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $unhideImage = $this->app->make(UnhideImageInterface::class);
-        $unhideImage->process($input);
+        $output = new UnhideImageOutput();
+        $unhideImage->process($input, $output);
     }
 
     /**

--- a/tests/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageOutputTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Command\UploadImage;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\ImagePath;
+use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageOutput;
+use Source\Wiki\Image\Domain\Entity\DraftImage;
+use Source\Wiki\Image\Domain\ValueObject\ImageUsage;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UploadImageOutputTest extends TestCase
+{
+    /**
+     * 正常系: DraftImageがセットされている場合、toArrayが正しい値を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithDraftImage(): void
+    {
+        $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
+        $draftImage = new DraftImage(
+            $imageIdentifier,
+            null,
+            ResourceType::TALENT,
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new ImagePath('images/test.png'),
+            ImageUsage::PROFILE,
+            1,
+            'https://example.com/source',
+            'Example Source',
+            'Alt text',
+            ApprovalStatus::UnderReview,
+            new DateTimeImmutable(),
+            new DateTimeImmutable(),
+        );
+
+        $output = new UploadImageOutput();
+        $output->setDraftImage($draftImage);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
+        $this->assertSame('talent', $result['resourceType']);
+        $this->assertSame('profile', $result['imageUsage']);
+        $this->assertSame('under_review', $result['status']);
+    }
+
+    /**
+     * 正常系: DraftImageがセットされていない場合、toArrayが全てnullの配列を返すこと.
+     *
+     * @return void
+     */
+    public function testToArrayWithoutDraftImage(): void
+    {
+        $output = new UploadImageOutput();
+
+        $result = $output->toArray();
+
+        $this->assertSame([
+            'imageIdentifier' => null,
+            'resourceType' => null,
+            'imageUsage' => null,
+            'status' => null,
+        ], $result);
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageTest.php
@@ -10,12 +10,12 @@ use Mockery;
 use Source\Shared\Application\DTO\ImageUploadResult;
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
 use Source\Shared\Application\Service\ImageServiceInterface;
-use Source\Shared\Application\Service\Uuid\UuidValidator;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\ImagePath;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImage;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageInput;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageInterface;
+use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageOutput;
 use Source\Wiki\Image\Domain\Entity\DraftImage;
 use Source\Wiki\Image\Domain\Factory\DraftImageFactoryInterface;
 use Source\Wiki\Image\Domain\Repository\DraftImageRepositoryInterface;
@@ -143,20 +143,14 @@ class UploadImageTest extends TestCase
         $this->app->instance(ImageAuthorizationResourceBuilderInterface::class, $imageAuthorizationResourceBuilder);
 
         $uploadImage = $this->app->make(UploadImageInterface::class);
-        $result = $uploadImage->process($input);
+        $output = new UploadImageOutput();
+        $uploadImage->process($input, $output);
 
-        $this->assertTrue(UuidValidator::isValid((string)$result->imageIdentifier()));
-        $this->assertSame((string)$testData->publishedImageIdentifier, (string)$result->publishedImageIdentifier());
-        $this->assertSame($testData->resourceType, $result->resourceType());
-        $this->assertSame((string)$testData->draftResourceIdentifier, (string)$result->wikiIdentifier());
-        $this->assertSame((string)$testData->principalIdentifier, (string)$result->uploaderIdentifier());
-        $this->assertSame((string)$testData->imagePath, (string)$result->imagePath());
-        $this->assertSame($testData->imageUsage, $result->imageUsage());
-        $this->assertSame($testData->displayOrder, $result->displayOrder());
-        $this->assertSame($testData->sourceUrl, $result->sourceUrl());
-        $this->assertSame($testData->sourceName, $result->sourceName());
-        $this->assertSame($testData->altText, $result->altText());
-        $this->assertSame(ApprovalStatus::UnderReview, $result->status());
+        $result = $output->toArray();
+        $this->assertNotNull($result['imageIdentifier']);
+        $this->assertSame($testData->resourceType->value, $result['resourceType']);
+        $this->assertSame($testData->imageUsage->value, $result['imageUsage']);
+        $this->assertSame('under_review', $result['status']);
     }
 
     /**
@@ -215,7 +209,8 @@ class UploadImageTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $uploadImage = $this->app->make(UploadImageInterface::class);
-        $uploadImage->process($input);
+        $output = new UploadImageOutput();
+        $uploadImage->process($input, $output);
     }
 
     /**
@@ -264,7 +259,8 @@ class UploadImageTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $uploadImage = $this->app->make(UploadImageInterface::class);
-        $uploadImage->process($input);
+        $output = new UploadImageOutput();
+        $uploadImage->process($input, $output);
     }
 
     /**


### PR DESCRIPTION
## 📝 変更内容

- Image関連の4つのユースケース（ApproveImage, RejectImage, UnhideImage, UploadImage）にOutputパターンを導入
- 各ユースケースにOutput / OutputPortクラスを新規作成
- HTTPアクション（Action / Request）を新規作成し、エンドポイントを追加
- ルーティング（wiki_private_api.php）に4エンドポイント追加
- 6言語のエラーメッセージ追加（en, es, ja, ko, zh_CN, zh_TW）
- 既存ユースケーステストをOutputパターンに対応して更新
- Outputクラスのユニットテストを新規作成

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🔧 リファクタリング (Refactoring)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

ImageサブドメインのユースケースにOutputパターンを導入し、ユースケース層とプレゼンテーション層の責務を明確に分離する。
あわせてHTTPエンドポイントを作成し、API経由でImage操作を実行可能にする。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Outputクラスの設計が他サブドメイン（Wiki, Delegation, AccountVerification等）と一貫しているか
- Actionクラスの例外ハンドリングが適切か
- ルーティング定義が既存パターンに沿っているか

## 📖 関連情報

### 関連Issue・タスク

Closes #272

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した