### PR TITLE
add: OfficialCertificationサブドメインにOutputパターン導入・独自例外への移行・エンドポイント作成

### DIFF
--- a/application/Http/Action/Wiki/OfficialCertification/Command/ApproveCertification/ApproveCertificationAction.php
+++ b/application/Http/Action/Wiki/OfficialCertification/Command/ApproveCertification/ApproveCertificationAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInput;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ApproveCertificationAction
+{
+    public function __construct(
+        private ApproveCertificationInterface $approveCertification,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ApproveCertificationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ApproveCertificationInput(
+                    new CertificationIdentifier($request->certificationId()),
+                );
+                $output = new ApproveCertificationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->approveCertification->process($input, $output);
+                DB::commit();
+            } catch (OfficialCertificationNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('official_certification_not_found', $language), previous: $e);
+            } catch (OfficialCertificationInvalidStatusException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('official_certification_invalid_status', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/OfficialCertification/Command/ApproveCertification/ApproveCertificationRequest.php
+++ b/application/Http/Action/Wiki/OfficialCertification/Command/ApproveCertification/ApproveCertificationRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveCertificationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function certificationId(): string
+    {
+        return (string) $this->route('certificationId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/OfficialCertification/Command/RejectCertification/RejectCertificationAction.php
+++ b/application/Http/Action/Wiki/OfficialCertification/Command/RejectCertification/RejectCertificationAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\OfficialCertification\Command\RejectCertification;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationInput;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RejectCertificationAction
+{
+    public function __construct(
+        private RejectCertificationInterface $rejectCertification,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RejectCertificationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RejectCertificationInput(
+                    new CertificationIdentifier($request->certificationId()),
+                );
+                $output = new RejectCertificationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->rejectCertification->process($input, $output);
+                DB::commit();
+            } catch (OfficialCertificationNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('official_certification_not_found', $language), previous: $e);
+            } catch (OfficialCertificationInvalidStatusException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('official_certification_invalid_status', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/OfficialCertification/Command/RejectCertification/RejectCertificationRequest.php
+++ b/application/Http/Action/Wiki/OfficialCertification/Command/RejectCertification/RejectCertificationRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\OfficialCertification\Command\RejectCertification;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectCertificationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function certificationId(): string
+    {
+        return (string) $this->route('certificationId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/application/Http/Action/Wiki/OfficialCertification/Command/RequestCertification/RequestCertificationAction.php
+++ b/application/Http/Action/Wiki/OfficialCertification/Command/RequestCertification/RequestCertificationAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\OfficialCertification\Command\RequestCertification;
+
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationAlreadyRequestedException;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationInput;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationOutput;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class RequestCertificationAction
+{
+    public function __construct(
+        private RequestCertificationInterface $requestCertification,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(RequestCertificationRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new RequestCertificationInput(
+                    ResourceType::from($request->resourceType()),
+                    new WikiIdentifier($request->wikiId()),
+                    new AccountIdentifier($request->ownerAccountId()),
+                );
+                $output = new RequestCertificationOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->requestCertification->process($input, $output);
+                DB::commit();
+            } catch (OfficialCertificationAlreadyRequestedException $e) {
+                DB::rollBack();
+
+                throw new ConflictHttpException(detail: error_message('official_certification_already_requested', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/OfficialCertification/Command/RequestCertification/RequestCertificationRequest.php
+++ b/application/Http/Action/Wiki/OfficialCertification/Command/RequestCertification/RequestCertificationRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\OfficialCertification\Command\RequestCertification;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RequestCertificationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'resourceType' => ['required', 'string'],
+            'wikiId' => ['required', 'uuid'],
+            'ownerAccountId' => ['required', 'uuid'],
+        ];
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->input('wikiId');
+    }
+
+    public function ownerAccountId(): string
+    {
+        return (string) $this->input('ownerAccountId');
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -105,8 +105,14 @@ return [
 
     // ImageHideRequest
     'image_hide_request_not_found' => 'The specified image hide request was not found.',
-    'image_not_found' => 'The specified image was not found.',
     'image_hide_request_not_pending_for_approval' => 'Only pending image hide requests can be approved.',
     'image_hide_request_not_pending_for_rejection' => 'Only pending image hide requests can be rejected.',
     'image_hide_request_already_pending' => 'An image hide request is already pending for this image.',
+
+    // Wiki OfficialCertification
+    'official_certification_not_found' => 'The specified official certification was not found.',
+    'certification_not_pending_for_approval' => 'Only pending certifications can be approved.',
+    'certification_not_pending_for_rejection' => 'Only pending certifications can be rejected.',
+    'official_certification_already_requested' => 'An official certification has already been requested.',
+    'official_certification_invalid_status' => 'The certification status is invalid for this operation.',
 ];

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -105,8 +105,14 @@ return [
 
     // ImageHideRequest
     'image_hide_request_not_found' => 'No se encontró la solicitud de ocultación de imagen especificada.',
-    'image_not_found' => 'No se encontró la imagen especificada.',
     'image_hide_request_not_pending_for_approval' => 'Solo se pueden aprobar solicitudes de ocultación de imagen pendientes.',
     'image_hide_request_not_pending_for_rejection' => 'Solo se pueden rechazar solicitudes de ocultación de imagen pendientes.',
     'image_hide_request_already_pending' => 'Ya existe una solicitud de ocultación pendiente para esta imagen.',
+
+    // Wiki OfficialCertification
+    'official_certification_not_found' => 'No se encontró la certificación oficial especificada.',
+    'certification_not_pending_for_approval' => 'Solo se pueden aprobar las certificaciones pendientes.',
+    'certification_not_pending_for_rejection' => 'Solo se pueden rechazar las certificaciones pendientes.',
+    'official_certification_already_requested' => 'Ya se ha solicitado una certificación oficial.',
+    'official_certification_invalid_status' => 'El estado de la certificación es inválido para esta operación.',
 ];

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -105,8 +105,14 @@ return [
 
     // ImageHideRequest
     'image_hide_request_not_found' => '指定された画像非表示リクエストが見つかりません。',
-    'image_not_found' => '指定された画像が見つかりません。',
     'image_hide_request_not_pending_for_approval' => '保留中以外の画像非表示リクエストは承認できません。',
     'image_hide_request_not_pending_for_rejection' => '保留中以外の画像非表示リクエストは拒否できません。',
     'image_hide_request_already_pending' => 'この画像に対する非表示リクエストは既に保留中です。',
+
+    // Wiki OfficialCertification
+    'official_certification_not_found' => '指定された公式認定が見つかりません。',
+    'certification_not_pending_for_approval' => '保留中の公式認定のみ承認できます。',
+    'certification_not_pending_for_rejection' => '保留中の公式認定のみ却下できます。',
+    'official_certification_already_requested' => '公式認定は既に申請されています。',
+    'official_certification_invalid_status' => '公式認定のステータスがこの操作に対して無効です。',
 ];

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -105,8 +105,14 @@ return [
 
     // ImageHideRequest
     'image_hide_request_not_found' => '지정된 이미지 숨김 요청을 찾을 수 없습니다.',
-    'image_not_found' => '지정된 이미지를 찾을 수 없습니다.',
     'image_hide_request_not_pending_for_approval' => '대기 중인 이미지 숨김 요청만 승인할 수 있습니다.',
     'image_hide_request_not_pending_for_rejection' => '대기 중인 이미지 숨김 요청만 거부할 수 있습니다.',
     'image_hide_request_already_pending' => '이 이미지에 대한 숨김 요청이 이미 대기 중입니다.',
+
+    // Wiki OfficialCertification
+    'official_certification_not_found' => '지정된 공식 인증을 찾을 수 없습니다.',
+    'certification_not_pending_for_approval' => '보류 중인 공식 인증만 승인할 수 있습니다.',
+    'certification_not_pending_for_rejection' => '보류 중인 공식 인증만 거부할 수 있습니다.',
+    'official_certification_already_requested' => '공식 인증이 이미 신청되었습니다.',
+    'official_certification_invalid_status' => '공식 인증의 상태가 이 작업에 대해 유효하지 않습니다.',
 ];

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -105,8 +105,14 @@ return [
 
     // ImageHideRequest
     'image_hide_request_not_found' => '未找到指定的图片隐藏请求。',
-    'image_not_found' => '未找到指定的图片。',
     'image_hide_request_not_pending_for_approval' => '只能批准待处理的图片隐藏请求。',
     'image_hide_request_not_pending_for_rejection' => '只能拒绝待处理的图片隐藏请求。',
     'image_hide_request_already_pending' => '该图片已存在待处理的隐藏请求。',
+
+    // Wiki OfficialCertification
+    'official_certification_not_found' => '找不到指定的官方认证。',
+    'certification_not_pending_for_approval' => '只能批准待处理的官方认证。',
+    'certification_not_pending_for_rejection' => '只能拒绝待处理的官方认证。',
+    'official_certification_already_requested' => '官方认证已被申请。',
+    'official_certification_invalid_status' => '官方认证的状态对此操作无效。',
 ];

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -105,8 +105,14 @@ return [
 
     // ImageHideRequest
     'image_hide_request_not_found' => '未找到指定的圖片隱藏請求。',
-    'image_not_found' => '未找到指定的圖片。',
     'image_hide_request_not_pending_for_approval' => '只能批准待處理的圖片隱藏請求。',
     'image_hide_request_not_pending_for_rejection' => '只能拒絕待處理的圖片隱藏請求。',
     'image_hide_request_already_pending' => '該圖片已存在待處理的隱藏請求。',
+
+    // Wiki OfficialCertification
+    'official_certification_not_found' => '找不到指定的官方認證。',
+    'certification_not_pending_for_approval' => '只能核准待處理的官方認證。',
+    'certification_not_pending_for_rejection' => '只能拒絕待處理的官方認證。',
+    'official_certification_already_requested' => '官方認證已被申請。',
+    'official_certification_invalid_status' => '官方認證的狀態對此操作無效。',
 ];

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -11,6 +11,9 @@ use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\
 use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\CreatePolicy\CreatePolicyAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification\ApproveCertificationAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\RejectCertification\RejectCertificationAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\RequestCertification\RequestCertificationAction;
 use Application\Http\Action\Wiki\Principal\Command\CreatePrincipal\CreatePrincipalAction;
 use Application\Http\Action\Wiki\Principal\Command\CreatePrincipalGroup\CreatePrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\CreateRole\CreateRoleAction;
@@ -72,3 +75,8 @@ Route::delete('/policy/{policyId}', DeletePolicyAction::class);
 Route::post('/image-hide-request/create', RequestImageHideAction::class);
 Route::post('/image-hide-request/{requestId}/approve', ApproveImageHideRequestAction::class);
 Route::post('/image-hide-request/{requestId}/reject', RejectImageHideRequestAction::class);
+
+// OfficialCertification
+Route::post('/official-certification/request', RequestCertificationAction::class);
+Route::post('/official-certification/{certificationId}/approve', ApproveCertificationAction::class);
+Route::post('/official-certification/{certificationId}/reject', RejectCertificationAction::class);

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertification.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertification.php
@@ -7,7 +7,6 @@ namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveC
 use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
 use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
 use Source\Wiki\OfficialCertification\Application\Service\OfficialResourceUpdaterInterface;
-use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
 use Source\Wiki\OfficialCertification\Domain\Repository\OfficialCertificationRepositoryInterface;
 
 readonly class ApproveCertification implements ApproveCertificationInterface
@@ -18,7 +17,7 @@ readonly class ApproveCertification implements ApproveCertificationInterface
     ) {
     }
 
-    public function process(ApproveCertificationInputPort $input): OfficialCertification
+    public function process(ApproveCertificationInputPort $input, ApproveCertificationOutputPort $output): void
     {
         $certification = $this->repository->findById($input->certificationIdentifier());
 
@@ -40,6 +39,6 @@ readonly class ApproveCertification implements ApproveCertificationInterface
             $certification->ownerAccountIdentifier(),
         );
 
-        return $certification;
+        $output->setOfficialCertification($certification);
     }
 }

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationInterface.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationInterface.php
@@ -4,9 +4,17 @@ declare(strict_types=1);
 
 namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification;
 
-use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
 
 interface ApproveCertificationInterface
 {
-    public function process(ApproveCertificationInputPort $input): OfficialCertification;
+    /**
+     * @param ApproveCertificationInputPort $input
+     * @param ApproveCertificationOutputPort $output
+     * @return void
+     * @throws OfficialCertificationNotFoundException
+     * @throws OfficialCertificationInvalidStatusException
+     */
+    public function process(ApproveCertificationInputPort $input, ApproveCertificationOutputPort $output): void;
 }

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationOutput.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification;
+
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+
+class ApproveCertificationOutput implements ApproveCertificationOutputPort
+{
+    private ?OfficialCertification $officialCertification = null;
+
+    public function setOfficialCertification(OfficialCertification $officialCertification): void
+    {
+        $this->officialCertification = $officialCertification;
+    }
+
+    /**
+     * @return array{certificationIdentifier: ?string, resourceType: ?string, wikiIdentifier: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->officialCertification === null) {
+            return [
+                'certificationIdentifier' => null,
+                'resourceType' => null,
+                'wikiIdentifier' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'certificationIdentifier' => (string) $this->officialCertification->certificationIdentifier(),
+            'resourceType' => $this->officialCertification->resourceType()->value,
+            'wikiIdentifier' => (string) $this->officialCertification->wikiIdentifier(),
+            'status' => $this->officialCertification->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationOutputPort.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification;
+
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+
+interface ApproveCertificationOutputPort
+{
+    public function setOfficialCertification(OfficialCertification $officialCertification): void;
+
+    /**
+     * @return array{certificationIdentifier: ?string, resourceType: ?string, wikiIdentifier: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertification.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertification.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCe
 
 use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
 use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
-use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
 use Source\Wiki\OfficialCertification\Domain\Repository\OfficialCertificationRepositoryInterface;
 
 readonly class RejectCertification implements RejectCertificationInterface
@@ -18,10 +17,12 @@ readonly class RejectCertification implements RejectCertificationInterface
 
     /**
      * @param RejectCertificationInputPort $input
-     * @return OfficialCertification
+     * @param RejectCertificationOutputPort $output
+     * @return void
      * @throws OfficialCertificationNotFoundException
+     * @throws OfficialCertificationInvalidStatusException
      */
-    public function process(RejectCertificationInputPort $input): OfficialCertification
+    public function process(RejectCertificationInputPort $input, RejectCertificationOutputPort $output): void
     {
         $certification = $this->repository->findById($input->certificationIdentifier());
 
@@ -37,6 +38,6 @@ readonly class RejectCertification implements RejectCertificationInterface
 
         $this->repository->save($certification);
 
-        return $certification;
+        $output->setOfficialCertification($certification);
     }
 }

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationInterface.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationInterface.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification;
 
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
 use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
-use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
 
 interface RejectCertificationInterface
 {
     /**
      * @param RejectCertificationInputPort $input
-     * @return OfficialCertification
+     * @param RejectCertificationOutputPort $output
+     * @return void
      * @throws OfficialCertificationNotFoundException
+     * @throws OfficialCertificationInvalidStatusException
      */
-    public function process(RejectCertificationInputPort $input): OfficialCertification;
+    public function process(RejectCertificationInputPort $input, RejectCertificationOutputPort $output): void;
 }

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationOutput.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification;
+
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+
+class RejectCertificationOutput implements RejectCertificationOutputPort
+{
+    private ?OfficialCertification $officialCertification = null;
+
+    public function setOfficialCertification(OfficialCertification $officialCertification): void
+    {
+        $this->officialCertification = $officialCertification;
+    }
+
+    /**
+     * @return array{certificationIdentifier: ?string, resourceType: ?string, wikiIdentifier: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->officialCertification === null) {
+            return [
+                'certificationIdentifier' => null,
+                'resourceType' => null,
+                'wikiIdentifier' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'certificationIdentifier' => (string) $this->officialCertification->certificationIdentifier(),
+            'resourceType' => $this->officialCertification->resourceType()->value,
+            'wikiIdentifier' => (string) $this->officialCertification->wikiIdentifier(),
+            'status' => $this->officialCertification->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationOutputPort.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification;
+
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+
+interface RejectCertificationOutputPort
+{
+    public function setOfficialCertification(OfficialCertification $officialCertification): void;
+
+    /**
+     * @return array{certificationIdentifier: ?string, resourceType: ?string, wikiIdentifier: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertification.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertification.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification;
 
 use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationAlreadyRequestedException;
-use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
 use Source\Wiki\OfficialCertification\Domain\Factory\OfficialCertificationFactoryInterface;
 use Source\Wiki\OfficialCertification\Domain\Repository\OfficialCertificationRepositoryInterface;
 
@@ -19,9 +18,11 @@ readonly class RequestCertification implements RequestCertificationInterface
 
     /**
      * @param RequestCertificationInputPort $input
-     * @return OfficialCertification
+     * @param RequestCertificationOutputPort $output
+     * @return void
+     * @throws OfficialCertificationAlreadyRequestedException
      */
-    public function process(RequestCertificationInputPort $input): OfficialCertification
+    public function process(RequestCertificationInputPort $input, RequestCertificationOutputPort $output): void
     {
         $existing = $this->repository->findByResource(
             $input->resourceType(),
@@ -40,6 +41,6 @@ readonly class RequestCertification implements RequestCertificationInterface
 
         $this->repository->save($certification);
 
-        return $certification;
+        $output->setOfficialCertification($certification);
     }
 }

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationInterface.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationInterface.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification;
 
-use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationAlreadyRequestedException;
 
 interface RequestCertificationInterface
 {
     /**
      * @param RequestCertificationInputPort $input
-     * @return OfficialCertification
+     * @param RequestCertificationOutputPort $output
+     * @return void
+     * @throws OfficialCertificationAlreadyRequestedException
      */
-    public function process(RequestCertificationInputPort $input): OfficialCertification;
+    public function process(RequestCertificationInputPort $input, RequestCertificationOutputPort $output): void;
 }

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationOutput.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification;
+
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+
+class RequestCertificationOutput implements RequestCertificationOutputPort
+{
+    private ?OfficialCertification $officialCertification = null;
+
+    public function setOfficialCertification(OfficialCertification $officialCertification): void
+    {
+        $this->officialCertification = $officialCertification;
+    }
+
+    /**
+     * @return array{certificationIdentifier: ?string, resourceType: ?string, wikiIdentifier: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->officialCertification === null) {
+            return [
+                'certificationIdentifier' => null,
+                'resourceType' => null,
+                'wikiIdentifier' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'certificationIdentifier' => (string) $this->officialCertification->certificationIdentifier(),
+            'resourceType' => $this->officialCertification->resourceType()->value,
+            'wikiIdentifier' => (string) $this->officialCertification->wikiIdentifier(),
+            'status' => $this->officialCertification->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationOutputPort.php
+++ b/src/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification;
+
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+
+interface RequestCertificationOutputPort
+{
+    public function setOfficialCertification(OfficialCertification $officialCertification): void;
+
+    /**
+     * @return array{certificationIdentifier: ?string, resourceType: ?string, wikiIdentifier: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/OfficialCertification/Domain/Entity/OfficialCertification.php
+++ b/src/Wiki/OfficialCertification/Domain/Entity/OfficialCertification.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Source\Wiki\OfficialCertification\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Domain\Exception\CertificationNotPendingForApprovalException;
+use Source\Wiki\OfficialCertification\Domain\Exception\CertificationNotPendingForRejectionException;
 use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
 use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -69,7 +70,7 @@ class OfficialCertification
     public function approve(): void
     {
         if (! $this->status->isPending()) {
-            throw new DomainException('Only pending certifications can be approved.');
+            throw new CertificationNotPendingForApprovalException();
         }
 
         $this->status = CertificationStatus::APPROVED;
@@ -79,7 +80,7 @@ class OfficialCertification
     public function reject(): void
     {
         if (! $this->status->isPending()) {
-            throw new DomainException('Only pending certifications can be rejected.');
+            throw new CertificationNotPendingForRejectionException();
         }
 
         $this->status = CertificationStatus::REJECTED;

--- a/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForApprovalException.php
+++ b/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForApprovalException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Domain\Exception;
+
+use DomainException;
+
+class CertificationNotPendingForApprovalException extends DomainException
+{
+    public function __construct(
+        string $message = 'Only pending certifications can be approved.',
+    ) {
+        parent::__construct($message, 0);
+    }
+}

--- a/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForRejectionException.php
+++ b/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForRejectionException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\OfficialCertification\Domain\Exception;
+
+use DomainException;
+
+class CertificationNotPendingForRejectionException extends DomainException
+{
+    public function __construct(
+        string $message = 'Only pending certifications can be rejected.',
+    ) {
+        parent::__construct($message, 0);
+    }
+}

--- a/tests/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationOutputTest.php
+++ b/tests/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationOutputTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ApproveCertificationOutputTest extends TestCase
+{
+    /**
+     * 正常系: OfficialCertificationがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithOfficialCertification(): void
+    {
+        $certificationIdentifier = new CertificationIdentifier(StrTestHelper::generateUuid());
+        $wikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+
+        $certification = new OfficialCertification(
+            $certificationIdentifier,
+            ResourceType::AGENCY,
+            $wikiIdentifier,
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            CertificationStatus::APPROVED,
+            new DateTimeImmutable(),
+            new DateTimeImmutable(),
+            null,
+        );
+
+        $output = new ApproveCertificationOutput();
+        $output->setOfficialCertification($certification);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $certificationIdentifier, $result['certificationIdentifier']);
+        $this->assertSame(ResourceType::AGENCY->value, $result['resourceType']);
+        $this->assertSame((string) $wikiIdentifier, $result['wikiIdentifier']);
+        $this->assertSame(CertificationStatus::APPROVED->value, $result['status']);
+    }
+
+    /**
+     * 正常系: OfficialCertificationが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutOfficialCertification(): void
+    {
+        $output = new ApproveCertificationOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['certificationIdentifier']);
+        $this->assertNull($result['resourceType']);
+        $this->assertNull($result['wikiIdentifier']);
+        $this->assertNull($result['status']);
+    }
+}

--- a/tests/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationTest.php
+++ b/tests/Wiki/OfficialCertification/Application/UseCase/Command/ApproveCertification/ApproveCertificationTest.php
@@ -14,6 +14,7 @@ use Source\Wiki\OfficialCertification\Application\Service\OfficialResourceUpdate
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertification;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInput;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationOutput;
 use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
 use Source\Wiki\OfficialCertification\Domain\Repository\OfficialCertificationRepositoryInterface;
 use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
@@ -79,11 +80,12 @@ class ApproveCertificationTest extends TestCase
         $useCase = $this->app->make(ApproveCertificationInterface::class);
 
         $input = new ApproveCertificationInput($certificationId);
+        $output = new ApproveCertificationOutput();
 
-        $result = $useCase->process($input);
+        $useCase->process($input, $output);
 
-        $this->assertTrue($result->isApproved());
-        $this->assertNotNull($result->approvedAt());
+        $this->assertTrue($certification->isApproved());
+        $this->assertNotNull($certification->approvedAt());
     }
 
     public function testProcessWhenNotFound(): void
@@ -105,9 +107,11 @@ class ApproveCertificationTest extends TestCase
 
         $input = new ApproveCertificationInput($certificationId);
 
+        $output = new ApproveCertificationOutput();
+
         $this->expectException(OfficialCertificationNotFoundException::class);
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 
     public function testProcessWhenInvalidStatus(): void
@@ -139,8 +143,10 @@ class ApproveCertificationTest extends TestCase
 
         $input = new ApproveCertificationInput($certificationId);
 
+        $output = new ApproveCertificationOutput();
+
         $this->expectException(OfficialCertificationInvalidStatusException::class);
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 }

--- a/tests/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationOutputTest.php
+++ b/tests/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationOutputTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RejectCertificationOutputTest extends TestCase
+{
+    /**
+     * 正常系: OfficialCertificationがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithOfficialCertification(): void
+    {
+        $certificationIdentifier = new CertificationIdentifier(StrTestHelper::generateUuid());
+        $wikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+
+        $certification = new OfficialCertification(
+            $certificationIdentifier,
+            ResourceType::GROUP,
+            $wikiIdentifier,
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            CertificationStatus::REJECTED,
+            new DateTimeImmutable(),
+            null,
+            new DateTimeImmutable(),
+        );
+
+        $output = new RejectCertificationOutput();
+        $output->setOfficialCertification($certification);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $certificationIdentifier, $result['certificationIdentifier']);
+        $this->assertSame(ResourceType::GROUP->value, $result['resourceType']);
+        $this->assertSame((string) $wikiIdentifier, $result['wikiIdentifier']);
+        $this->assertSame(CertificationStatus::REJECTED->value, $result['status']);
+    }
+
+    /**
+     * 正常系: OfficialCertificationが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutOfficialCertification(): void
+    {
+        $output = new RejectCertificationOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['certificationIdentifier']);
+        $this->assertNull($result['resourceType']);
+        $this->assertNull($result['wikiIdentifier']);
+        $this->assertNull($result['status']);
+    }
+}

--- a/tests/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationTest.php
+++ b/tests/Wiki/OfficialCertification/Application/UseCase/Command/RejectCertification/RejectCertificationTest.php
@@ -13,6 +13,7 @@ use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificatio
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertification;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationInput;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationOutput;
 use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
 use Source\Wiki\OfficialCertification\Domain\Repository\OfficialCertificationRepositoryInterface;
 use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
@@ -66,11 +67,12 @@ class RejectCertificationTest extends TestCase
         $useCase = $this->app->make(RejectCertificationInterface::class);
 
         $input = new RejectCertificationInput($certificationId);
+        $output = new RejectCertificationOutput();
 
-        $result = $useCase->process($input);
+        $useCase->process($input, $output);
 
-        $this->assertTrue($result->isRejected());
-        $this->assertNotNull($result->rejectedAt());
+        $this->assertTrue($certification->isRejected());
+        $this->assertNotNull($certification->rejectedAt());
     }
 
     public function testProcessWhenNotFound(): void
@@ -89,9 +91,11 @@ class RejectCertificationTest extends TestCase
 
         $input = new RejectCertificationInput($certificationId);
 
+        $output = new RejectCertificationOutput();
+
         $this->expectException(OfficialCertificationNotFoundException::class);
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 
     public function testProcessWhenInvalidStatus(): void
@@ -120,8 +124,10 @@ class RejectCertificationTest extends TestCase
 
         $input = new RejectCertificationInput($certificationId);
 
+        $output = new RejectCertificationOutput();
+
         $this->expectException(OfficialCertificationInvalidStatusException::class);
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 }

--- a/tests/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationOutputTest.php
+++ b/tests/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationOutputTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification;
+
+use DateTimeImmutable;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RequestCertificationOutputTest extends TestCase
+{
+    /**
+     * 正常系: OfficialCertificationがセットされるとtoArrayが正しい値を返すこと.
+     */
+    public function testToArrayWithOfficialCertification(): void
+    {
+        $certificationIdentifier = new CertificationIdentifier(StrTestHelper::generateUuid());
+        $wikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+
+        $certification = new OfficialCertification(
+            $certificationIdentifier,
+            ResourceType::TALENT,
+            $wikiIdentifier,
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            CertificationStatus::PENDING,
+            new DateTimeImmutable(),
+            null,
+            null,
+        );
+
+        $output = new RequestCertificationOutput();
+        $output->setOfficialCertification($certification);
+
+        $result = $output->toArray();
+
+        $this->assertSame((string) $certificationIdentifier, $result['certificationIdentifier']);
+        $this->assertSame(ResourceType::TALENT->value, $result['resourceType']);
+        $this->assertSame((string) $wikiIdentifier, $result['wikiIdentifier']);
+        $this->assertSame(CertificationStatus::PENDING->value, $result['status']);
+    }
+
+    /**
+     * 正常系: OfficialCertificationが未セットの場合toArrayがnull値の配列を返すこと.
+     */
+    public function testToArrayWithoutOfficialCertification(): void
+    {
+        $output = new RequestCertificationOutput();
+
+        $result = $output->toArray();
+
+        $this->assertNull($result['certificationIdentifier']);
+        $this->assertNull($result['resourceType']);
+        $this->assertNull($result['wikiIdentifier']);
+        $this->assertNull($result['status']);
+    }
+}

--- a/tests/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationTest.php
+++ b/tests/Wiki/OfficialCertification/Application/UseCase/Command/RequestCertification/RequestCertificationTest.php
@@ -12,6 +12,7 @@ use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificatio
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertification;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationInput;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationOutput;
 use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
 use Source\Wiki\OfficialCertification\Domain\Factory\OfficialCertificationFactoryInterface;
 use Source\Wiki\OfficialCertification\Domain\Repository\OfficialCertificationRepositoryInterface;
@@ -82,10 +83,14 @@ class RequestCertificationTest extends TestCase
             $ownerAccountIdentifier,
         );
 
-        $certification = $useCase->process($input);
+        $output = new RequestCertificationOutput();
 
-        $this->assertSame($certificationId, (string) $certification->certificationIdentifier());
-        $this->assertTrue($certification->status()->isPending());
+        $useCase->process($input, $output);
+
+        $result = $output->toArray();
+
+        $this->assertSame($certificationId, $result['certificationIdentifier']);
+        $this->assertSame(CertificationStatus::PENDING->value, $result['status']);
     }
 
     public function testProcessWhenAlreadyRequested(): void
@@ -121,8 +126,10 @@ class RequestCertificationTest extends TestCase
             new AccountIdentifier(StrTestHelper::generateUuid()),
         );
 
+        $output = new RequestCertificationOutput();
+
         $this->expectException(OfficialCertificationAlreadyRequestedException::class);
 
-        $useCase->process($input);
+        $useCase->process($input, $output);
     }
 }

--- a/tests/Wiki/OfficialCertification/Domain/Entity/OfficialCertificationTest.php
+++ b/tests/Wiki/OfficialCertification/Domain/Entity/OfficialCertificationTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Tests\Wiki\OfficialCertification\Domain\Entity;
 
 use DateTimeImmutable;
-use DomainException;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Domain\Exception\CertificationNotPendingForApprovalException;
+use Source\Wiki\OfficialCertification\Domain\Exception\CertificationNotPendingForRejectionException;
 use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
 use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -100,7 +101,7 @@ class OfficialCertificationTest extends TestCase
             null,
         );
 
-        $this->expectException(DomainException::class);
+        $this->expectException(CertificationNotPendingForApprovalException::class);
 
         $certification->approve();
     }
@@ -123,7 +124,7 @@ class OfficialCertificationTest extends TestCase
             null,
         );
 
-        $this->expectException(DomainException::class);
+        $this->expectException(CertificationNotPendingForRejectionException::class);
 
         $certification->reject();
     }

--- a/tests/Wiki/OfficialCertification/Http/Action/Command/ApproveCertification/ApproveCertificationActionTest.php
+++ b/tests/Wiki/OfficialCertification/Http/Action/Command/ApproveCertification/ApproveCertificationActionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\OfficialCertification\Http\Action\Command\ApproveCertification;
+
+use Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification\ApproveCertificationAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification\ApproveCertificationRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInput;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ApproveCertificationActionTest extends TestCase
+{
+    /**
+     * 正常系: 承認成功時にHTTP 200を返すこと.
+     */
+    public function testInvokeReturnsOkResponse(): void
+    {
+        $certificationIdentifier = StrTestHelper::generateUuid();
+        $wikiIdentifier = StrTestHelper::generateUuid();
+
+        /** @var ApproveCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(ApproveCertificationRequest::class);
+        $request->shouldReceive('certificationId')->andReturn($certificationIdentifier);
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var ApproveCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(ApproveCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(ApproveCertificationInput::class),
+                Mockery::on(function ($output) use ($certificationIdentifier, $wikiIdentifier): bool {
+                    if (! $output instanceof ApproveCertificationOutput) {
+                        return false;
+                    }
+
+                    $output->setOfficialCertification(new OfficialCertification(
+                        new CertificationIdentifier($certificationIdentifier),
+                        ResourceType::AGENCY,
+                        new WikiIdentifier($wikiIdentifier),
+                        new AccountIdentifier(StrTestHelper::generateUuid()),
+                        CertificationStatus::APPROVED,
+                        new DateTimeImmutable(),
+                        new DateTimeImmutable(),
+                        null,
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new ApproveCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($certificationIdentifier, $payload['certificationIdentifier']);
+        $this->assertSame(ResourceType::AGENCY->value, $payload['resourceType']);
+        $this->assertSame($wikiIdentifier, $payload['wikiIdentifier']);
+        $this->assertSame(CertificationStatus::APPROVED->value, $payload['status']);
+    }
+
+    /**
+     * 異常系: 公式認定が見つからない場合にHTTP 404を返すこと.
+     */
+    public function testInvokeReturnsNotFoundResponseWhenCertificationNotFound(): void
+    {
+        /** @var ApproveCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(ApproveCertificationRequest::class);
+        $request->shouldReceive('certificationId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var ApproveCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(ApproveCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new OfficialCertificationNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new ApproveCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('official_certification_not_found', 'en'), $payload['detail']);
+    }
+
+    /**
+     * 異常系: ステータスが無効な場合にHTTP 409を返すこと.
+     */
+    public function testInvokeReturnsConflictResponseWhenInvalidStatus(): void
+    {
+        /** @var ApproveCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(ApproveCertificationRequest::class);
+        $request->shouldReceive('certificationId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var ApproveCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(ApproveCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new OfficialCertificationInvalidStatusException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new ApproveCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('official_certification_invalid_status', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/OfficialCertification/Http/Action/Command/RejectCertification/RejectCertificationActionTest.php
+++ b/tests/Wiki/OfficialCertification/Http/Action/Command/RejectCertification/RejectCertificationActionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\OfficialCertification\Http\Action\Command\RejectCertification;
+
+use Application\Http\Action\Wiki\OfficialCertification\Command\RejectCertification\RejectCertificationAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\RejectCertification\RejectCertificationRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationInvalidStatusException;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationNotFoundException;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationInput;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RejectCertificationActionTest extends TestCase
+{
+    /**
+     * 正常系: 却下成功時にHTTP 200を返すこと.
+     */
+    public function testInvokeReturnsOkResponse(): void
+    {
+        $certificationIdentifier = StrTestHelper::generateUuid();
+        $wikiIdentifier = StrTestHelper::generateUuid();
+
+        /** @var RejectCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RejectCertificationRequest::class);
+        $request->shouldReceive('certificationId')->andReturn($certificationIdentifier);
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var RejectCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RejectCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(RejectCertificationInput::class),
+                Mockery::on(function ($output) use ($certificationIdentifier, $wikiIdentifier): bool {
+                    if (! $output instanceof RejectCertificationOutput) {
+                        return false;
+                    }
+
+                    $output->setOfficialCertification(new OfficialCertification(
+                        new CertificationIdentifier($certificationIdentifier),
+                        ResourceType::GROUP,
+                        new WikiIdentifier($wikiIdentifier),
+                        new AccountIdentifier(StrTestHelper::generateUuid()),
+                        CertificationStatus::REJECTED,
+                        new DateTimeImmutable(),
+                        null,
+                        new DateTimeImmutable(),
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new RejectCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame($certificationIdentifier, $payload['certificationIdentifier']);
+        $this->assertSame(ResourceType::GROUP->value, $payload['resourceType']);
+        $this->assertSame($wikiIdentifier, $payload['wikiIdentifier']);
+        $this->assertSame(CertificationStatus::REJECTED->value, $payload['status']);
+    }
+
+    /**
+     * 異常系: 公式認定が見つからない場合にHTTP 404を返すこと.
+     */
+    public function testInvokeReturnsNotFoundResponseWhenCertificationNotFound(): void
+    {
+        /** @var RejectCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RejectCertificationRequest::class);
+        $request->shouldReceive('certificationId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var RejectCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RejectCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new OfficialCertificationNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new RejectCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('official_certification_not_found', 'en'), $payload['detail']);
+    }
+
+    /**
+     * 異常系: ステータスが無効な場合にHTTP 409を返すこと.
+     */
+    public function testInvokeReturnsConflictResponseWhenInvalidStatus(): void
+    {
+        /** @var RejectCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RejectCertificationRequest::class);
+        $request->shouldReceive('certificationId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var RejectCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RejectCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new OfficialCertificationInvalidStatusException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new RejectCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('official_certification_invalid_status', 'en'), $payload['detail']);
+    }
+}

--- a/tests/Wiki/OfficialCertification/Http/Action/Command/RequestCertification/RequestCertificationActionTest.php
+++ b/tests/Wiki/OfficialCertification/Http/Action/Command/RequestCertification/RequestCertificationActionTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\OfficialCertification\Http\Action\Command\RequestCertification;
+
+use Application\Http\Action\Wiki\OfficialCertification\Command\RequestCertification\RequestCertificationAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\RequestCertification\RequestCertificationRequest;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\OfficialCertification\Application\Exception\OfficialCertificationAlreadyRequestedException;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationInput;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationInterface;
+use Source\Wiki\OfficialCertification\Application\UseCase\Command\RequestCertification\RequestCertificationOutput;
+use Source\Wiki\OfficialCertification\Domain\Entity\OfficialCertification;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationIdentifier;
+use Source\Wiki\OfficialCertification\Domain\ValueObject\CertificationStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class RequestCertificationActionTest extends TestCase
+{
+    /**
+     * 正常系: 申請成功時にHTTP 201を返すこと.
+     */
+    public function testInvokeReturnsCreatedResponse(): void
+    {
+        $certificationIdentifier = StrTestHelper::generateUuid();
+        $wikiIdentifier = StrTestHelper::generateUuid();
+        $ownerAccountIdentifier = StrTestHelper::generateUuid();
+
+        /** @var RequestCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RequestCertificationRequest::class);
+        $request->shouldReceive('resourceType')->andReturn(ResourceType::AGENCY->value);
+        $request->shouldReceive('wikiId')->andReturn($wikiIdentifier);
+        $request->shouldReceive('ownerAccountId')->andReturn($ownerAccountIdentifier);
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var RequestCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RequestCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(RequestCertificationInput::class),
+                Mockery::on(function ($output) use ($certificationIdentifier, $wikiIdentifier, $ownerAccountIdentifier): bool {
+                    if (! $output instanceof RequestCertificationOutput) {
+                        return false;
+                    }
+
+                    $output->setOfficialCertification(new OfficialCertification(
+                        new CertificationIdentifier($certificationIdentifier),
+                        ResourceType::AGENCY,
+                        new WikiIdentifier($wikiIdentifier),
+                        new AccountIdentifier($ownerAccountIdentifier),
+                        CertificationStatus::PENDING,
+                        new DateTimeImmutable(),
+                        null,
+                        null,
+                    ));
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new RequestCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame($certificationIdentifier, $payload['certificationIdentifier']);
+        $this->assertSame(ResourceType::AGENCY->value, $payload['resourceType']);
+        $this->assertSame($wikiIdentifier, $payload['wikiIdentifier']);
+        $this->assertSame(CertificationStatus::PENDING->value, $payload['status']);
+    }
+
+    /**
+     * 異常系: 既に申請済みの場合にHTTP 409を返すこと.
+     */
+    public function testInvokeReturnsConflictResponseWhenAlreadyRequested(): void
+    {
+        /** @var RequestCertificationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RequestCertificationRequest::class);
+        $request->shouldReceive('resourceType')->andReturn(ResourceType::AGENCY->value);
+        $request->shouldReceive('wikiId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('ownerAccountId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var RequestCertificationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RequestCertificationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new OfficialCertificationAlreadyRequestedException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new RequestCertificationAction($useCase, $logger);
+
+        $response = $action($request);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(error_message('official_certification_already_requested', 'en'), $payload['detail']);
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

- OfficialCertificationサブドメインにOutputパターン（OutputPort / Output）を導入
- 汎用例外から独自例外（`CertificationNotPendingForApprovalException`, `CertificationNotPendingForRejectionException`）へ移行
- 3つのHTTPエンドポイント（ApproveCertification, RejectCertification, RequestCertification）を作成
- 各UseCaseのOutputテスト、UseCaseテスト、Actionテストを追加
- 多言語（ja/en/es/ko/zh_CN/zh_TW）のエラーメッセージを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)

## 🎯 変更理由・背景

OfficialCertification（公認認定）サブドメインにおいて、UseCaseの出力をOutputパターンで統一し、エラーハンドリングを独自例外に移行することで、ドメインロジックの明確化とHTTP層との責務分離を実現する。また、対応するAPIエンドポイントを作成し、クライアントからの利用を可能にする。

## 🧪 テスト

### テストの実行確認

- [x] `make check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- OutputPort / Output パターンの実装が他サブドメイン（Image, ImageHideRequest, Principal等）と一貫しているか
- 独自例外（`CertificationNotPendingForApprovalException`, `CertificationNotPendingForRejectionException`）の命名とハンドリング
- ActionクラスでのDB::transaction内のエラーハンドリングとHTTP例外への変換

## 📖 関連情報

### 関連Issue・タスク

Closes #274

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した