### PR TITLE
Add: pnpmに公開から14日未満のパッケージを新規解決対象から外す設定を導入

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 20160


### PR DESCRIPTION
## 📝 変更内容

pnpm の依存解決に `minimumReleaseAge: 20160` を追加し、公開から14日未満のパッケージを新規解決対象から外す設定を導入しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

新規公開直後の依存バージョンを即時に取り込まないようにし、サプライチェーンリスクを下げるためです。
再解決が発生する install / add / update 時に、一定期間を経たバージョンのみを利用する運用に寄せます。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `minimumReleaseAge` を 20160 分として設定していること
- この設定が lockfile 再解決時の依存取得ポリシーとして妥当か
- 即時反映が必要な依存の例外設定が不要か

## 📖 関連情報

## ⚠️ 注意事項

`pnpm-lock.yaml` に固定済みの依存をそのまま使う install では影響が限定的で、主に依存の再解決時に効きます。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した