### PR TITLE
Add TypeSpec and OpenAPI definitions for Stripe webhook

### DIFF
--- a/doc/openapi/KPool.WebhookApi.openapi.yaml
+++ b/doc/openapi/KPool.WebhookApi.openapi.yaml
@@ -3,8 +3,72 @@ info:
   title: k-pool Webhook API
   version: 0.0.0
 tags: []
-paths: {}
-components: {}
+paths:
+  /stripe:
+    post:
+      operationId: StripeWebhookOperations_receiveStripeWebhook
+      description: Receive Stripe account external account webhook events.
+      parameters:
+        - name: Stripe-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 200 response for accepted Stripe webhook events.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/StripeWebhookAcceptedResponseBody'
+                  - $ref: '#/components/schemas/StripeWebhookIgnoredResponseBody'
+        '400':
+          description: 400 response for Stripe webhook requests with an invalid signature.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StripeWebhookInvalidSignatureResponseBody'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {}
+components:
+  schemas:
+    StripeWebhookAcceptedResponseBody:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - accepted
+          description: Webhook processing result.
+      description: Response body returned when a Stripe webhook event is accepted for processing.
+    StripeWebhookIgnoredResponseBody:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - ignored
+          description: Webhook processing result.
+      description: Response body returned when a Stripe webhook event is ignored.
+    StripeWebhookInvalidSignatureResponseBody:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - Invalid signature
+          description: Error message describing why the webhook was rejected.
+      description: Response body returned when Stripe signature verification fails.
 servers:
   - url: /webhook
     description: Laravel route prefix from bootstrap/app.php.

--- a/typespec/services/webhook.tsp
+++ b/typespec/services/webhook.tsp
@@ -3,3 +3,49 @@ using TypeSpec.Http;
 @service(#{ title: "k-pool Webhook API" })
 @server("/webhook", "Laravel route prefix from bootstrap/app.php.")
 namespace KPool.WebhookApi;
+
+@doc("Response body returned when a Stripe webhook event is accepted for processing.")
+model StripeWebhookAcceptedResponseBody {
+  @doc("Webhook processing result.")
+  status: "accepted";
+}
+
+@doc("Response body returned when a Stripe webhook event is ignored.")
+model StripeWebhookIgnoredResponseBody {
+  @doc("Webhook processing result.")
+  status: "ignored";
+}
+
+@doc("Response body returned when Stripe signature verification fails.")
+model StripeWebhookInvalidSignatureResponseBody {
+  @doc("Error message describing why the webhook was rejected.")
+  error: "Invalid signature";
+}
+
+@doc("200 response for accepted Stripe webhook events.")
+model StripeWebhookAcceptedResponse {
+  @statusCode statusCode: 200;
+  @body body: StripeWebhookAcceptedResponseBody;
+}
+
+@doc("200 response for ignored Stripe webhook events.")
+model StripeWebhookIgnoredResponse {
+  @statusCode statusCode: 200;
+  @body body: StripeWebhookIgnoredResponseBody;
+}
+
+@doc("400 response for Stripe webhook requests with an invalid signature.")
+model StripeWebhookInvalidSignatureResponse {
+  @statusCode statusCode: 400;
+  @body body: StripeWebhookInvalidSignatureResponseBody;
+}
+
+@route("/stripe")
+interface StripeWebhookOperations {
+  @post
+  @doc("Receive Stripe account external account webhook events.")
+  receiveStripeWebhook(
+    @header("Stripe-Signature") stripeSignature: string,
+    @body body: unknown,
+  ): StripeWebhookAcceptedResponse | StripeWebhookIgnoredResponse | StripeWebhookInvalidSignatureResponse;
+}


### PR DESCRIPTION
## 📝 変更内容

- Stripe webhook の `/stripe` エンドポイントを `typespec/services/webhook.tsp` に追加
- `Stripe-Signature` ヘッダー、リクエストボディ、レスポンスモデルを TypeSpec で定義
- 生成された OpenAPI ドキュメント `doc/openapi/KPool.WebhookApi.openapi.yaml` を更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

- Webhook API についても TypeSpec ベースで契約を管理し、OpenAPI を生成できる状態に揃えるため
- Stripe webhook の受け口と応答仕様を明文化し、実装とドキュメントの整合性を取りやすくするため

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `/webhook/stripe` の API 契約が既存の Laravel 実装意図と一致しているか
- `200` で `accepted` / `ignored` を返す設計と `400` の invalid signature 応答が妥当か
- `requestBody` を `unknown` としている粒度が現時点の用途に適しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #299

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [ ] 適切なブランチ名を使用している
- [ ] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した