### PR TITLE
add: VideoLinkサブドメインのSaveVideoLinksエンドポイント作成

### DIFF
--- a/application/Http/Action/Wiki/VideoLink/Command/SaveVideoLinks/SaveVideoLinksAction.php
+++ b/application/Http/Action/Wiki/VideoLink/Command/SaveVideoLinks/SaveVideoLinksAction.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\ExternalContentLink;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\VideoLink\Application\UseCase\Command\SaveVideoLinks\SaveVideoLinksInput;
+use Source\Wiki\VideoLink\Application\UseCase\Command\SaveVideoLinks\SaveVideoLinksInterface;
+use Source\Wiki\VideoLink\Application\UseCase\Command\SaveVideoLinks\VideoLinkData;
+use Source\Wiki\VideoLink\Domain\ValueObject\VideoUsage;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class SaveVideoLinksAction
+{
+    public function __construct(
+        private SaveVideoLinksInterface $saveVideoLinks,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(SaveVideoLinksRequest $request): Response
+    {
+        try {
+            try {
+                $videoLinkDataArray = array_map(
+                    static fn (array $item): VideoLinkData => new VideoLinkData(
+                        new ExternalContentLink($item['url']),
+                        VideoUsage::from($item['videoUsage']),
+                        $item['title'] ?? '',
+                        $item['displayOrder'],
+                        $item['thumbnailUrl'] ?? null,
+                        isset($item['publishedAt']) ? new DateTimeImmutable($item['publishedAt']) : null,
+                    ),
+                    $request->videoLinks(),
+                );
+
+                $input = new SaveVideoLinksInput(
+                    new PrincipalIdentifier($request->principalId()),
+                    ResourceType::from($request->resourceType()),
+                    new WikiIdentifier($request->wikiIdentifier()),
+                    $videoLinkDataArray,
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            try {
+                $this->saveVideoLinks->process($input);
+                DB::commit();
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->noContent(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/application/Http/Action/Wiki/VideoLink/Command/SaveVideoLinks/SaveVideoLinksRequest.php
+++ b/application/Http/Action/Wiki/VideoLink/Command/SaveVideoLinks/SaveVideoLinksRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SaveVideoLinksRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'principalId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'wikiIdentifier' => ['required', 'uuid'],
+            'videoLinks' => ['present', 'array'],
+            'videoLinks.*.url' => ['required', 'url'],
+            'videoLinks.*.videoUsage' => ['required', 'string'],
+            'videoLinks.*.title' => ['nullable', 'string'],
+            'videoLinks.*.displayOrder' => ['required', 'integer'],
+            'videoLinks.*.thumbnailUrl' => ['nullable', 'url'],
+            'videoLinks.*.publishedAt' => ['nullable', 'date'],
+        ];
+    }
+
+    public function principalId(): string
+    {
+        return (string) $this->input('principalId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return (string) $this->input('wikiIdentifier');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function videoLinks(): array
+    {
+        /** @var array<int, array<string, mixed>> $videoLinks */
+        $videoLinks = $this->input('videoLinks', []);
+
+        return $videoLinks;
+    }
+
+    public function language(): string
+    {
+        return (string) ($this->input('language') ?? 'en');
+    }
+}

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -35,6 +35,7 @@ use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
 use Application\Http\Action\Wiki\ImageHideRequest\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\ImageHideRequest\Command\RejectImageHideRequest\RejectImageHideRequestAction;
 use Application\Http\Action\Wiki\ImageHideRequest\Command\RequestImageHide\RequestImageHideAction;
+use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinksAction;
 use Application\Http\Action\Wiki\Wiki\Command\TranslateWiki\TranslateWikiAction;
 use Illuminate\Support\Facades\Route;
 
@@ -80,3 +81,6 @@ Route::post('/image-hide-request/{requestId}/reject', RejectImageHideRequestActi
 Route::post('/official-certification/request', RequestCertificationAction::class);
 Route::post('/official-certification/{certificationId}/approve', ApproveCertificationAction::class);
 Route::post('/official-certification/{certificationId}/reject', RejectCertificationAction::class);
+
+// VideoLink
+Route::post('/video-link/save', SaveVideoLinksAction::class);

--- a/tests/Wiki/VideoLink/Http/Action/Command/SaveVideoLinks/SaveVideoLinksActionTest.php
+++ b/tests/Wiki/VideoLink/Http/Action/Command/SaveVideoLinks/SaveVideoLinksActionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\VideoLink\Http\Action\Command\SaveVideoLinks;
+
+use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinksAction;
+use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinksRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\VideoLink\Application\UseCase\Command\SaveVideoLinks\SaveVideoLinksInput;
+use Source\Wiki\VideoLink\Application\UseCase\Command\SaveVideoLinks\SaveVideoLinksInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class SaveVideoLinksActionTest extends TestCase
+{
+    public function testInvokeReturnsNoContentResponse(): void
+    {
+        /** @var SaveVideoLinksRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(SaveVideoLinksRequest::class);
+        $request->shouldReceive('principalId')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('resourceType')->andReturn('talent');
+        $request->shouldReceive('wikiIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('videoLinks')->andReturn([
+            [
+                'url' => 'https://www.youtube.com/watch?v=test123',
+                'videoUsage' => 'music_video',
+                'title' => 'Test Video',
+                'displayOrder' => 1,
+                'thumbnailUrl' => 'https://img.youtube.com/vi/test123/0.jpg',
+                'publishedAt' => '2024-01-01',
+            ],
+        ]);
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var SaveVideoLinksInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(SaveVideoLinksInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(SaveVideoLinksInput::class));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new SaveVideoLinksAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertSame('', $response->getContent());
+    }
+
+    public function testInvokeReturnsUnprocessableEntityResponseWhenInvalidArgumentException(): void
+    {
+        /** @var SaveVideoLinksRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(SaveVideoLinksRequest::class);
+        $request->shouldReceive('principalId')->andReturn('invalid-uuid');
+        $request->shouldReceive('resourceType')->andReturn('talent');
+        $request->shouldReceive('wikiIdentifier')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('videoLinks')->andReturn([
+            [
+                'url' => 'https://www.youtube.com/watch?v=test123',
+                'videoUsage' => 'music_video',
+                'title' => 'Test Video',
+                'displayOrder' => 1,
+                'thumbnailUrl' => null,
+                'publishedAt' => null,
+            ],
+        ]);
+        $request->shouldReceive('language')->andReturn('en');
+
+        /** @var SaveVideoLinksInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(SaveVideoLinksInterface::class);
+        $useCase->shouldNotReceive('process');
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new SaveVideoLinksAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

- VideoLinkサブドメインに `SaveVideoLinks` エンドポイント（Action + FormRequest）を新規作成
- `POST /video-link/save` ルートを Wiki Private API に追加
- リクエストバリデーション（principalId, resourceType, wikiIdentifier, videoLinks配列）を実装
- Action内でトランザクション管理、ドメイン値オブジェクトへの変換、エラーハンドリングを実装
- ユニットテスト（正常系・InvalidArgumentException時の422レスポンス）を作成

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki に紐づく動画リンク情報を一括保存するためのAPIエンドポイントが必要なため、VideoLinkサブドメインにSaveVideoLinksエンドポイントを新規作成した。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Action内のtry-catchのネスト構造（バリデーションエラーとDB例外の分離）が適切か
- FormRequestのバリデーションルール（videoLinks配列の各フィールド）が要件を満たしているか

## 📖 関連情報

### 関連Issue・タスク

Closes #275

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した