### PR TITLE
Add: Account APIのTypeSpec定義を追加

### DIFF
--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -3,8 +3,1519 @@ info:
   title: k-pool Account API
   version: 0.0.0
 tags: []
-paths: {}
-components: {}
+paths:
+  /account-verifications:
+    post:
+      operationId: AccountVerificationOperations_requestVerification
+      description: Request account verification.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when an account verification is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountVerificationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestVerificationRequestBody'
+  /account-verifications/{verificationId}/approve:
+    post:
+      operationId: AccountVerificationOperations_approveVerification
+      description: Approve account verification.
+      parameters:
+        - name: verificationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when an account verification operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountVerificationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApproveVerificationRequestBody'
+  /account-verifications/{verificationId}/reject:
+    post:
+      operationId: AccountVerificationOperations_rejectVerification
+      description: Reject account verification.
+      parameters:
+        - name: verificationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when an account verification operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountVerificationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RejectVerificationRequestBody'
+  /accounts:
+    post:
+      operationId: AccountOperations_createAccount
+      description: Create an account.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when an account is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatedAccountSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAccountRequestBody'
+  /accounts/{accountId}:
+    delete:
+      operationId: AccountOperations_deleteAccount
+      description: Delete an account.
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when an account operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /affiliations:
+    post:
+      operationId: AffiliationOperations_requestAffiliation
+      description: Request an affiliation.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when an affiliation is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AffiliationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestAffiliationRequestBody'
+  /affiliations/{affiliationId}/approve:
+    post:
+      operationId: AffiliationOperations_approveAffiliation
+      description: Approve an affiliation.
+      parameters:
+        - name: affiliationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when an affiliation operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AffiliationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApproveAffiliationRequestBody'
+  /affiliations/{affiliationId}/reject:
+    post:
+      operationId: AffiliationOperations_rejectAffiliation
+      description: Reject an affiliation.
+      parameters:
+        - name: affiliationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '204':
+          description: Response with no content.
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RejectAffiliationRequestBody'
+  /affiliations/{affiliationId}/terminate:
+    post:
+      operationId: AffiliationOperations_terminateAffiliation
+      description: Terminate an affiliation.
+      parameters:
+        - name: affiliationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when an affiliation operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AffiliationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TerminateAffiliationRequestBody'
+  /delegation-permissions:
+    post:
+      operationId: DelegationPermissionOperations_grantDelegationPermission
+      description: Grant a delegation permission.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when a delegation permission is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegationPermissionSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrantDelegationPermissionRequestBody'
+  /delegation-permissions/{delegationPermissionId}:
+    delete:
+      operationId: DelegationPermissionOperations_revokeDelegationPermission
+      description: Revoke a delegation permission.
+      parameters:
+        - name: delegationPermissionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '204':
+          description: Response with no content.
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /delegations:
+    post:
+      operationId: DelegationOperations_requestDelegation
+      description: Request a delegation.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when a delegation is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestDelegationRequestBody'
+  /delegations/{delegationId}/approve:
+    post:
+      operationId: DelegationOperations_approveDelegation
+      description: Approve a delegation.
+      parameters:
+        - name: delegationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when a delegation operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApproveDelegationRequestBody'
+  /delegations/{delegationId}/revoke:
+    post:
+      operationId: DelegationOperations_revokeDelegation
+      description: Revoke a delegation.
+      parameters:
+        - name: delegationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when a delegation operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevokeDelegationRequestBody'
+  /identity-groups:
+    post:
+      operationId: IdentityGroupOperations_createIdentityGroup
+      description: Create an identity group.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when an identity group is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatedIdentityGroupSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIdentityGroupRequestBody'
+  /identity-groups/{identityGroupId}:
+    delete:
+      operationId: IdentityGroupOperations_deleteIdentityGroup
+      description: Delete an identity group.
+      parameters:
+        - name: identityGroupId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '204':
+          description: Response with no content.
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /identity-groups/{identityGroupId}/add-member:
+    post:
+      operationId: IdentityGroupOperations_addIdentityToIdentityGroup
+      description: Add an identity to an identity group.
+      parameters:
+        - name: identityGroupId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when an identity group operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityGroupSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MutateIdentityGroupMemberRequestBody'
+  /identity-groups/{identityGroupId}/remove-member:
+    post:
+      operationId: IdentityGroupOperations_removeIdentityFromIdentityGroup
+      description: Remove an identity from an identity group.
+      parameters:
+        - name: identityGroupId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Uuid'
+      responses:
+        '200':
+          description: Response returned when an identity group operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityGroupSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MutateIdentityGroupMemberRequestBody'
+  /invitations:
+    post:
+      operationId: InvitationOperations_createInvitation
+      description: Create invitations for one or more email addresses.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when invitations are created.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InvitationSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateInvitationRequestBody'
+components:
+  schemas:
+    AccountSummary:
+      type: object
+      required:
+        - accountIdentifier
+        - email
+        - type
+        - name
+        - status
+      properties:
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Account identifier.
+        email:
+          type: string
+          description: Account email address.
+        type:
+          type: string
+          description: Account type.
+        name:
+          type: string
+          description: Account display name.
+        status:
+          type: string
+          description: Account status.
+      description: Current account state.
+    AccountVerificationSummary:
+      type: object
+      required:
+        - verificationIdentifier
+        - accountIdentifier
+        - verificationType
+        - status
+        - applicantName
+        - requestedAt
+        - documents
+      properties:
+        verificationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Verification identifier.
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Account identifier under review.
+        verificationType:
+          type: string
+          description: Verification type.
+        status:
+          type: string
+          description: Verification status.
+        applicantName:
+          type: string
+          description: Applicant full name.
+        requestedAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Timestamp when the verification was requested.
+        reviewedBy:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          nullable: true
+          description: Reviewer account identifier.
+        reviewedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          nullable: true
+          description: Timestamp when the verification was reviewed.
+        rejectionReason:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/VerificationRejectionReasonSummary'
+          nullable: true
+          description: Optional rejection reason.
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerificationDocumentSummary'
+          description: Submitted documents.
+      description: Account verification state.
+    AffiliationSummary:
+      type: object
+      required:
+        - affiliationIdentifier
+        - agencyAccountIdentifier
+        - talentAccountIdentifier
+        - requestedBy
+        - status
+        - requestedAt
+      properties:
+        affiliationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Affiliation identifier.
+        agencyAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Agency account identifier.
+        talentAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Talent account identifier.
+        requestedBy:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Account that initiated the affiliation workflow.
+        status:
+          type: string
+          description: Affiliation status.
+        terms:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/AffiliationTermsSummary'
+          nullable: true
+          description: Optional affiliation terms.
+        requestedAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Timestamp when the affiliation was requested.
+        activatedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          nullable: true
+          description: Timestamp when the affiliation was activated.
+        terminatedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          nullable: true
+          description: Timestamp when the affiliation was terminated.
+      description: Affiliation state.
+    AffiliationTermsSummary:
+      type: object
+      properties:
+        revenueSharePercentage:
+          type: integer
+          format: int32
+          description: Revenue share percentage.
+        contractNotes:
+          type: string
+          description: Free-form contract notes.
+      description: Affiliation contract terms.
+    ApproveAffiliationRequestBody:
+      type: object
+      required:
+        - approverAccountIdentifier
+      properties:
+        approverAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Approver account identifier.
+      description: Request body for approving an affiliation.
+    ApproveDelegationRequestBody:
+      type: object
+      required:
+        - approverIdentifier
+      properties:
+        approverIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier approving the delegation.
+      description: Request body for approving a delegation.
+    ApproveVerificationRequestBody:
+      type: object
+      required:
+        - reviewerAccountIdentifier
+      properties:
+        reviewerAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Reviewer account identifier.
+      description: Request body for approving account verification.
+    CreateAccountRequestBody:
+      type: object
+      required:
+        - email
+        - accountType
+        - accountName
+      properties:
+        email:
+          type: string
+          description: Account email address.
+        accountType:
+          type: string
+          description: Account type.
+        accountName:
+          type: string
+          description: Account display name.
+        identityIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          nullable: true
+          description: Identity identifier to attach to the account.
+      description: Request body for creating an account.
+    CreateIdentityGroupRequestBody:
+      type: object
+      required:
+        - accountIdentifier
+        - name
+        - role
+      properties:
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Owning account identifier.
+        name:
+          type: string
+          description: Identity group name.
+        role:
+          type: string
+          description: Role assigned to the identity group.
+      description: Request body for creating an identity group.
+    CreateInvitationRequestBody:
+      type: object
+      required:
+        - accountIdentifier
+        - inviterIdentityIdentifier
+        - emails
+      properties:
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Account identifier that owns the invitations.
+        inviterIdentityIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier sending the invitations.
+        emails:
+          type: array
+          items:
+            type: string
+          description: Invitee email addresses.
+      description: Request body for creating invitations.
+    CreatedAccountSummary:
+      type: object
+      required:
+        - accountCategory
+      properties:
+        accountCategory:
+          type: string
+          description: Account category assigned during creation.
+      allOf:
+        - $ref: '#/components/schemas/AccountSummary'
+      description: Account creation result.
+    CreatedIdentityGroupSummary:
+      type: object
+      required:
+        - createdAt
+      properties:
+        createdAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Timestamp when the identity group was created.
+      allOf:
+        - $ref: '#/components/schemas/IdentityGroupSummary'
+      description: Identity group snapshot returned immediately after creation.
+    DelegationPermissionSummary:
+      type: object
+      required:
+        - delegationPermissionIdentifier
+        - identityGroupIdentifier
+        - targetAccountIdentifier
+        - affiliationIdentifier
+        - createdAt
+      properties:
+        delegationPermissionIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Delegation permission identifier.
+        identityGroupIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity group identifier that owns the permission.
+        targetAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Target account identifier.
+        affiliationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Affiliation identifier covered by the permission.
+        createdAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Timestamp when the permission was created.
+      description: Delegation permission state.
+    DelegationSummary:
+      type: object
+      required:
+        - delegationIdentifier
+        - affiliationIdentifier
+        - delegateIdentifier
+        - delegatorIdentifier
+        - status
+        - direction
+        - requestedAt
+      properties:
+        delegationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Delegation identifier.
+        affiliationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Affiliation identifier backing the delegation.
+        delegateIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Delegate identity identifier.
+        delegatorIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Delegator identity identifier.
+        status:
+          type: string
+          description: Delegation status.
+        direction:
+          type: string
+          description: Delegation direction.
+        requestedAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Timestamp when the delegation was requested.
+        approvedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          nullable: true
+          description: Timestamp when the delegation was approved.
+        revokedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          nullable: true
+          description: Timestamp when the delegation was revoked.
+      description: Delegation state.
+    GrantDelegationPermissionRequestBody:
+      type: object
+      required:
+        - identityGroupIdentifier
+        - targetAccountIdentifier
+        - affiliationIdentifier
+      properties:
+        identityGroupIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity group identifier receiving the permission.
+        targetAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Account identifier that can be delegated.
+        affiliationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Affiliation identifier covered by the permission.
+      description: Request body for granting a delegation permission.
+    IdentityGroupSummary:
+      type: object
+      required:
+        - identityGroupIdentifier
+        - accountIdentifier
+        - name
+        - role
+        - isDefault
+      properties:
+        identityGroupIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity group identifier.
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Owning account identifier.
+        name:
+          type: string
+          description: Identity group name.
+        role:
+          type: string
+          description: Identity group role.
+        isDefault:
+          type: boolean
+          description: Whether this is the default identity group.
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/Uuid'
+          description: Identity identifiers currently assigned to the group.
+      description: Identity group snapshot returned after updates.
+    InvitationSummary:
+      type: object
+      required:
+        - invitationIdentifier
+        - accountIdentifier
+        - invitedByIdentityIdentifier
+        - email
+        - token
+        - status
+        - expiresAt
+        - createdAt
+      properties:
+        invitationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Invitation identifier.
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Target account identifier.
+        invitedByIdentityIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier that created the invitation.
+        email:
+          type: string
+          description: Invitee email address.
+        token:
+          type: string
+          description: Invitation token.
+        status:
+          type: string
+          description: Invitation status.
+        expiresAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Invitation expiration timestamp.
+        createdAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Invitation creation timestamp.
+      description: Invitation state.
+    KPool.Common.ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          description: URI reference identifying the problem type.
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code.
+        title:
+          type: string
+          description: Short error title.
+        detail:
+          type: string
+          description: Human-readable error detail.
+        instance:
+          type: string
+          description: URI reference identifying the specific occurrence.
+      description: RFC 9457 Problem Details payload shared by JSON error responses.
+    MutateIdentityGroupMemberRequestBody:
+      type: object
+      required:
+        - identityIdentifier
+      properties:
+        identityIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier to add or remove.
+      description: Request body for mutating identity group membership.
+    RejectAffiliationRequestBody:
+      type: object
+      required:
+        - rejectorAccountIdentifier
+      properties:
+        rejectorAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Rejector account identifier.
+      description: Request body for rejecting an affiliation.
+    RejectVerificationRequestBody:
+      type: object
+      required:
+        - reviewerAccountIdentifier
+        - rejectionReasonCode
+      properties:
+        reviewerAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Reviewer account identifier.
+        rejectionReasonCode:
+          type: string
+          description: Rejection reason code.
+        rejectionReasonDetail:
+          type: string
+          nullable: true
+          description: Optional rejection detail.
+      description: Request body for rejecting account verification.
+    RequestAffiliationRequestBody:
+      type: object
+      required:
+        - agencyAccountIdentifier
+        - talentAccountIdentifier
+        - requestedBy
+      properties:
+        agencyAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Agency account identifier.
+        talentAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Talent account identifier.
+        requestedBy:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Account identifier that requested the affiliation.
+        terms:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/AffiliationTermsSummary'
+          nullable: true
+          description: Optional contract terms.
+      description: Request body for requesting an affiliation.
+    RequestDelegationRequestBody:
+      type: object
+      required:
+        - affiliationIdentifier
+        - delegateIdentifier
+        - delegatorIdentifier
+      properties:
+        affiliationIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Affiliation identifier used for delegation.
+        delegateIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier of the delegate.
+        delegatorIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier of the delegator.
+      description: Request body for requesting a delegation.
+    RequestVerificationRequestBody:
+      type: object
+      required:
+        - accountIdentifier
+        - verificationType
+        - applicantName
+        - documents
+      properties:
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Account identifier under review.
+        verificationType:
+          type: string
+          description: Verification type.
+        applicantName:
+          type: string
+          description: Applicant full name.
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerificationDocumentUploadRequestBody'
+          description: Documents submitted for review.
+      description: Request body for requesting account verification.
+    RevokeDelegationRequestBody:
+      type: object
+      required:
+        - revokerIdentifier
+      properties:
+        revokerIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier revoking the delegation.
+      description: Request body for revoking a delegation.
+    TerminateAffiliationRequestBody:
+      type: object
+      required:
+        - terminatorAccountIdentifier
+      properties:
+        terminatorAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Terminator account identifier.
+      description: Request body for terminating an affiliation.
+    Timestamp:
+      type: string
+      description: Timestamp in ISO 8601 format.
+    Uuid:
+      type: string
+      format: uuid
+      description: UUID identifier.
+    VerificationDocumentSummary:
+      type: object
+      required:
+        - documentIdentifier
+        - documentType
+        - documentPath
+        - originalFileName
+        - fileSizeBytes
+        - uploadedAt
+      properties:
+        documentIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Document identifier.
+        documentType:
+          type: string
+          description: Document type.
+        documentPath:
+          type: string
+          description: Stored document path.
+        originalFileName:
+          type: string
+          description: Original file name.
+        fileSizeBytes:
+          type: integer
+          format: int32
+          description: Document size in bytes.
+        uploadedAt:
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          description: Timestamp when the document was uploaded.
+      description: Verification document state.
+    VerificationDocumentUploadRequestBody:
+      type: object
+      required:
+        - documentType
+        - fileName
+        - fileContents
+        - fileSizeBytes
+      properties:
+        documentType:
+          type: string
+          description: Document type.
+        fileName:
+          type: string
+          description: Original file name.
+        fileContents:
+          type: string
+          description: Base64-encoded file contents.
+        fileSizeBytes:
+          type: integer
+          format: int32
+          description: Document size in bytes.
+      description: Verification document submitted by the applicant.
+    VerificationRejectionReasonSummary:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          description: Reason code.
+        detail:
+          type: string
+          nullable: true
+          description: Optional reviewer detail.
+      description: Verification rejection reason.
 servers:
   - url: /api/account
     description: Laravel route prefix from bootstrap/app.php.

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1740,6 +1740,9 @@ components:
     KPool.Common.ProblemDetails:
       type: object
       properties:
+        type:
+          type: string
+          description: URI reference identifying the problem type.
         status:
           type: integer
           format: int32
@@ -1750,6 +1753,9 @@ components:
         detail:
           type: string
           description: Human-readable error detail.
+        instance:
+          type: string
+          description: URI reference identifying the specific occurrence.
       description: RFC 9457 Problem Details payload shared by JSON error responses.
     MutatePrincipalGroupMemberRequestBody:
       type: object

--- a/typespec/common/problem-details.tsp
+++ b/typespec/common/problem-details.tsp
@@ -4,6 +4,9 @@ namespace KPool.Common;
 
 @doc("RFC 9457 Problem Details payload shared by JSON error responses.")
 model ProblemDetails {
+  @doc("URI reference identifying the problem type.")
+  type?: string;
+
   @doc("HTTP status code.")
   status?: int32;
 
@@ -12,6 +15,14 @@ model ProblemDetails {
 
   @doc("Human-readable error detail.")
   detail?: string;
+
+  @doc("URI reference identifying the specific occurrence.")
+  instance?: string;
+}
+
+model UnauthorizedProblemResponse {
+  @statusCode statusCode: 401;
+  @body body: ProblemDetails;
 }
 
 model ForbiddenProblemResponse {

--- a/typespec/services/account-api.tsp
+++ b/typespec/services/account-api.tsp
@@ -1,3 +1,12 @@
+import "./account-api/common.tsp";
+import "./account-api/account.tsp";
+import "./account-api/delegation.tsp";
+import "./account-api/delegation-permission.tsp";
+import "./account-api/identity-group.tsp";
+import "./account-api/invitation.tsp";
+import "./account-api/account-verification.tsp";
+import "./account-api/affiliation.tsp";
+
 using TypeSpec.Http;
 
 @service(#{ title: "k-pool Account API" })

--- a/typespec/services/account-api/account-verification.tsp
+++ b/typespec/services/account-api/account-verification.tsp
@@ -1,0 +1,80 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@doc("Verification document submitted by the applicant.")
+model VerificationDocumentUploadRequestBody {
+  @doc("Document type.")
+  documentType: string;
+  @doc("Original file name.")
+  fileName: string;
+  @doc("Base64-encoded file contents.")
+  fileContents: string;
+  @doc("Document size in bytes.")
+  fileSizeBytes: int32;
+}
+
+@doc("Request body for requesting account verification.")
+model RequestVerificationRequestBody {
+  @doc("Account identifier under review.")
+  accountIdentifier: Uuid;
+  @doc("Verification type.")
+  verificationType: string;
+  @doc("Applicant full name.")
+  applicantName: string;
+  @doc("Documents submitted for review.")
+  documents: VerificationDocumentUploadRequestBody[];
+}
+
+@doc("Request body for approving account verification.")
+model ApproveVerificationRequestBody {
+  @doc("Reviewer account identifier.")
+  reviewerAccountIdentifier: Uuid;
+}
+
+@doc("Request body for rejecting account verification.")
+model RejectVerificationRequestBody {
+  @doc("Reviewer account identifier.")
+  reviewerAccountIdentifier: Uuid;
+  @doc("Rejection reason code.")
+  rejectionReasonCode: string;
+  @doc("Optional rejection detail.")
+  rejectionReasonDetail?: string | null;
+}
+
+@doc("Response returned when an account verification is created.")
+model CreateAccountVerificationResponse {
+  @statusCode statusCode: 201;
+  @body body: AccountVerificationSummary;
+}
+
+@doc("Response returned when an account verification operation succeeds.")
+model OkAccountVerificationResponse {
+  @statusCode statusCode: 200;
+  @body body: AccountVerificationSummary;
+}
+
+@route("/account-verifications")
+interface AccountVerificationOperations {
+  @post
+  @doc("Request account verification.")
+  requestVerification(
+    @body body: RequestVerificationRequestBody,
+  ): CreateAccountVerificationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{verificationId}/approve")
+  @doc("Approve account verification.")
+  approveVerification(
+    @path verificationId: Uuid,
+    @body body: ApproveVerificationRequestBody,
+  ): OkAccountVerificationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{verificationId}/reject")
+  @doc("Reject account verification.")
+  rejectVerification(
+    @path verificationId: Uuid,
+    @body body: RejectVerificationRequestBody,
+  ): OkAccountVerificationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}

--- a/typespec/services/account-api/account.tsp
+++ b/typespec/services/account-api/account.tsp
@@ -1,0 +1,43 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@doc("Request body for creating an account.")
+model CreateAccountRequestBody {
+  @doc("Account email address.")
+  email: string;
+  @doc("Account type.")
+  accountType: string;
+  @doc("Account display name.")
+  accountName: string;
+  @doc("Identity identifier to attach to the account.")
+  identityIdentifier?: Uuid | null;
+}
+
+@doc("Response returned when an account is created.")
+model CreateAccountResponse {
+  @statusCode statusCode: 201;
+  @body body: CreatedAccountSummary;
+}
+
+@doc("Response returned when an account operation succeeds.")
+model OkAccountResponse {
+  @statusCode statusCode: 200;
+  @body body: AccountSummary;
+}
+
+@route("/accounts")
+interface AccountOperations {
+  @post
+  @doc("Create an account.")
+  createAccount(
+    @body body: CreateAccountRequestBody,
+  ): CreateAccountResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @delete
+  @route("/{accountId}")
+  @doc("Delete an account.")
+  deleteAccount(
+    @path accountId: Uuid,
+  ): OkAccountResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}

--- a/typespec/services/account-api/affiliation.tsp
+++ b/typespec/services/account-api/affiliation.tsp
@@ -1,0 +1,78 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@doc("Request body for requesting an affiliation.")
+model RequestAffiliationRequestBody {
+  @doc("Agency account identifier.")
+  agencyAccountIdentifier: Uuid;
+  @doc("Talent account identifier.")
+  talentAccountIdentifier: Uuid;
+  @doc("Account identifier that requested the affiliation.")
+  requestedBy: Uuid;
+  @doc("Optional contract terms.")
+  terms?: AffiliationTermsSummary | null;
+}
+
+@doc("Request body for approving an affiliation.")
+model ApproveAffiliationRequestBody {
+  @doc("Approver account identifier.")
+  approverAccountIdentifier: Uuid;
+}
+
+@doc("Request body for rejecting an affiliation.")
+model RejectAffiliationRequestBody {
+  @doc("Rejector account identifier.")
+  rejectorAccountIdentifier: Uuid;
+}
+
+@doc("Request body for terminating an affiliation.")
+model TerminateAffiliationRequestBody {
+  @doc("Terminator account identifier.")
+  terminatorAccountIdentifier: Uuid;
+}
+
+@doc("Response returned when an affiliation is created.")
+model CreateAffiliationResponse {
+  @statusCode statusCode: 201;
+  @body body: AffiliationSummary;
+}
+
+@doc("Response returned when an affiliation operation succeeds.")
+model OkAffiliationResponse {
+  @statusCode statusCode: 200;
+  @body body: AffiliationSummary;
+}
+
+@route("/affiliations")
+interface AffiliationOperations {
+  @post
+  @doc("Request an affiliation.")
+  requestAffiliation(
+    @body body: RequestAffiliationRequestBody,
+  ): CreateAffiliationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{affiliationId}/approve")
+  @doc("Approve an affiliation.")
+  approveAffiliation(
+    @path affiliationId: Uuid,
+    @body body: ApproveAffiliationRequestBody,
+  ): OkAffiliationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{affiliationId}/reject")
+  @doc("Reject an affiliation.")
+  rejectAffiliation(
+    @path affiliationId: Uuid,
+    @body body: RejectAffiliationRequestBody,
+  ): NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{affiliationId}/terminate")
+  @doc("Terminate an affiliation.")
+  terminateAffiliation(
+    @path affiliationId: Uuid,
+    @body body: TerminateAffiliationRequestBody,
+  ): OkAffiliationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}

--- a/typespec/services/account-api/common.tsp
+++ b/typespec/services/account-api/common.tsp
@@ -1,0 +1,191 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@format("uuid")
+@doc("UUID identifier.")
+scalar Uuid extends string;
+
+@doc("Timestamp in ISO 8601 format.")
+scalar Timestamp extends string;
+
+@doc("Response with no content.")
+model NoContentResponse {
+  @statusCode statusCode: 204;
+}
+
+@doc("Current account state.")
+model AccountSummary {
+  @doc("Account identifier.")
+  accountIdentifier: Uuid;
+  @doc("Account email address.")
+  email: string;
+  @doc("Account type.")
+  type: string;
+  @doc("Account display name.")
+  name: string;
+  @doc("Account status.")
+  status: string;
+}
+
+@doc("Account creation result.")
+model CreatedAccountSummary extends AccountSummary {
+  @doc("Account category assigned during creation.")
+  accountCategory: string;
+}
+
+@doc("Affiliation contract terms.")
+model AffiliationTermsSummary {
+  @doc("Revenue share percentage.")
+  revenueSharePercentage?: int32;
+  @doc("Free-form contract notes.")
+  contractNotes?: string;
+}
+
+@doc("Affiliation state.")
+model AffiliationSummary {
+  @doc("Affiliation identifier.")
+  affiliationIdentifier: Uuid;
+  @doc("Agency account identifier.")
+  agencyAccountIdentifier: Uuid;
+  @doc("Talent account identifier.")
+  talentAccountIdentifier: Uuid;
+  @doc("Account that initiated the affiliation workflow.")
+  requestedBy: Uuid;
+  @doc("Affiliation status.")
+  status: string;
+  @doc("Optional affiliation terms.")
+  terms?: AffiliationTermsSummary | null;
+  @doc("Timestamp when the affiliation was requested.")
+  requestedAt: Timestamp;
+  @doc("Timestamp when the affiliation was activated.")
+  activatedAt?: Timestamp | null;
+  @doc("Timestamp when the affiliation was terminated.")
+  terminatedAt?: Timestamp | null;
+}
+
+@doc("Delegation state.")
+model DelegationSummary {
+  @doc("Delegation identifier.")
+  delegationIdentifier: Uuid;
+  @doc("Affiliation identifier backing the delegation.")
+  affiliationIdentifier: Uuid;
+  @doc("Delegate identity identifier.")
+  delegateIdentifier: Uuid;
+  @doc("Delegator identity identifier.")
+  delegatorIdentifier: Uuid;
+  @doc("Delegation status.")
+  status: string;
+  @doc("Delegation direction.")
+  direction: string;
+  @doc("Timestamp when the delegation was requested.")
+  requestedAt: Timestamp;
+  @doc("Timestamp when the delegation was approved.")
+  approvedAt?: Timestamp | null;
+  @doc("Timestamp when the delegation was revoked.")
+  revokedAt?: Timestamp | null;
+}
+
+@doc("Delegation permission state.")
+model DelegationPermissionSummary {
+  @doc("Delegation permission identifier.")
+  delegationPermissionIdentifier: Uuid;
+  @doc("Identity group identifier that owns the permission.")
+  identityGroupIdentifier: Uuid;
+  @doc("Target account identifier.")
+  targetAccountIdentifier: Uuid;
+  @doc("Affiliation identifier covered by the permission.")
+  affiliationIdentifier: Uuid;
+  @doc("Timestamp when the permission was created.")
+  createdAt: Timestamp;
+}
+
+@doc("Identity group snapshot returned after updates.")
+model IdentityGroupSummary {
+  @doc("Identity group identifier.")
+  identityGroupIdentifier: Uuid;
+  @doc("Owning account identifier.")
+  accountIdentifier: Uuid;
+  @doc("Identity group name.")
+  name: string;
+  @doc("Identity group role.")
+  role: string;
+  @doc("Whether this is the default identity group.")
+  isDefault: boolean;
+  @doc("Identity identifiers currently assigned to the group.")
+  members?: Uuid[];
+}
+
+@doc("Identity group snapshot returned immediately after creation.")
+model CreatedIdentityGroupSummary extends IdentityGroupSummary {
+  @doc("Timestamp when the identity group was created.")
+  createdAt: Timestamp;
+}
+
+@doc("Invitation state.")
+model InvitationSummary {
+  @doc("Invitation identifier.")
+  invitationIdentifier: Uuid;
+  @doc("Target account identifier.")
+  accountIdentifier: Uuid;
+  @doc("Identity identifier that created the invitation.")
+  invitedByIdentityIdentifier: Uuid;
+  @doc("Invitee email address.")
+  email: string;
+  @doc("Invitation token.")
+  token: string;
+  @doc("Invitation status.")
+  status: string;
+  @doc("Invitation expiration timestamp.")
+  expiresAt: Timestamp;
+  @doc("Invitation creation timestamp.")
+  createdAt: Timestamp;
+}
+
+@doc("Verification rejection reason.")
+model VerificationRejectionReasonSummary {
+  @doc("Reason code.")
+  code: string;
+  @doc("Optional reviewer detail.")
+  detail?: string | null;
+}
+
+@doc("Verification document state.")
+model VerificationDocumentSummary {
+  @doc("Document identifier.")
+  documentIdentifier: Uuid;
+  @doc("Document type.")
+  documentType: string;
+  @doc("Stored document path.")
+  documentPath: string;
+  @doc("Original file name.")
+  originalFileName: string;
+  @doc("Document size in bytes.")
+  fileSizeBytes: int32;
+  @doc("Timestamp when the document was uploaded.")
+  uploadedAt: Timestamp;
+}
+
+@doc("Account verification state.")
+model AccountVerificationSummary {
+  @doc("Verification identifier.")
+  verificationIdentifier: Uuid;
+  @doc("Account identifier under review.")
+  accountIdentifier: Uuid;
+  @doc("Verification type.")
+  verificationType: string;
+  @doc("Verification status.")
+  status: string;
+  @doc("Applicant full name.")
+  applicantName: string;
+  @doc("Timestamp when the verification was requested.")
+  requestedAt: Timestamp;
+  @doc("Reviewer account identifier.")
+  reviewedBy?: Uuid | null;
+  @doc("Timestamp when the verification was reviewed.")
+  reviewedAt?: Timestamp | null;
+  @doc("Optional rejection reason.")
+  rejectionReason?: VerificationRejectionReasonSummary | null;
+  @doc("Submitted documents.")
+  documents: VerificationDocumentSummary[];
+}

--- a/typespec/services/account-api/delegation-permission.tsp
+++ b/typespec/services/account-api/delegation-permission.tsp
@@ -1,0 +1,35 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@doc("Request body for granting a delegation permission.")
+model GrantDelegationPermissionRequestBody {
+  @doc("Identity group identifier receiving the permission.")
+  identityGroupIdentifier: Uuid;
+  @doc("Account identifier that can be delegated.")
+  targetAccountIdentifier: Uuid;
+  @doc("Affiliation identifier covered by the permission.")
+  affiliationIdentifier: Uuid;
+}
+
+@doc("Response returned when a delegation permission is created.")
+model CreateDelegationPermissionResponse {
+  @statusCode statusCode: 201;
+  @body body: DelegationPermissionSummary;
+}
+
+@route("/delegation-permissions")
+interface DelegationPermissionOperations {
+  @post
+  @doc("Grant a delegation permission.")
+  grantDelegationPermission(
+    @body body: GrantDelegationPermissionRequestBody,
+  ): CreateDelegationPermissionResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @delete
+  @route("/{delegationPermissionId}")
+  @doc("Revoke a delegation permission.")
+  revokeDelegationPermission(
+    @path delegationPermissionId: Uuid,
+  ): NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}

--- a/typespec/services/account-api/delegation.tsp
+++ b/typespec/services/account-api/delegation.tsp
@@ -1,0 +1,62 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@doc("Request body for requesting a delegation.")
+model RequestDelegationRequestBody {
+  @doc("Affiliation identifier used for delegation.")
+  affiliationIdentifier: Uuid;
+  @doc("Identity identifier of the delegate.")
+  delegateIdentifier: Uuid;
+  @doc("Identity identifier of the delegator.")
+  delegatorIdentifier: Uuid;
+}
+
+@doc("Request body for approving a delegation.")
+model ApproveDelegationRequestBody {
+  @doc("Identity identifier approving the delegation.")
+  approverIdentifier: Uuid;
+}
+
+@doc("Request body for revoking a delegation.")
+model RevokeDelegationRequestBody {
+  @doc("Identity identifier revoking the delegation.")
+  revokerIdentifier: Uuid;
+}
+
+@doc("Response returned when a delegation is created.")
+model CreateDelegationResponse {
+  @statusCode statusCode: 201;
+  @body body: DelegationSummary;
+}
+
+@doc("Response returned when a delegation operation succeeds.")
+model OkDelegationResponse {
+  @statusCode statusCode: 200;
+  @body body: DelegationSummary;
+}
+
+@route("/delegations")
+interface DelegationOperations {
+  @post
+  @doc("Request a delegation.")
+  requestDelegation(
+    @body body: RequestDelegationRequestBody,
+  ): CreateDelegationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{delegationId}/approve")
+  @doc("Approve a delegation.")
+  approveDelegation(
+    @path delegationId: Uuid,
+    @body body: ApproveDelegationRequestBody,
+  ): OkDelegationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{delegationId}/revoke")
+  @doc("Revoke a delegation.")
+  revokeDelegation(
+    @path delegationId: Uuid,
+    @body body: RevokeDelegationRequestBody,
+  ): OkDelegationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}

--- a/typespec/services/account-api/identity-group.tsp
+++ b/typespec/services/account-api/identity-group.tsp
@@ -1,0 +1,63 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@doc("Request body for creating an identity group.")
+model CreateIdentityGroupRequestBody {
+  @doc("Owning account identifier.")
+  accountIdentifier: Uuid;
+  @doc("Identity group name.")
+  name: string;
+  @doc("Role assigned to the identity group.")
+  role: string;
+}
+
+@doc("Request body for mutating identity group membership.")
+model MutateIdentityGroupMemberRequestBody {
+  @doc("Identity identifier to add or remove.")
+  identityIdentifier: Uuid;
+}
+
+@doc("Response returned when an identity group is created.")
+model CreateIdentityGroupResponse {
+  @statusCode statusCode: 201;
+  @body body: CreatedIdentityGroupSummary;
+}
+
+@doc("Response returned when an identity group operation succeeds.")
+model OkIdentityGroupResponse {
+  @statusCode statusCode: 200;
+  @body body: IdentityGroupSummary;
+}
+
+@route("/identity-groups")
+interface IdentityGroupOperations {
+  @post
+  @doc("Create an identity group.")
+  createIdentityGroup(
+    @body body: CreateIdentityGroupRequestBody,
+  ): CreateIdentityGroupResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{identityGroupId}/add-member")
+  @doc("Add an identity to an identity group.")
+  addIdentityToIdentityGroup(
+    @path identityGroupId: Uuid,
+    @body body: MutateIdentityGroupMemberRequestBody,
+  ): OkIdentityGroupResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{identityGroupId}/remove-member")
+  @doc("Remove an identity from an identity group.")
+  removeIdentityFromIdentityGroup(
+    @path identityGroupId: Uuid,
+    @body body: MutateIdentityGroupMemberRequestBody,
+  ): OkIdentityGroupResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @delete
+  @route("/{identityGroupId}")
+  @doc("Delete an identity group.")
+  deleteIdentityGroup(
+    @path identityGroupId: Uuid,
+  ): NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}

--- a/typespec/services/account-api/invitation.tsp
+++ b/typespec/services/account-api/invitation.tsp
@@ -1,0 +1,28 @@
+using TypeSpec.Http;
+
+namespace KPool.AccountApi;
+
+@doc("Request body for creating invitations.")
+model CreateInvitationRequestBody {
+  @doc("Account identifier that owns the invitations.")
+  accountIdentifier: Uuid;
+  @doc("Identity identifier sending the invitations.")
+  inviterIdentityIdentifier: Uuid;
+  @doc("Invitee email addresses.")
+  emails: string[];
+}
+
+@doc("Response returned when invitations are created.")
+model CreateInvitationResponse {
+  @statusCode statusCode: 201;
+  @body body: InvitationSummary[];
+}
+
+@route("/invitations")
+interface InvitationOperations {
+  @post
+  @doc("Create invitations for one or more email addresses.")
+  createInvitation(
+    @body body: CreateInvitationRequestBody,
+  ): CreateInvitationResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}


### PR DESCRIPTION
## 📝 変更内容

- Account API 向け TypeSpec 定義を新規追加
- accounts / delegations / delegation-permissions / identity-groups / invitations / account-verifications / affiliations の各操作と共通モデルを定義
- `ProblemDetails` に `type` / `instance` を追加し、401 応答モデルを定義
- Account API の OpenAPI 出力を更新し、Wiki Private API の OpenAPI 出力にも共通定義変更を反映

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Account API についても既存の Webhook API / Wiki API と同様に TypeSpec ベースで契約を管理できるようにし、OpenAPI を生成可能な状態に揃えるためです。あわせて、エラーレスポンスの共通表現を RFC 9457 に寄せて補強しています。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- 各 TypeSpec 定義が実際の Account API のユースケースと命名に沿っているか
- 共通モデルとレスポンスコードの切り出し方に不足や過不足がないか
- 生成された OpenAPI 差分が想定どおりの契約になっているか

## 📖 関連情報

### 関連Issue・タスク

Closes #304

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した