### PR TITLE
add: ImageHideRequestにOutputパターン導入・独自例外・エンドポイント作成

### DIFF
--- a/application/Http/Action/Wiki/ImageHideRequest/Command/ApproveImageHideRequest/ApproveImageHideRequestAction.php
+++ b/application/Http/Action/Wiki/ImageHideRequest/Command/ApproveImageHideRequest/ApproveImageHideRequestAction.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\ImageHideRequest\Command\ApproveImageHideRequest;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
+use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestInvalidStatusException;
+use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestNotFoundException;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestInput;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestInterface;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestOutput;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ApproveImageHideRequestAction
+{
+    public function __construct(
+        private ApproveImageHideRequestInterface $approveImageHideRequest,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param ApproveImageHideRequestRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ApproveImageHideRequestRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ApproveImageHideRequestInput(
+                    new ImageHideRequestIdentifier($request->requestId()),
+                    new PrincipalIdentifier($request->principalId()),
+                    $request->reviewerComment(),
+                );
+                $output = new ApproveImageHideRequestOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->approveImageHideRequest->process($input, $output);
+                DB::commit();
+            } catch (ImageHideRequestNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_hide_request_not_found', $language), previous: $e);
+            } catch (ImageHideRequestInvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('image_hide_request_not_pending_for_approval', $language), previous: $e);
+            } catch (ImageNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/ImageHideRequest/Command/ApproveImageHideRequest/ApproveImageHideRequestRequest.php
+++ b/application/Http/Action/Wiki/ImageHideRequest/Command/ApproveImageHideRequest/ApproveImageHideRequestRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\ImageHideRequest\Command\ApproveImageHideRequest;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveImageHideRequestRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'requestId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'reviewerComment' => ['required', 'string'],
+        ];
+    }
+
+    public function requestId(): string
+    {
+        return (string) $this->input('requestId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function reviewerComment(): string
+    {
+        return (string) $this->input('reviewerComment');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/ImageHideRequest/Command/RejectImageHideRequest/RejectImageHideRequestAction.php
+++ b/application/Http/Action/Wiki/ImageHideRequest/Command/RejectImageHideRequest/RejectImageHideRequestAction.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\ImageHideRequest\Command\RejectImageHideRequest;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
+use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestInvalidStatusException;
+use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestNotFoundException;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestInput;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestInterface;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestOutput;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RejectImageHideRequestAction
+{
+    public function __construct(
+        private RejectImageHideRequestInterface $rejectImageHideRequest,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RejectImageHideRequestRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RejectImageHideRequestRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RejectImageHideRequestInput(
+                    new ImageHideRequestIdentifier($request->requestId()),
+                    new PrincipalIdentifier($request->principalId()),
+                    $request->reviewerComment(),
+                );
+                $output = new RejectImageHideRequestOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->rejectImageHideRequest->process($input, $output);
+                DB::commit();
+            } catch (ImageHideRequestNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_hide_request_not_found', $language), previous: $e);
+            } catch (ImageHideRequestInvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('image_hide_request_not_pending_for_rejection', $language), previous: $e);
+            } catch (ImageNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_not_found', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/ImageHideRequest/Command/RejectImageHideRequest/RejectImageHideRequestRequest.php
+++ b/application/Http/Action/Wiki/ImageHideRequest/Command/RejectImageHideRequest/RejectImageHideRequestRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\ImageHideRequest\Command\RejectImageHideRequest;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectImageHideRequestRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'requestId' => ['required', 'uuid'],
+            'principalId' => ['required', 'uuid'],
+            'reviewerComment' => ['required', 'string'],
+        ];
+    }
+
+    public function requestId(): string
+    {
+        return (string) $this->input('requestId');
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function reviewerComment(): string
+    {
+        return (string) $this->input('reviewerComment');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/ImageHideRequest/Command/RequestImageHide/RequestImageHideAction.php
+++ b/application/Http/Action/Wiki/ImageHideRequest/Command/RequestImageHide/RequestImageHideAction.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\ImageHideRequest\Command\RequestImageHide;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
+use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestAlreadyPendingException;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideInput;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideInterface;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideOutput;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RequestImageHideAction
+{
+    public function __construct(
+        private RequestImageHideInterface $requestImageHide,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param RequestImageHideRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RequestImageHideRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RequestImageHideInput(
+                    new ImageIdentifier($request->imageIdentifier()),
+                    $request->requesterName(),
+                    $request->requesterEmail(),
+                    $request->reason(),
+                );
+                $output = new RequestImageHideOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->requestImageHide->process($input, $output);
+                DB::commit();
+            } catch (ImageNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('image_not_found', $language), previous: $e);
+            } catch (ImageHideRequestAlreadyPendingException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('image_hide_request_already_pending', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/ImageHideRequest/Command/RequestImageHide/RequestImageHideRequest.php
+++ b/application/Http/Action/Wiki/ImageHideRequest/Command/RequestImageHide/RequestImageHideRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\ImageHideRequest\Command\RequestImageHide;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RequestImageHideRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'imageIdentifier' => ['required', 'uuid'],
+            'requesterName' => ['required', 'string'],
+            'requesterEmail' => ['required', 'email'],
+            'reason' => ['required', 'string'],
+        ];
+    }
+
+    public function imageIdentifier(): string
+    {
+        return (string) $this->input('imageIdentifier');
+    }
+
+    public function requesterName(): string
+    {
+        return (string) $this->input('requesterName');
+    }
+
+    public function requesterEmail(): string
+    {
+        return (string) $this->input('requesterEmail');
+    }
+
+    public function reason(): string
+    {
+        return (string) $this->input('reason');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -102,4 +102,11 @@ return [
     'principal_already_member' => 'The principal is already a member of this group.',
     'principal_not_member' => 'The principal is not a member of this group.',
     'cannot_change_non_delegated_principal' => 'Cannot change the enabled status of a non-delegated principal.',
+
+    // ImageHideRequest
+    'image_hide_request_not_found' => 'The specified image hide request was not found.',
+    'image_not_found' => 'The specified image was not found.',
+    'image_hide_request_not_pending_for_approval' => 'Only pending image hide requests can be approved.',
+    'image_hide_request_not_pending_for_rejection' => 'Only pending image hide requests can be rejected.',
+    'image_hide_request_already_pending' => 'An image hide request is already pending for this image.',
 ];

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -102,4 +102,11 @@ return [
     'principal_already_member' => 'El principal ya es miembro de este grupo.',
     'principal_not_member' => 'El principal no es miembro de este grupo.',
     'cannot_change_non_delegated_principal' => 'No se puede cambiar el estado habilitado de un principal no delegado.',
+
+    // ImageHideRequest
+    'image_hide_request_not_found' => 'No se encontró la solicitud de ocultación de imagen especificada.',
+    'image_not_found' => 'No se encontró la imagen especificada.',
+    'image_hide_request_not_pending_for_approval' => 'Solo se pueden aprobar solicitudes de ocultación de imagen pendientes.',
+    'image_hide_request_not_pending_for_rejection' => 'Solo se pueden rechazar solicitudes de ocultación de imagen pendientes.',
+    'image_hide_request_already_pending' => 'Ya existe una solicitud de ocultación pendiente para esta imagen.',
 ];

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -102,4 +102,11 @@ return [
     'principal_already_member' => 'このプリンシパルは既にこのグループのメンバーです。',
     'principal_not_member' => 'このプリンシパルはこのグループのメンバーではありません。',
     'cannot_change_non_delegated_principal' => '委任されていないプリンシパルの有効状態は変更できません。',
+
+    // ImageHideRequest
+    'image_hide_request_not_found' => '指定された画像非表示リクエストが見つかりません。',
+    'image_not_found' => '指定された画像が見つかりません。',
+    'image_hide_request_not_pending_for_approval' => '保留中以外の画像非表示リクエストは承認できません。',
+    'image_hide_request_not_pending_for_rejection' => '保留中以外の画像非表示リクエストは拒否できません。',
+    'image_hide_request_already_pending' => 'この画像に対する非表示リクエストは既に保留中です。',
 ];

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -102,4 +102,11 @@ return [
     'principal_already_member' => '이 프린시펄은 이미 이 그룹의 멤버입니다.',
     'principal_not_member' => '이 프린시펄은 이 그룹의 멤버가 아닙니다.',
     'cannot_change_non_delegated_principal' => '위임되지 않은 프린시펄의 활성 상태는 변경할 수 없습니다.',
+
+    // ImageHideRequest
+    'image_hide_request_not_found' => '지정된 이미지 숨김 요청을 찾을 수 없습니다.',
+    'image_not_found' => '지정된 이미지를 찾을 수 없습니다.',
+    'image_hide_request_not_pending_for_approval' => '대기 중인 이미지 숨김 요청만 승인할 수 있습니다.',
+    'image_hide_request_not_pending_for_rejection' => '대기 중인 이미지 숨김 요청만 거부할 수 있습니다.',
+    'image_hide_request_already_pending' => '이 이미지에 대한 숨김 요청이 이미 대기 중입니다.',
 ];

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -102,4 +102,11 @@ return [
     'principal_already_member' => '该主体已是此组的成员。',
     'principal_not_member' => '该主体不是此组的成员。',
     'cannot_change_non_delegated_principal' => '无法更改非委托主体的启用状态。',
+
+    // ImageHideRequest
+    'image_hide_request_not_found' => '未找到指定的图片隐藏请求。',
+    'image_not_found' => '未找到指定的图片。',
+    'image_hide_request_not_pending_for_approval' => '只能批准待处理的图片隐藏请求。',
+    'image_hide_request_not_pending_for_rejection' => '只能拒绝待处理的图片隐藏请求。',
+    'image_hide_request_already_pending' => '该图片已存在待处理的隐藏请求。',
 ];

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -102,4 +102,11 @@ return [
     'principal_already_member' => '該主體已是此群組的成員。',
     'principal_not_member' => '該主體不是此群組的成員。',
     'cannot_change_non_delegated_principal' => '無法變更非委任主體的啟用狀態。',
+
+    // ImageHideRequest
+    'image_hide_request_not_found' => '未找到指定的圖片隱藏請求。',
+    'image_not_found' => '未找到指定的圖片。',
+    'image_hide_request_not_pending_for_approval' => '只能批准待處理的圖片隱藏請求。',
+    'image_hide_request_not_pending_for_rejection' => '只能拒絕待處理的圖片隱藏請求。',
+    'image_hide_request_already_pending' => '該圖片已存在待處理的隱藏請求。',
 ];

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -29,6 +29,9 @@ use Application\Http\Action\Wiki\Wiki\Command\PublishWiki\PublishWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RejectWiki\RejectWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RollbackWiki\RollbackWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
+use Application\Http\Action\Wiki\ImageHideRequest\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
+use Application\Http\Action\Wiki\ImageHideRequest\Command\RejectImageHideRequest\RejectImageHideRequestAction;
+use Application\Http\Action\Wiki\ImageHideRequest\Command\RequestImageHide\RequestImageHideAction;
 use Application\Http\Action\Wiki\Wiki\Command\TranslateWiki\TranslateWikiAction;
 use Illuminate\Support\Facades\Route;
 
@@ -64,3 +67,8 @@ Route::post('/role/{roleId}/attach-policy', AttachPolicyToRoleAction::class);
 Route::post('/role/{roleId}/detach-policy', DetachPolicyFromRoleAction::class);
 Route::post('/policy/create', CreatePolicyAction::class);
 Route::delete('/policy/{policyId}', DeletePolicyAction::class);
+
+// ImageHideRequest
+Route::post('/image-hide-request/create', RequestImageHideAction::class);
+Route::post('/image-hide-request/{requestId}/approve', ApproveImageHideRequestAction::class);
+Route::post('/image-hide-request/{requestId}/reject', RejectImageHideRequestAction::class);

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequest.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequest.php
@@ -9,7 +9,6 @@ use Source\Wiki\Image\Domain\Repository\ImageRepositoryInterface;
 use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
 use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestInvalidStatusException;
 use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestNotFoundException;
-use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\ImageHideRequest\Domain\Repository\ImageHideRequestRepositoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
@@ -30,12 +29,13 @@ readonly class ApproveImageHideRequest implements ApproveImageHideRequestInterfa
 
     /**
      * @param ApproveImageHideRequestInputPort $input
-     * @return ImageHideRequest
+     * @param ApproveImageHideRequestOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws PrincipalNotFoundException
      */
-    public function process(ApproveImageHideRequestInputPort $input): ImageHideRequest
+    public function process(ApproveImageHideRequestInputPort $input, ApproveImageHideRequestOutputPort $output): void
     {
         $imageHideRequest = $this->imageHideRequestRepository->findById($input->requestIdentifier());
         if ($imageHideRequest === null) {
@@ -67,6 +67,6 @@ readonly class ApproveImageHideRequest implements ApproveImageHideRequestInterfa
         $image->hide($input->principalIdentifier());
         $this->imageRepository->save($image);
 
-        return $imageHideRequest;
+        $output->setImageHideRequest($imageHideRequest);
     }
 }

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestInterface.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 
@@ -13,10 +12,11 @@ interface ApproveImageHideRequestInterface
 {
     /**
      * @param ApproveImageHideRequestInputPort $input
-     * @return ImageHideRequest
+     * @param ApproveImageHideRequestOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws PrincipalNotFoundException
      */
-    public function process(ApproveImageHideRequestInputPort $input): ImageHideRequest;
+    public function process(ApproveImageHideRequestInputPort $input, ApproveImageHideRequestOutputPort $output): void;
 }

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestOutput.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest;
+
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+
+class ApproveImageHideRequestOutput implements ApproveImageHideRequestOutputPort
+{
+    private ?ImageHideRequest $imageHideRequest = null;
+
+    public function setImageHideRequest(ImageHideRequest $imageHideRequest): void
+    {
+        $this->imageHideRequest = $imageHideRequest;
+    }
+
+    /**
+     * @return array{requestIdentifier: ?string, imageIdentifier: ?string, status: ?string, reviewerComment: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->imageHideRequest === null) {
+            return [
+                'requestIdentifier' => null,
+                'imageIdentifier' => null,
+                'status' => null,
+                'reviewerComment' => null,
+            ];
+        }
+
+        return [
+            'requestIdentifier' => (string) $this->imageHideRequest->requestIdentifier(),
+            'imageIdentifier' => (string) $this->imageHideRequest->imageIdentifier(),
+            'status' => $this->imageHideRequest->status()->value,
+            'reviewerComment' => $this->imageHideRequest->reviewerComment(),
+        ];
+    }
+}

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestOutputPort.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest;
+
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+
+interface ApproveImageHideRequestOutputPort
+{
+    public function setImageHideRequest(ImageHideRequest $imageHideRequest): void;
+
+    /**
+     * @return array{requestIdentifier: ?string, imageIdentifier: ?string, status: ?string, reviewerComment: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequest.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequest.php
@@ -9,7 +9,6 @@ use Source\Wiki\Image\Domain\Repository\ImageRepositoryInterface;
 use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
 use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestInvalidStatusException;
 use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestNotFoundException;
-use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\ImageHideRequest\Domain\Repository\ImageHideRequestRepositoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
@@ -30,12 +29,13 @@ readonly class RejectImageHideRequest implements RejectImageHideRequestInterface
 
     /**
      * @param RejectImageHideRequestInputPort $input
-     * @return ImageHideRequest
+     * @param RejectImageHideRequestOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws PrincipalNotFoundException
      */
-    public function process(RejectImageHideRequestInputPort $input): ImageHideRequest
+    public function process(RejectImageHideRequestInputPort $input, RejectImageHideRequestOutputPort $output): void
     {
         $imageHideRequest = $this->imageHideRequestRepository->findById($input->requestIdentifier());
         if ($imageHideRequest === null) {
@@ -64,6 +64,6 @@ readonly class RejectImageHideRequest implements RejectImageHideRequestInterface
         $imageHideRequest->reject($input->principalIdentifier(), $input->reviewerComment());
         $this->imageHideRequestRepository->save($imageHideRequest);
 
-        return $imageHideRequest;
+        $output->setImageHideRequest($imageHideRequest);
     }
 }

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestInterface.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 
@@ -13,10 +12,11 @@ interface RejectImageHideRequestInterface
 {
     /**
      * @param RejectImageHideRequestInputPort $input
-     * @return ImageHideRequest
+     * @param RejectImageHideRequestOutputPort $output
+     * @return void
      * @throws DisallowedException
      * @throws ImageNotFoundException
      * @throws PrincipalNotFoundException
      */
-    public function process(RejectImageHideRequestInputPort $input): ImageHideRequest;
+    public function process(RejectImageHideRequestInputPort $input, RejectImageHideRequestOutputPort $output): void;
 }

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestOutput.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest;
+
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+
+class RejectImageHideRequestOutput implements RejectImageHideRequestOutputPort
+{
+    private ?ImageHideRequest $imageHideRequest = null;
+
+    public function setImageHideRequest(ImageHideRequest $imageHideRequest): void
+    {
+        $this->imageHideRequest = $imageHideRequest;
+    }
+
+    /**
+     * @return array{requestIdentifier: ?string, imageIdentifier: ?string, status: ?string, reviewerComment: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->imageHideRequest === null) {
+            return [
+                'requestIdentifier' => null,
+                'imageIdentifier' => null,
+                'status' => null,
+                'reviewerComment' => null,
+            ];
+        }
+
+        return [
+            'requestIdentifier' => (string) $this->imageHideRequest->requestIdentifier(),
+            'imageIdentifier' => (string) $this->imageHideRequest->imageIdentifier(),
+            'status' => $this->imageHideRequest->status()->value,
+            'reviewerComment' => $this->imageHideRequest->reviewerComment(),
+        ];
+    }
+}

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestOutputPort.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest;
+
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+
+interface RejectImageHideRequestOutputPort
+{
+    public function setImageHideRequest(ImageHideRequest $imageHideRequest): void;
+
+    /**
+     * @return array{requestIdentifier: ?string, imageIdentifier: ?string, status: ?string, reviewerComment: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHide.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHide.php
@@ -7,7 +7,6 @@ namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageH
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
 use Source\Wiki\Image\Domain\Repository\ImageRepositoryInterface;
 use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestAlreadyPendingException;
-use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\ImageHideRequest\Domain\Factory\ImageHideRequestFactoryInterface;
 use Source\Wiki\ImageHideRequest\Domain\Repository\ImageHideRequestRepositoryInterface;
 
@@ -22,10 +21,11 @@ readonly class RequestImageHide implements RequestImageHideInterface
 
     /**
      * @param RequestImageHideInputPort $input
-     * @return ImageHideRequest
+     * @param RequestImageHideOutputPort $output
+     * @return void
      * @throws ImageNotFoundException
      */
-    public function process(RequestImageHideInputPort $input): ImageHideRequest
+    public function process(RequestImageHideInputPort $input, RequestImageHideOutputPort $output): void
     {
         $image = $this->imageRepository->findById($input->imageIdentifier());
         if ($image === null) {
@@ -45,6 +45,6 @@ readonly class RequestImageHide implements RequestImageHideInterface
 
         $this->imageHideRequestRepository->save($imageHideRequest);
 
-        return $imageHideRequest;
+        $output->setImageHideRequest($imageHideRequest);
     }
 }

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideInterface.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideInterface.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide;
 
 use Source\Wiki\Image\Application\Exception\ImageNotFoundException;
-use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 
 interface RequestImageHideInterface
 {
     /**
      * @param RequestImageHideInputPort $input
-     * @return ImageHideRequest
+     * @param RequestImageHideOutputPort $output
+     * @return void
      * @throws ImageNotFoundException
      */
-    public function process(RequestImageHideInputPort $input): ImageHideRequest;
+    public function process(RequestImageHideInputPort $input, RequestImageHideOutputPort $output): void;
 }

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideOutput.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideOutput.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide;
+
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+
+class RequestImageHideOutput implements RequestImageHideOutputPort
+{
+    private ?ImageHideRequest $imageHideRequest = null;
+
+    public function setImageHideRequest(ImageHideRequest $imageHideRequest): void
+    {
+        $this->imageHideRequest = $imageHideRequest;
+    }
+
+    /**
+     * @return array{requestIdentifier: ?string, imageIdentifier: ?string, requesterName: ?string, requesterEmail: ?string, reason: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->imageHideRequest === null) {
+            return [
+                'requestIdentifier' => null,
+                'imageIdentifier' => null,
+                'requesterName' => null,
+                'requesterEmail' => null,
+                'reason' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'requestIdentifier' => (string) $this->imageHideRequest->requestIdentifier(),
+            'imageIdentifier' => (string) $this->imageHideRequest->imageIdentifier(),
+            'requesterName' => $this->imageHideRequest->requesterName(),
+            'requesterEmail' => $this->imageHideRequest->requesterEmail(),
+            'reason' => $this->imageHideRequest->reason(),
+            'status' => $this->imageHideRequest->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideOutputPort.php
+++ b/src/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide;
+
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+
+interface RequestImageHideOutputPort
+{
+    public function setImageHideRequest(ImageHideRequest $imageHideRequest): void;
+
+    /**
+     * @return array{requestIdentifier: ?string, imageIdentifier: ?string, requesterName: ?string, requesterEmail: ?string, reason: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/ImageHideRequest/Domain/Entity/ImageHideRequest.php
+++ b/src/Wiki/ImageHideRequest/Domain/Entity/ImageHideRequest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Source\Wiki\ImageHideRequest\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
+use Source\Wiki\ImageHideRequest\Domain\Exception\ImageHideRequestNotPendingForApprovalException;
+use Source\Wiki\ImageHideRequest\Domain\Exception\ImageHideRequestNotPendingForRejectionException;
 use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
 use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestStatus;
 use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
@@ -80,7 +81,7 @@ class ImageHideRequest
     public function approve(PrincipalIdentifier $reviewerIdentifier, string $reviewerComment): void
     {
         if (! $this->status->isPending()) {
-            throw new DomainException('Only pending requests can be approved.');
+            throw new ImageHideRequestNotPendingForApprovalException();
         }
 
         $this->status = ImageHideRequestStatus::APPROVED;
@@ -92,7 +93,7 @@ class ImageHideRequest
     public function reject(PrincipalIdentifier $reviewerIdentifier, string $reviewerComment): void
     {
         if (! $this->status->isPending()) {
-            throw new DomainException('Only pending requests can be rejected.');
+            throw new ImageHideRequestNotPendingForRejectionException();
         }
 
         $this->status = ImageHideRequestStatus::REJECTED;

--- a/src/Wiki/ImageHideRequest/Domain/Exception/ImageHideRequestNotPendingForApprovalException.php
+++ b/src/Wiki/ImageHideRequest/Domain/Exception/ImageHideRequestNotPendingForApprovalException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Domain\Exception;
+
+use DomainException;
+
+class ImageHideRequestNotPendingForApprovalException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Only pending requests can be approved.');
+    }
+}

--- a/src/Wiki/ImageHideRequest/Domain/Exception/ImageHideRequestNotPendingForRejectionException.php
+++ b/src/Wiki/ImageHideRequest/Domain/Exception/ImageHideRequestNotPendingForRejectionException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\ImageHideRequest\Domain\Exception;
+
+use DomainException;
+
+class ImageHideRequestNotPendingForRejectionException extends DomainException
+{
+    public function __construct()
+    {
+        parent::__construct('Only pending requests can be rejected.');
+    }
+}

--- a/tests/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestOutputTest.php
+++ b/tests/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestOutputTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestOutput;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestOutputPort;
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class ApproveImageHideRequestOutputTest extends TestCase
+{
+    /**
+     * 正常系: OutputPortインターフェースを実装していること.
+     */
+    public function testImplementsOutputPort(): void
+    {
+        $output = new ApproveImageHideRequestOutput();
+        $this->assertInstanceOf(ApproveImageHideRequestOutputPort::class, $output);
+    }
+
+    /**
+     * 正常系: エンティティ未設定時にnullフィールドを返すこと.
+     */
+    public function testToArrayReturnsNullFieldsWhenNoEntitySet(): void
+    {
+        $output = new ApproveImageHideRequestOutput();
+        $result = $output->toArray();
+
+        $this->assertNull($result['requestIdentifier']);
+        $this->assertNull($result['imageIdentifier']);
+        $this->assertNull($result['status']);
+        $this->assertNull($result['reviewerComment']);
+    }
+
+    /**
+     * 正常系: エンティティ設定時に正しい値を返すこと.
+     */
+    public function testToArrayReturnsCorrectValuesWhenEntitySet(): void
+    {
+        $requestIdentifier = new ImageHideRequestIdentifier(StrTestHelper::generateUuid());
+        $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
+        $reviewerComment = 'Approved for valid reason.';
+
+        $imageHideRequest = new ImageHideRequest(
+            $requestIdentifier,
+            $imageIdentifier,
+            'Test Requester',
+            'requester@example.com',
+            'Privacy concern',
+            ImageHideRequestStatus::APPROVED,
+            new DateTimeImmutable(),
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new DateTimeImmutable(),
+            $reviewerComment,
+        );
+
+        $output = new ApproveImageHideRequestOutput();
+        $output->setImageHideRequest($imageHideRequest);
+        $result = $output->toArray();
+
+        $this->assertSame((string) $requestIdentifier, $result['requestIdentifier']);
+        $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
+        $this->assertSame('approved', $result['status']);
+        $this->assertSame($reviewerComment, $result['reviewerComment']);
+    }
+}

--- a/tests/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestTest.php
+++ b/tests/Wiki/ImageHideRequest/Application/UseCase/Command/ApproveImageHideRequest/ApproveImageHideRequestTest.php
@@ -19,6 +19,7 @@ use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestNotFoundE
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequest;
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestInput;
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestInterface;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\ApproveImageHideRequest\ApproveImageHideRequestOutput;
 use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\ImageHideRequest\Domain\Repository\ImageHideRequestRepositoryInterface;
 use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
@@ -125,12 +126,19 @@ class ApproveImageHideRequestTest extends TestCase
         $this->app->instance(ImageAuthorizationResourceBuilderInterface::class, $imageAuthorizationResourceBuilder);
 
         $approveImageHideRequest = $this->app->make(ApproveImageHideRequestInterface::class);
-        $result = $approveImageHideRequest->process($input);
+        $output = new ApproveImageHideRequestOutput();
+        $approveImageHideRequest->process($input, $output);
 
-        $this->assertSame(ImageHideRequestStatus::APPROVED, $result->status());
-        $this->assertSame((string) $principalIdentifier, (string) $result->reviewerIdentifier());
-        $this->assertSame($reviewerComment, $result->reviewerComment());
+        $this->assertSame(ImageHideRequestStatus::APPROVED, $testData->imageHideRequest->status());
+        $this->assertSame((string) $principalIdentifier, (string) $testData->imageHideRequest->reviewerIdentifier());
+        $this->assertSame($reviewerComment, $testData->imageHideRequest->reviewerComment());
         $this->assertTrue($testData->image->isHidden());
+
+        $outputArray = $output->toArray();
+        $this->assertSame((string) $testData->requestIdentifier, $outputArray['requestIdentifier']);
+        $this->assertSame((string) $testData->imageIdentifier, $outputArray['imageIdentifier']);
+        $this->assertSame('approved', $outputArray['status']);
+        $this->assertSame($reviewerComment, $outputArray['reviewerComment']);
     }
 
     /**
@@ -173,7 +181,8 @@ class ApproveImageHideRequestTest extends TestCase
 
         $this->expectException(ImageHideRequestNotFoundException::class);
         $approveImageHideRequest = $this->app->make(ApproveImageHideRequestInterface::class);
-        $approveImageHideRequest->process($input);
+        $output = new ApproveImageHideRequestOutput();
+        $approveImageHideRequest->process($input, $output);
     }
 
     /**
@@ -216,7 +225,8 @@ class ApproveImageHideRequestTest extends TestCase
 
         $this->expectException(ImageHideRequestInvalidStatusException::class);
         $approveImageHideRequest = $this->app->make(ApproveImageHideRequestInterface::class);
-        $approveImageHideRequest->process($input);
+        $output = new ApproveImageHideRequestOutput();
+        $approveImageHideRequest->process($input, $output);
     }
 
     /**
@@ -262,7 +272,8 @@ class ApproveImageHideRequestTest extends TestCase
 
         $this->expectException(ImageNotFoundException::class);
         $approveImageHideRequest = $this->app->make(ApproveImageHideRequestInterface::class);
-        $approveImageHideRequest->process($input);
+        $output = new ApproveImageHideRequestOutput();
+        $approveImageHideRequest->process($input, $output);
     }
 
     /**
@@ -311,7 +322,8 @@ class ApproveImageHideRequestTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $approveImageHideRequest = $this->app->make(ApproveImageHideRequestInterface::class);
-        $approveImageHideRequest->process($input);
+        $output = new ApproveImageHideRequestOutput();
+        $approveImageHideRequest->process($input, $output);
     }
 
     /**
@@ -370,7 +382,8 @@ class ApproveImageHideRequestTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $approveImageHideRequest = $this->app->make(ApproveImageHideRequestInterface::class);
-        $approveImageHideRequest->process($input);
+        $output = new ApproveImageHideRequestOutput();
+        $approveImageHideRequest->process($input, $output);
     }
 
     /**

--- a/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestOutputTest.php
+++ b/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestOutputTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestOutput;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestOutputPort;
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class RejectImageHideRequestOutputTest extends TestCase
+{
+    /**
+     * 正常系: OutputPortインターフェースを実装していること.
+     */
+    public function testImplementsOutputPort(): void
+    {
+        $output = new RejectImageHideRequestOutput();
+        $this->assertInstanceOf(RejectImageHideRequestOutputPort::class, $output);
+    }
+
+    /**
+     * 正常系: エンティティ未設定時にnullフィールドを返すこと.
+     */
+    public function testToArrayReturnsNullFieldsWhenNoEntitySet(): void
+    {
+        $output = new RejectImageHideRequestOutput();
+        $result = $output->toArray();
+
+        $this->assertNull($result['requestIdentifier']);
+        $this->assertNull($result['imageIdentifier']);
+        $this->assertNull($result['status']);
+        $this->assertNull($result['reviewerComment']);
+    }
+
+    /**
+     * 正常系: エンティティ設定時に正しい値を返すこと.
+     */
+    public function testToArrayReturnsCorrectValuesWhenEntitySet(): void
+    {
+        $requestIdentifier = new ImageHideRequestIdentifier(StrTestHelper::generateUuid());
+        $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
+        $reviewerComment = 'Rejected for invalid reason.';
+
+        $imageHideRequest = new ImageHideRequest(
+            $requestIdentifier,
+            $imageIdentifier,
+            'Test Requester',
+            'requester@example.com',
+            'Privacy concern',
+            ImageHideRequestStatus::REJECTED,
+            new DateTimeImmutable(),
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new DateTimeImmutable(),
+            $reviewerComment,
+        );
+
+        $output = new RejectImageHideRequestOutput();
+        $output->setImageHideRequest($imageHideRequest);
+        $result = $output->toArray();
+
+        $this->assertSame((string) $requestIdentifier, $result['requestIdentifier']);
+        $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
+        $this->assertSame('rejected', $result['status']);
+        $this->assertSame($reviewerComment, $result['reviewerComment']);
+    }
+}

--- a/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestTest.php
+++ b/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RejectImageHideRequest/RejectImageHideRequestTest.php
@@ -19,6 +19,7 @@ use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestNotFoundE
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequest;
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestInput;
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestInterface;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RejectImageHideRequest\RejectImageHideRequestOutput;
 use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\ImageHideRequest\Domain\Repository\ImageHideRequestRepositoryInterface;
 use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
@@ -123,12 +124,19 @@ class RejectImageHideRequestTest extends TestCase
         $this->app->instance(ImageAuthorizationResourceBuilderInterface::class, $imageAuthorizationResourceBuilder);
 
         $rejectImageHideRequest = $this->app->make(RejectImageHideRequestInterface::class);
-        $result = $rejectImageHideRequest->process($input);
+        $output = new RejectImageHideRequestOutput();
+        $rejectImageHideRequest->process($input, $output);
 
-        $this->assertSame(ImageHideRequestStatus::REJECTED, $result->status());
-        $this->assertSame((string) $principalIdentifier, (string) $result->reviewerIdentifier());
-        $this->assertSame($reviewerComment, $result->reviewerComment());
+        $this->assertSame(ImageHideRequestStatus::REJECTED, $testData->imageHideRequest->status());
+        $this->assertSame((string) $principalIdentifier, (string) $testData->imageHideRequest->reviewerIdentifier());
+        $this->assertSame($reviewerComment, $testData->imageHideRequest->reviewerComment());
         $this->assertFalse($testData->image->isHidden());
+
+        $outputArray = $output->toArray();
+        $this->assertSame((string) $testData->requestIdentifier, $outputArray['requestIdentifier']);
+        $this->assertSame((string) $testData->imageIdentifier, $outputArray['imageIdentifier']);
+        $this->assertSame('rejected', $outputArray['status']);
+        $this->assertSame($reviewerComment, $outputArray['reviewerComment']);
     }
 
     /**
@@ -171,7 +179,8 @@ class RejectImageHideRequestTest extends TestCase
 
         $this->expectException(ImageHideRequestNotFoundException::class);
         $rejectImageHideRequest = $this->app->make(RejectImageHideRequestInterface::class);
-        $rejectImageHideRequest->process($input);
+        $output = new RejectImageHideRequestOutput();
+        $rejectImageHideRequest->process($input, $output);
     }
 
     /**
@@ -214,7 +223,8 @@ class RejectImageHideRequestTest extends TestCase
 
         $this->expectException(ImageHideRequestInvalidStatusException::class);
         $rejectImageHideRequest = $this->app->make(RejectImageHideRequestInterface::class);
-        $rejectImageHideRequest->process($input);
+        $output = new RejectImageHideRequestOutput();
+        $rejectImageHideRequest->process($input, $output);
     }
 
     /**
@@ -260,7 +270,8 @@ class RejectImageHideRequestTest extends TestCase
 
         $this->expectException(ImageNotFoundException::class);
         $rejectImageHideRequest = $this->app->make(RejectImageHideRequestInterface::class);
-        $rejectImageHideRequest->process($input);
+        $output = new RejectImageHideRequestOutput();
+        $rejectImageHideRequest->process($input, $output);
     }
 
     /**
@@ -309,7 +320,8 @@ class RejectImageHideRequestTest extends TestCase
 
         $this->expectException(PrincipalNotFoundException::class);
         $rejectImageHideRequest = $this->app->make(RejectImageHideRequestInterface::class);
-        $rejectImageHideRequest->process($input);
+        $output = new RejectImageHideRequestOutput();
+        $rejectImageHideRequest->process($input, $output);
     }
 
     /**
@@ -368,7 +380,8 @@ class RejectImageHideRequestTest extends TestCase
 
         $this->expectException(DisallowedException::class);
         $rejectImageHideRequest = $this->app->make(RejectImageHideRequestInterface::class);
-        $rejectImageHideRequest->process($input);
+        $output = new RejectImageHideRequestOutput();
+        $rejectImageHideRequest->process($input, $output);
     }
 
     /**

--- a/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideOutputTest.php
+++ b/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideOutputTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideOutput;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideOutputPort;
+use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
+use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class RequestImageHideOutputTest extends TestCase
+{
+    /**
+     * 正常系: OutputPortインターフェースを実装していること.
+     */
+    public function testImplementsOutputPort(): void
+    {
+        $output = new RequestImageHideOutput();
+        $this->assertInstanceOf(RequestImageHideOutputPort::class, $output);
+    }
+
+    /**
+     * 正常系: エンティティ未設定時にnullフィールドを返すこと.
+     */
+    public function testToArrayReturnsNullFieldsWhenNoEntitySet(): void
+    {
+        $output = new RequestImageHideOutput();
+        $result = $output->toArray();
+
+        $this->assertNull($result['requestIdentifier']);
+        $this->assertNull($result['imageIdentifier']);
+        $this->assertNull($result['requesterName']);
+        $this->assertNull($result['requesterEmail']);
+        $this->assertNull($result['reason']);
+        $this->assertNull($result['status']);
+    }
+
+    /**
+     * 正常系: エンティティ設定時に正しい値を返すこと.
+     */
+    public function testToArrayReturnsCorrectValuesWhenEntitySet(): void
+    {
+        $requestIdentifier = new ImageHideRequestIdentifier(StrTestHelper::generateUuid());
+        $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
+        $requesterName = 'Test Requester';
+        $requesterEmail = 'requester@example.com';
+        $reason = 'Privacy concern';
+
+        $imageHideRequest = new ImageHideRequest(
+            $requestIdentifier,
+            $imageIdentifier,
+            $requesterName,
+            $requesterEmail,
+            $reason,
+            ImageHideRequestStatus::PENDING,
+            new DateTimeImmutable(),
+            null,
+            null,
+            null,
+        );
+
+        $output = new RequestImageHideOutput();
+        $output->setImageHideRequest($imageHideRequest);
+        $result = $output->toArray();
+
+        $this->assertSame((string) $requestIdentifier, $result['requestIdentifier']);
+        $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
+        $this->assertSame($requesterName, $result['requesterName']);
+        $this->assertSame($requesterEmail, $result['requesterEmail']);
+        $this->assertSame($reason, $result['reason']);
+        $this->assertSame('pending', $result['status']);
+    }
+}

--- a/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideTest.php
+++ b/tests/Wiki/ImageHideRequest/Application/UseCase/Command/RequestImageHide/RequestImageHideTest.php
@@ -16,6 +16,7 @@ use Source\Wiki\ImageHideRequest\Application\Exception\ImageHideRequestAlreadyPe
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHide;
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideInput;
 use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideInterface;
+use Source\Wiki\ImageHideRequest\Application\UseCase\Command\RequestImageHide\RequestImageHideOutput;
 use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
 use Source\Wiki\ImageHideRequest\Domain\Factory\ImageHideRequestFactoryInterface;
 use Source\Wiki\ImageHideRequest\Domain\Repository\ImageHideRequestRepositoryInterface;
@@ -111,13 +112,15 @@ class RequestImageHideTest extends TestCase
         $this->app->instance(ImageHideRequestFactoryInterface::class, $imageHideRequestFactory);
 
         $requestImageHide = $this->app->make(RequestImageHideInterface::class);
-        $result = $requestImageHide->process($input);
+        $output = new RequestImageHideOutput();
+        $requestImageHide->process($input, $output);
 
-        $this->assertSame(ImageHideRequestStatus::PENDING, $result->status());
-        $this->assertSame((string) $testData->imageIdentifier, (string) $result->imageIdentifier());
-        $this->assertSame($requesterName, $result->requesterName());
-        $this->assertSame($requesterEmail, $result->requesterEmail());
-        $this->assertSame($reason, $result->reason());
+        $outputArray = $output->toArray();
+        $this->assertSame('pending', $outputArray['status']);
+        $this->assertSame((string) $testData->imageIdentifier, $outputArray['imageIdentifier']);
+        $this->assertSame($requesterName, $outputArray['requesterName']);
+        $this->assertSame($requesterEmail, $outputArray['requesterEmail']);
+        $this->assertSame($reason, $outputArray['reason']);
     }
 
     /**
@@ -156,7 +159,8 @@ class RequestImageHideTest extends TestCase
 
         $this->expectException(ImageNotFoundException::class);
         $requestImageHide = $this->app->make(RequestImageHideInterface::class);
-        $requestImageHide->process($input);
+        $output = new RequestImageHideOutput();
+        $requestImageHide->process($input, $output);
     }
 
     /**
@@ -198,7 +202,8 @@ class RequestImageHideTest extends TestCase
 
         $this->expectException(ImageHideRequestAlreadyPendingException::class);
         $requestImageHide = $this->app->make(RequestImageHideInterface::class);
-        $requestImageHide->process($input);
+        $output = new RequestImageHideOutput();
+        $requestImageHide->process($input, $output);
     }
 
     /**

--- a/tests/Wiki/ImageHideRequest/Domain/Entity/ImageHideRequestTest.php
+++ b/tests/Wiki/ImageHideRequest/Domain/Entity/ImageHideRequestTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Tests\Wiki\ImageHideRequest\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use PHPUnit\Framework\TestCase;
 use Source\Wiki\ImageHideRequest\Domain\Entity\ImageHideRequest;
+use Source\Wiki\ImageHideRequest\Domain\Exception\ImageHideRequestNotPendingForApprovalException;
+use Source\Wiki\ImageHideRequest\Domain\Exception\ImageHideRequestNotPendingForRejectionException;
 use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestIdentifier;
 use Source\Wiki\ImageHideRequest\Domain\ValueObject\ImageHideRequestStatus;
 use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
@@ -90,7 +91,7 @@ class ImageHideRequestTest extends TestCase
         $imageHideRequest = $this->createDummyImageHideRequest(ImageHideRequestStatus::APPROVED);
         $reviewerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
-        $this->expectException(DomainException::class);
+        $this->expectException(ImageHideRequestNotPendingForApprovalException::class);
         $this->expectExceptionMessage('Only pending requests can be approved.');
 
         $imageHideRequest->approve($reviewerIdentifier, 'comment');
@@ -129,7 +130,7 @@ class ImageHideRequestTest extends TestCase
         $imageHideRequest = $this->createDummyImageHideRequest(ImageHideRequestStatus::REJECTED);
         $reviewerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
-        $this->expectException(DomainException::class);
+        $this->expectException(ImageHideRequestNotPendingForRejectionException::class);
         $this->expectExceptionMessage('Only pending requests can be rejected.');
 
         $imageHideRequest->reject($reviewerIdentifier, 'comment');


### PR DESCRIPTION
## 📝 変更内容

- ImageHideRequestサブドメインの3つのユースケース（RequestImageHide, ApproveImageHideRequest, RejectImageHideRequest）にOutputパターンを導入
- 各ユースケースにOutput/OutputPortを追加し、戻り値を型安全に
- ドメイン固有例外（ImageHideRequestNotPendingForApprovalException, ImageHideRequestNotPendingForRejectionException）を追加し、汎用例外から移行
- HTTPエンドポイント（Action + FormRequest）を3つ新規作成
- 多言語エラーメッセージを6言語分追加（en, ja, ko, es, zh_CN, zh_TW）
- 対応するテストを追加・更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

ImageHideRequestサブドメインのユースケースにOutputパターンを導入し、他のサブドメイン（Image, Principal, Invitation等）と同様のアーキテクチャに統一する。また、汎用例外からドメイン固有例外への移行により、エラーハンドリングの明確化とHTTPエンドポイントでの適切なステータスコード返却を実現する。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Output/OutputPortの設計が他サブドメイン（Image等）と一貫しているか
- ドメイン固有例外（NotPendingForApproval/NotPendingForRejection）の粒度が適切か
- エンドポイントのエラーハンドリングとHTTPステータスコードのマッピングが正しいか

## 📖 関連情報

### 関連Issue・タスク

Closes #273

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した