### PR TITLE
refactor: event()グローバル関数をEventDispatcherInterface経由に置き換え

### DIFF
--- a/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
+++ b/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
@@ -11,6 +11,7 @@ use Source\Account\Invitation\Application\Exception\InvitationNotFoundException;
 use Source\Account\Invitation\Domain\Event\InvitationAccepted;
 use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class IdentityCreatedViaInvitationHandler
 {
@@ -20,6 +21,7 @@ readonly class IdentityCreatedViaInvitationHandler
         private InvitationRepositoryInterface $invitationRepository,
         private IdentityGroupRepositoryInterface $identityGroupRepository,
         private IdentityGroupFactoryInterface $identityGroupFactory,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -53,7 +55,7 @@ readonly class IdentityCreatedViaInvitationHandler
         $invitation->accept($event->identityIdentifier);
         $this->invitationRepository->save($invitation);
 
-        event(new InvitationAccepted(
+        $this->eventDispatcher->dispatch(new InvitationAccepted(
             invitationIdentifier: $invitation->invitationIdentifier(),
             accountIdentifier: $invitation->accountIdentifier(),
             acceptedByIdentityIdentifier: $event->identityIdentifier,

--- a/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitation.php
+++ b/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitation.php
@@ -10,6 +10,7 @@ use Source\Account\Invitation\Application\Exception\DisallowedInvitationExceptio
 use Source\Account\Invitation\Domain\Event\InvitationCreated;
 use Source\Account\Invitation\Domain\Factory\InvitationFactoryInterface;
 use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class CreateInvitation implements CreateInvitationInterface
 {
@@ -17,6 +18,7 @@ readonly class CreateInvitation implements CreateInvitationInterface
         private InvitationRepositoryInterface $invitationRepository,
         private InvitationFactoryInterface $invitationFactory,
         private IdentityGroupRepositoryInterface $identityGroupRepository,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -44,7 +46,7 @@ readonly class CreateInvitation implements CreateInvitationInterface
 
             $this->invitationRepository->save($invitation);
 
-            event(new InvitationCreated(
+            $this->eventDispatcher->dispatch(new InvitationCreated(
                 invitationIdentifier: $invitation->invitationIdentifier(),
                 accountIdentifier: $invitation->accountIdentifier(),
                 invitedByIdentityIdentifier: $invitation->invitedByIdentityIdentifier(),

--- a/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentity.php
+++ b/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentity.php
@@ -13,6 +13,7 @@ use Source\Identity\Domain\Factory\IdentityFactoryInterface;
 use Source\Identity\Domain\Repository\AuthCodeSessionRepositoryInterface;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Application\Service\ImageServiceInterface;
 
 readonly class CreateIdentity implements CreateIdentityInterface
@@ -22,6 +23,7 @@ readonly class CreateIdentity implements CreateIdentityInterface
         private IdentityFactoryInterface $identityFactory,
         private ImageServiceInterface $imageService,
         private IdentityRepositoryInterface $identityRepository,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -67,7 +69,7 @@ readonly class CreateIdentity implements CreateIdentityInterface
         $this->identityRepository->save($identity);
 
         if ($input->invitationToken() !== null) {
-            event(new IdentityCreatedViaInvitation(
+            $this->eventDispatcher->dispatch(new IdentityCreatedViaInvitation(
                 identityIdentifier: $identity->identityIdentifier(),
                 invitationToken: $input->invitationToken(),
             ));

--- a/src/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallback.php
+++ b/src/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallback.php
@@ -15,6 +15,7 @@ use Source\Identity\Domain\Repository\SignupSessionRepositoryInterface;
 use Source\Identity\Domain\Service\AuthServiceInterface;
 use Source\Identity\Domain\Service\SocialOAuthServiceInterface;
 use Source\Identity\Domain\ValueObject\SocialConnection;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class SocialLoginCallback implements SocialLoginCallbackInterface
 {
@@ -27,6 +28,7 @@ readonly class SocialLoginCallback implements SocialLoginCallbackInterface
         private IdentityFactoryInterface           $identityFactory,
         private SignupSessionRepositoryInterface   $signupSessionRepository,
         private AuthServiceInterface               $authService,
+        private EventDispatcherInterface           $eventDispatcher,
     ) {
     }
 
@@ -74,12 +76,12 @@ readonly class SocialLoginCallback implements SocialLoginCallbackInterface
         $this->identityRepository->save($newIdentity);
 
         if ($invitationToken = $signupSession?->invitationToken()) {
-            event(new IdentityCreatedViaInvitation(
+            $this->eventDispatcher->dispatch(new IdentityCreatedViaInvitation(
                 identityIdentifier: $newIdentity->identityIdentifier(),
                 invitationToken: $invitationToken,
             ));
         } else {
-            event(new IdentityCreated(
+            $this->eventDispatcher->dispatch(new IdentityCreated(
                 identityIdentifier: $newIdentity->identityIdentifier(),
                 email: $profile->email(),
                 accountType: $accountType,

--- a/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
+++ b/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
@@ -7,7 +7,6 @@ namespace Tests\Account\Invitation\Application\EventHandler;
 use DateTimeImmutable;
 use DomainException;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Facades\Event;
 use Mockery;
 use Source\Account\IdentityGroup\Domain\Entity\IdentityGroup;
 use Source\Account\IdentityGroup\Domain\Factory\IdentityGroupFactoryInterface;
@@ -23,6 +22,7 @@ use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
 use Source\Account\Shared\Domain\ValueObject\IdentityGroupIdentifier;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -41,10 +41,12 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $invitationRepository = Mockery::mock(InvitationRepositoryInterface::class);
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
         $identityGroupFactory = Mockery::mock(IdentityGroupFactoryInterface::class);
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
 
@@ -58,9 +60,17 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
      */
     public function testHandleWhenMemberGroupExists(): void
     {
-        Event::fake();
-
         $data = $this->createTestData();
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof InvitationAccepted
+                    && (string) $event->invitationIdentifier === (string) $data->invitation->invitationIdentifier()
+                    && (string) $event->accountIdentifier === (string) $data->accountIdentifier
+                    && (string) $event->acceptedByIdentityIdentifier === (string) $data->identityIdentifier
+            ));
 
         $invitationRepository = Mockery::mock(InvitationRepositoryInterface::class);
         $invitationRepository->shouldReceive('findByToken')
@@ -83,6 +93,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $identityGroupFactory = Mockery::mock(IdentityGroupFactoryInterface::class);
         $identityGroupFactory->shouldNotReceive('create');
 
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
@@ -91,10 +102,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $handler->handle($data->event);
 
         $this->assertTrue($data->memberGroup->hasMember($data->identityIdentifier));
-
-        Event::assertDispatched(InvitationAccepted::class, static fn (InvitationAccepted $event) => (string) $event->invitationIdentifier === (string) $data->invitation->invitationIdentifier()
-            && (string) $event->accountIdentifier === (string) $data->accountIdentifier
-            && (string) $event->acceptedByIdentityIdentifier === (string) $data->identityIdentifier);
     }
 
     /**
@@ -104,9 +111,14 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
      */
     public function testHandleWhenMemberGroupNotExists(): void
     {
-        Event::fake();
-
         $data = $this->createTestData();
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof InvitationAccepted
+            ));
 
         $invitationRepository = Mockery::mock(InvitationRepositoryInterface::class);
         $invitationRepository->shouldReceive('findByToken')
@@ -132,6 +144,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->with($data->accountIdentifier, 'Members', AccountRole::MEMBER, false)
             ->andReturn($data->memberGroup);
 
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
@@ -140,8 +153,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $handler->handle($data->event);
 
         $this->assertTrue($data->memberGroup->hasMember($data->identityIdentifier));
-
-        Event::assertDispatched(InvitationAccepted::class);
     }
 
     /**
@@ -165,6 +176,9 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
         $identityGroupFactory = Mockery::mock(IdentityGroupFactoryInterface::class);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
@@ -198,6 +212,9 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
         $identityGroupFactory = Mockery::mock(IdentityGroupFactoryInterface::class);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
@@ -232,6 +249,9 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
         $identityGroupFactory = Mockery::mock(IdentityGroupFactoryInterface::class);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);

--- a/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationTest.php
+++ b/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationTest.php
@@ -6,7 +6,6 @@ namespace Tests\Account\Invitation\Application\UseCase\Command\CreateInvitation;
 
 use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Facades\Event;
 use Mockery;
 use Source\Account\IdentityGroup\Domain\Entity\IdentityGroup;
 use Source\Account\IdentityGroup\Domain\Repository\IdentityGroupRepositoryInterface;
@@ -24,6 +23,7 @@ use Source\Account\Invitation\Domain\ValueObject\InvitationIdentifier;
 use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
 use Source\Account\Shared\Domain\ValueObject\IdentityGroupIdentifier;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -42,10 +42,12 @@ class CreateInvitationTest extends TestCase
         $invitationRepository = Mockery::mock(InvitationRepositoryInterface::class);
         $invitationFactory = Mockery::mock(InvitationFactoryInterface::class);
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
 
@@ -59,9 +61,17 @@ class CreateInvitationTest extends TestCase
      */
     public function testProcessWithOwnerRole(): void
     {
-        Event::fake();
-
         $data = $this->createTestData(AccountRole::OWNER);
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof InvitationCreated
+                    && (string) $event->invitationIdentifier === (string) $data->invitation->invitationIdentifier()
+                    && (string) $event->accountIdentifier === (string) $data->accountIdentifier
+                    && (string) $event->email === (string) $data->email
+            ));
 
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
         $identityGroupRepository->shouldReceive('findByAccountIdAndIdentityId')
@@ -84,6 +94,7 @@ class CreateInvitationTest extends TestCase
             ->with($data->accountIdentifier, $data->inviterIdentityIdentifier, $data->email)
             ->andReturn($data->invitation);
 
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
@@ -93,10 +104,6 @@ class CreateInvitationTest extends TestCase
         $useCase->process($data->input, $output);
 
         $this->assertCount(1, $output->toArray());
-
-        Event::assertDispatched(InvitationCreated::class, static fn (InvitationCreated $event) => (string) $event->invitationIdentifier === (string) $data->invitation->invitationIdentifier()
-            && (string) $event->accountIdentifier === (string) $data->accountIdentifier
-            && (string) $event->email === (string) $data->email);
     }
 
     /**
@@ -106,9 +113,14 @@ class CreateInvitationTest extends TestCase
      */
     public function testProcessWithAdminRole(): void
     {
-        Event::fake();
-
         $data = $this->createTestData(AccountRole::ADMIN);
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof InvitationCreated
+            ));
 
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
         $identityGroupRepository->shouldReceive('findByAccountIdAndIdentityId')
@@ -131,6 +143,7 @@ class CreateInvitationTest extends TestCase
             ->with($data->accountIdentifier, $data->inviterIdentityIdentifier, $data->email)
             ->andReturn($data->invitation);
 
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
@@ -209,9 +222,14 @@ class CreateInvitationTest extends TestCase
      */
     public function testProcessRevokesExistingPendingInvitation(): void
     {
-        Event::fake();
-
         $data = $this->createTestData(AccountRole::OWNER);
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof InvitationCreated
+            ));
 
         $existingInvitation = Mockery::mock(Invitation::class);
         $existingInvitation->shouldReceive('revoke')->once();
@@ -240,6 +258,7 @@ class CreateInvitationTest extends TestCase
             ->with($data->accountIdentifier, $data->inviterIdentityIdentifier, $data->email)
             ->andReturn($data->invitation);
 
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
@@ -258,7 +277,12 @@ class CreateInvitationTest extends TestCase
      */
     public function testProcessWithMultipleEmails(): void
     {
-        Event::fake();
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->times(2)
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof InvitationCreated
+            ));
 
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $inviterIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
@@ -308,6 +332,7 @@ class CreateInvitationTest extends TestCase
             ->with($accountIdentifier, $inviterIdentityIdentifier, $email2)
             ->andReturn($invitation2);
 
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
@@ -317,8 +342,6 @@ class CreateInvitationTest extends TestCase
         $useCase->process($input, $output);
 
         $this->assertCount(2, $output->toArray());
-
-        Event::assertDispatchedTimes(InvitationCreated::class, 2);
     }
 
     /**
@@ -328,9 +351,14 @@ class CreateInvitationTest extends TestCase
      */
     public function testProcessWithMultipleGroupsOneIsOwner(): void
     {
-        Event::fake();
-
         $data = $this->createTestData(AccountRole::MEMBER);
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof InvitationCreated
+            ));
 
         $ownerGroup = $this->createIdentityGroup(
             $data->accountIdentifier,
@@ -359,6 +387,7 @@ class CreateInvitationTest extends TestCase
             ->with($data->accountIdentifier, $data->inviterIdentityIdentifier, $data->email)
             ->andReturn($data->invitation);
 
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);

--- a/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityTest.php
+++ b/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityTest.php
@@ -6,7 +6,6 @@ namespace Tests\Identity\Application\UseCase\Command\CreateIdentity;
 
 use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Facades\Event;
 use Mockery;
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
 use Source\Identity\Application\UseCase\Command\CreateIdentity\CreateIdentity;
@@ -28,6 +27,7 @@ use Source\Identity\Domain\ValueObject\HashedPassword;
 use Source\Identity\Domain\ValueObject\PlainPassword;
 use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Application\DTO\ImageUploadResult;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Application\Service\ImageServiceInterface;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -50,10 +50,12 @@ class CreateIdentityTest extends TestCase
         $identityFactory = Mockery::mock(IdentityFactoryInterface::class);
         $imageService = Mockery::mock(ImageServiceInterface::class);
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
         $this->assertInstanceOf(CreateIdentity::class, $useCase);
     }
@@ -131,10 +133,14 @@ class CreateIdentityTest extends TestCase
             ->with($userName, $email, $language, $password)
             ->andReturn($identity);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
 
         $output = new CreateIdentityOutput();
@@ -186,10 +192,13 @@ class CreateIdentityTest extends TestCase
         $imageService = Mockery::mock(ImageServiceInterface::class);
         $imageService->shouldNotReceive('upload');
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
 
         $this->expectException(AuthCodeSessionNotFoundException::class);
@@ -255,10 +264,13 @@ class CreateIdentityTest extends TestCase
         $imageService = Mockery::mock(ImageServiceInterface::class);
         $imageService->shouldNotReceive('upload');
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
 
         $this->expectException(AlreadyUserExistsException::class);
@@ -298,10 +310,13 @@ class CreateIdentityTest extends TestCase
         $imageService = Mockery::mock(ImageServiceInterface::class);
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
 
         $this->expectException(PasswordMismatchException::class);
@@ -369,10 +384,13 @@ class CreateIdentityTest extends TestCase
         $imageService = Mockery::mock(ImageServiceInterface::class);
         $imageService->shouldNotReceive('upload');
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
 
         $this->expectException(UnauthorizedEmailException::class);
@@ -392,8 +410,6 @@ class CreateIdentityTest extends TestCase
      */
     public function testProcessDispatchesIdentityCreatedViaInvitationEvent(): void
     {
-        Event::fake();
-
         $userName = new UserName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
@@ -451,19 +467,26 @@ class CreateIdentityTest extends TestCase
         $imageService = Mockery::mock(ImageServiceInterface::class);
         $imageService->shouldNotReceive('upload');
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn ($event) => $event instanceof IdentityCreatedViaInvitation
+                    && (string) $event->identityIdentifier === (string) $identityIdentifier
+                    && (string) $event->invitationToken === (string) $invitationToken
+            ));
+
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
 
         $output = new CreateIdentityOutput();
         $useCase->process($input, $output);
 
         $this->assertSame((string) $identity->identityIdentifier(), $output->toArray()['identityIdentifier']);
-
-        Event::assertDispatched(IdentityCreatedViaInvitation::class, static fn (IdentityCreatedViaInvitation $event) => (string) $event->identityIdentifier === (string) $identityIdentifier
-            && (string) $event->invitationToken === (string) $invitationToken);
     }
 
     /**
@@ -477,8 +500,6 @@ class CreateIdentityTest extends TestCase
      */
     public function testProcessDoesNotDispatchIdentityCreatedViaInvitationEventWhenTokenIsNull(): void
     {
-        Event::fake();
-
         $userName = new UserName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
@@ -533,17 +554,19 @@ class CreateIdentityTest extends TestCase
         $imageService = Mockery::mock(ImageServiceInterface::class);
         $imageService->shouldNotReceive('upload');
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+
         $this->app->instance(AuthCodeSessionRepositoryInterface::class, $authCodeSessionRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(ImageServiceInterface::class, $imageService);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateIdentityInterface::class);
 
         $output = new CreateIdentityOutput();
         $useCase->process($input, $output);
 
         $this->assertSame((string) $identity->identityIdentifier(), $output->toArray()['identityIdentifier']);
-
-        Event::assertNotDispatched(IdentityCreatedViaInvitation::class);
     }
 }

--- a/tests/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallbackTest.php
+++ b/tests/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallbackTest.php
@@ -6,7 +6,6 @@ namespace Tests\Identity\Application\UseCase\Command\SocialLogin\Callback;
 
 use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\Facades\Event;
 use Mockery;
 use RuntimeException;
 use Source\Account\Account\Domain\ValueObject\AccountType;
@@ -33,6 +32,7 @@ use Source\Identity\Domain\ValueObject\SocialConnection;
 use Source\Identity\Domain\ValueObject\SocialProfile;
 use Source\Identity\Domain\ValueObject\SocialProvider;
 use Source\Identity\Domain\ValueObject\UserName;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\Language;
@@ -56,12 +56,15 @@ class SocialLoginCallbackTest extends TestCase
         $signupSessionRepository = Mockery::mock(SignupSessionRepositoryInterface::class);
         $authService = Mockery::mock(AuthServiceInterface::class);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
         $this->app->instance(OAuthStateRepositoryInterface::class, $oauthStateRepository);
         $this->app->instance(SocialOAuthServiceInterface::class, $socialOAuthClient);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(SignupSessionRepositoryInterface::class, $signupSessionRepository);
         $this->app->instance(AuthServiceInterface::class, $authService);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(SocialLoginCallbackInterface::class);
 
@@ -76,8 +79,6 @@ class SocialLoginCallbackTest extends TestCase
      */
     public function testProcessWhenSocialConnectionExists(): void
     {
-        Event::fake();
-
         $provider = SocialProvider::GOOGLE;
         $code = new OAuthCode('code');
         $state = new OAuthState('state-token', new DateTimeImmutable('+10 minutes'));
@@ -121,19 +122,22 @@ class SocialLoginCallbackTest extends TestCase
             ->with($identity)
             ->andReturn($identity);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+
         $this->app->instance(OAuthStateRepositoryInterface::class, $oauthStateRepository);
         $this->app->instance(SocialOAuthServiceInterface::class, $socialOAuthClient);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(SignupSessionRepositoryInterface::class, $signupSessionRepository);
         $this->app->instance(AuthServiceInterface::class, $authService);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(SocialLoginCallbackInterface::class);
 
         $useCase->process($input, $output);
 
         $this->assertSame('/auth/callback', $output->redirectUrl());
-        Event::assertNotDispatched(IdentityCreated::class);
     }
 
     /**
@@ -144,8 +148,6 @@ class SocialLoginCallbackTest extends TestCase
      */
     public function testProcessWhenUserWithSameEmailExists(): void
     {
-        Event::fake();
-
         $provider = SocialProvider::LINE;
         $code = new OAuthCode('code');
         $state = new OAuthState('state-token', new DateTimeImmutable('+10 minutes'));
@@ -195,19 +197,22 @@ class SocialLoginCallbackTest extends TestCase
             ->with($existingUser)
             ->andReturn($existingUser);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+
         $this->app->instance(OAuthStateRepositoryInterface::class, $oauthStateRepository);
         $this->app->instance(SocialOAuthServiceInterface::class, $socialOAuthClient);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(SignupSessionRepositoryInterface::class, $signupSessionRepository);
         $this->app->instance(AuthServiceInterface::class, $authService);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(SocialLoginCallbackInterface::class);
 
         $useCase->process($input, $output);
 
         $this->assertSame('/auth/callback', $output->redirectUrl());
-        Event::assertNotDispatched(IdentityCreated::class);
     }
 
     /**
@@ -218,8 +223,6 @@ class SocialLoginCallbackTest extends TestCase
      */
     public function testProcessWhenUserNotFoundCreatesNewUserWithSignupSession(): void
     {
-        Event::fake();
-
         $provider = SocialProvider::KAKAO;
         $code = new OAuthCode('code');
         $state = new OAuthState('state-token', new DateTimeImmutable('+10 minutes'));
@@ -280,22 +283,30 @@ class SocialLoginCallbackTest extends TestCase
             ->with($newUser)
             ->andReturn($newUser);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                fn ($event) => $event instanceof IdentityCreated
+                    && (string) $event->identityIdentifier === (string) $newUser->identityIdentifier()
+                    && (string) $event->email === (string) $email
+                    && $event->accountType === AccountType::CORPORATION
+                    && $event->name === $profile->name()
+            ));
+
         $this->app->instance(OAuthStateRepositoryInterface::class, $oauthStateRepository);
         $this->app->instance(SocialOAuthServiceInterface::class, $socialOAuthClient);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(SignupSessionRepositoryInterface::class, $signupSessionRepository);
         $this->app->instance(AuthServiceInterface::class, $authService);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(SocialLoginCallbackInterface::class);
 
         $useCase->process($input, $output);
 
         $this->assertSame('/auth/callback', $output->redirectUrl());
-        Event::assertDispatched(IdentityCreated::class, fn (IdentityCreated $event) => (string) $event->identityIdentifier === (string) $newUser->identityIdentifier()
-            && (string) $event->email === (string) $email
-            && $event->accountType === AccountType::CORPORATION
-            && $event->name === $profile->name());
     }
 
     /**
@@ -306,8 +317,6 @@ class SocialLoginCallbackTest extends TestCase
      */
     public function testProcessWhenUserNotFoundWithInvitationToken(): void
     {
-        Event::fake();
-
         $provider = SocialProvider::GOOGLE;
         $code = new OAuthCode('code');
         $state = new OAuthState('state-token', new DateTimeImmutable('+10 minutes'));
@@ -369,21 +378,28 @@ class SocialLoginCallbackTest extends TestCase
             ->with($newUser)
             ->andReturn($newUser);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                fn ($event) => $event instanceof IdentityCreatedViaInvitation
+                    && (string) $event->identityIdentifier === (string) $newUser->identityIdentifier()
+                    && (string) $event->invitationToken === (string) $invitationToken
+            ));
+
         $this->app->instance(OAuthStateRepositoryInterface::class, $oauthStateRepository);
         $this->app->instance(SocialOAuthServiceInterface::class, $socialOAuthClient);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(SignupSessionRepositoryInterface::class, $signupSessionRepository);
         $this->app->instance(AuthServiceInterface::class, $authService);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(SocialLoginCallbackInterface::class);
 
         $useCase->process($input, $output);
 
         $this->assertSame('/auth/callback', $output->redirectUrl());
-        Event::assertDispatched(IdentityCreatedViaInvitation::class, fn (IdentityCreatedViaInvitation $event) => (string) $event->identityIdentifier === (string) $newUser->identityIdentifier()
-            && (string) $event->invitationToken === (string) $invitationToken);
-        Event::assertNotDispatched(IdentityCreated::class);
     }
 
     /**
@@ -394,8 +410,6 @@ class SocialLoginCallbackTest extends TestCase
      */
     public function testProcessWhenUserNotFoundCreatesNewUserWithoutSignupSession(): void
     {
-        Event::fake();
-
         $provider = SocialProvider::GOOGLE;
         $code = new OAuthCode('code');
         $state = new OAuthState('state-token', new DateTimeImmutable('+10 minutes'));
@@ -450,22 +464,30 @@ class SocialLoginCallbackTest extends TestCase
             ->with($newUser)
             ->andReturn($newUser);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                fn ($event) => $event instanceof IdentityCreated
+                    && (string) $event->identityIdentifier === (string) $newUser->identityIdentifier()
+                    && (string) $event->email === (string) $email
+                    && $event->accountType === AccountType::INDIVIDUAL
+                    && $event->name === $profile->name()
+            ));
+
         $this->app->instance(OAuthStateRepositoryInterface::class, $oauthStateRepository);
         $this->app->instance(SocialOAuthServiceInterface::class, $socialOAuthClient);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(SignupSessionRepositoryInterface::class, $signupSessionRepository);
         $this->app->instance(AuthServiceInterface::class, $authService);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(SocialLoginCallbackInterface::class);
 
         $useCase->process($input, $output);
 
         $this->assertSame('/auth/callback', $output->redirectUrl());
-        Event::assertDispatched(IdentityCreated::class, fn (IdentityCreated $event) => (string) $event->identityIdentifier === (string) $newUser->identityIdentifier()
-            && (string) $event->email === (string) $email
-            && $event->accountType === AccountType::INDIVIDUAL
-            && $event->name === $profile->name());
     }
 
     /**
@@ -496,12 +518,15 @@ class SocialLoginCallbackTest extends TestCase
         $signupSessionRepository = Mockery::mock(SignupSessionRepositoryInterface::class);
         $authService = Mockery::mock(AuthServiceInterface::class);
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
         $this->app->instance(OAuthStateRepositoryInterface::class, $oauthStateRepository);
         $this->app->instance(SocialOAuthServiceInterface::class, $socialOAuthClient);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(IdentityFactoryInterface::class, $identityFactory);
         $this->app->instance(SignupSessionRepositoryInterface::class, $signupSessionRepository);
         $this->app->instance(AuthServiceInterface::class, $authService);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(SocialLoginCallbackInterface::class);
 


### PR DESCRIPTION
## 📝 変更内容

- `event()` グローバルヘルパー関数の呼び出しを `EventDispatcherInterface::dispatch()` 経由に置き換え
- 対象クラス: `IdentityCreatedViaInvitationHandler`, `CreateInvitation`, `CreateIdentity`, `SocialLoginCallback`
- テストを `Event::fake()` / `Event::assertDispatched()` から Mockery ベースのモックに移行

## 🏷️ 変更の種類

- [x] 🔧 リファクタリング (Refactoring)

## 🎯 変更理由・背景

Laravelの `event()` グローバルヘルパーへの暗黙的な依存を排除し、`EventDispatcherInterface` をコンストラクタインジェクションで注入するパターンに統一する。これにより、フレームワークへの結合度を下げ、テスタビリティとアーキテクチャの一貫性を向上させる。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- 各クラスのコンストラクタに `EventDispatcherInterface` が正しく追加されているか
- テストでのイベントディスパッチ検証が Mockery の `shouldReceive('dispatch')` で適切に行われているか

## 📖 関連情報

### 関連Issue・タスク

Closes #143

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した