### PR TITLE
Add: Identity API 向けの TypeSpec 定義を追加

### DIFF
--- a/doc/openapi/KPool.IdentityApi.openapi.yaml
+++ b/doc/openapi/KPool.IdentityApi.openapi.yaml
@@ -3,8 +3,472 @@ info:
   title: k-pool Identity API
   version: 0.0.0
 tags: []
-paths: {}
-components: {}
+paths:
+  /auth/login:
+    post:
+      operationId: IdentityAuthOperations_login
+      description: Authenticate with email and password.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when an identity operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentitySummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequestBody'
+  /auth/logout:
+    post:
+      operationId: IdentityAuthOperations_logout
+      description: Log out the current authenticated identity.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when an endpoint succeeds with an empty JSON object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyJsonObject'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /auth/register:
+    post:
+      operationId: IdentityAuthOperations_createIdentity
+      description: Register a new identity.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when an identity is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentitySummary'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIdentityRequestBody'
+  /auth/send-auth-code:
+    post:
+      operationId: IdentityAuthOperations_sendAuthCode
+      description: Send an auth code to the specified email address.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when an endpoint succeeds with an empty JSON object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyJsonObject'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendAuthCodeRequestBody'
+  /auth/social/{provider}/callback:
+    get:
+      operationId: IdentityAuthOperations_socialLoginCallback
+      description: Handle the social login callback and return the client redirect URL.
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+          explode: false
+        - name: state
+          in: query
+          required: true
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: Response returned by social login endpoints.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedirectUrlResult'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /auth/social/{provider}/redirect:
+    get:
+      operationId: IdentityAuthOperations_socialLoginRedirect
+      description: Create an OAuth redirect URL for the selected social provider.
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: accountType
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+        - name: invitationToken
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: Response returned by social login endpoints.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedirectUrlResult'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /auth/switch-identity:
+    post:
+      operationId: IdentityAuthOperations_switchIdentity
+      description: Switch the current authenticated identity or clear delegation.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when identity switching succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SwitchedIdentitySummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SwitchIdentityRequestBody'
+  /auth/verify-email:
+    post:
+      operationId: IdentityAuthOperations_verifyEmail
+      description: Verify an email address using the issued auth code.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when email verification succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifyEmailResult'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyEmailRequestBody'
+components:
+  schemas:
+    CreateIdentityRequestBody:
+      type: object
+      required:
+        - username
+        - email
+        - password
+        - confirmedPassword
+      properties:
+        username:
+          type: string
+          description: Requested username.
+        email:
+          type: string
+          description: Email address.
+        password:
+          type: string
+          description: Plain text password.
+        confirmedPassword:
+          type: string
+          description: Password confirmation.
+        base64EncodedImage:
+          type: string
+          nullable: true
+          description: Base64-encoded profile image.
+        invitationToken:
+          type: string
+          nullable: true
+          description: Invitation token used during signup.
+      description: Request body for registering a new identity.
+    EmptyJsonObject:
+      type: object
+      description: Empty JSON object returned by endpoints with no payload.
+    IdentitySummary:
+      type: object
+      required:
+        - identityIdentifier
+        - username
+        - email
+        - language
+      properties:
+        identityIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          description: Identity identifier.
+        username:
+          type: string
+          description: Username.
+        email:
+          type: string
+          description: Email address.
+        language:
+          type: string
+          description: Language code associated with the identity.
+        profileImage:
+          type: string
+          nullable: true
+          description: Profile image path.
+      description: Identity summary returned after authentication-related operations.
+    KPool.Common.ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          description: URI reference identifying the problem type.
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code.
+        title:
+          type: string
+          description: Short error title.
+        detail:
+          type: string
+          description: Human-readable error detail.
+        instance:
+          type: string
+          description: URI reference identifying the specific occurrence.
+      description: RFC 9457 Problem Details payload shared by JSON error responses.
+    LoginRequestBody:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          description: Email address.
+        password:
+          type: string
+          description: Plain text password.
+      description: Request body for logging in.
+    RedirectUrlResult:
+      type: object
+      required:
+        - redirectUrl
+      properties:
+        redirectUrl:
+          type: string
+          description: Client redirect URL returned by the backend.
+      description: Redirect URL payload used by social login endpoints.
+    SendAuthCodeRequestBody:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          description: Email address that will receive the auth code.
+      description: Request body for sending an auth code.
+    SwitchIdentityRequestBody:
+      type: object
+      properties:
+        targetDelegationIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Uuid'
+          nullable: true
+          description: Delegation identifier to switch into. Null means returning to the original identity.
+      description: Request body for switching the active identity.
+    SwitchedIdentitySummary:
+      type: object
+      required:
+        - isDelegated
+      properties:
+        isDelegated:
+          type: boolean
+          description: Whether the active identity is delegated.
+      allOf:
+        - $ref: '#/components/schemas/IdentitySummary'
+      description: Identity summary returned after switching active identity.
+    Timestamp:
+      type: string
+      description: Timestamp in ISO 8601 format.
+    Uuid:
+      type: string
+      format: uuid
+      description: UUID identifier.
+    VerifyEmailRequestBody:
+      type: object
+      required:
+        - email
+        - authCode
+      properties:
+        email:
+          type: string
+          description: Email address being verified.
+        authCode:
+          type: string
+          description: Auth code delivered to the email address.
+      description: Request body for verifying an auth code.
+    VerifyEmailResult:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          description: Verified email address.
+        verifiedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Timestamp'
+          nullable: true
+          description: Timestamp when the email was verified.
+      description: Email verification result.
 servers:
   - url: /api/identity
     description: Laravel route prefix from bootstrap/app.php.

--- a/typespec/services/identity-api.tsp
+++ b/typespec/services/identity-api.tsp
@@ -3,3 +3,188 @@ using TypeSpec.Http;
 @service(#{ title: "k-pool Identity API" })
 @server("/api/identity", "Laravel route prefix from bootstrap/app.php.")
 namespace KPool.IdentityApi;
+
+@format("uuid")
+@doc("UUID identifier.")
+scalar Uuid extends string;
+
+@doc("Timestamp in ISO 8601 format.")
+scalar Timestamp extends string;
+
+@doc("Empty JSON object returned by endpoints with no payload.")
+model EmptyJsonObject {}
+
+@doc("Identity summary returned after authentication-related operations.")
+model IdentitySummary {
+  @doc("Identity identifier.")
+  identityIdentifier: Uuid;
+  @doc("Username.")
+  username: string;
+  @doc("Email address.")
+  email: string;
+  @doc("Language code associated with the identity.")
+  language: string;
+  @doc("Profile image path.")
+  profileImage?: string | null;
+}
+
+@doc("Identity summary returned after switching active identity.")
+model SwitchedIdentitySummary extends IdentitySummary {
+  @doc("Whether the active identity is delegated.")
+  isDelegated: boolean;
+}
+
+@doc("Email verification result.")
+model VerifyEmailResult {
+  @doc("Verified email address.")
+  email: string;
+  @doc("Timestamp when the email was verified.")
+  verifiedAt?: Timestamp | null;
+}
+
+@doc("Redirect URL payload used by social login endpoints.")
+model RedirectUrlResult {
+  @doc("Client redirect URL returned by the backend.")
+  redirectUrl: string;
+}
+
+@doc("Request body for sending an auth code.")
+model SendAuthCodeRequestBody {
+  @doc("Email address that will receive the auth code.")
+  email: string;
+}
+
+@doc("Request body for verifying an auth code.")
+model VerifyEmailRequestBody {
+  @doc("Email address being verified.")
+  email: string;
+  @doc("Auth code delivered to the email address.")
+  authCode: string;
+}
+
+@doc("Request body for registering a new identity.")
+model CreateIdentityRequestBody {
+  @doc("Requested username.")
+  username: string;
+  @doc("Email address.")
+  email: string;
+  @doc("Plain text password.")
+  password: string;
+  @doc("Password confirmation.")
+  confirmedPassword: string;
+  @doc("Base64-encoded profile image.")
+  base64EncodedImage?: string | null;
+  @doc("Invitation token used during signup.")
+  invitationToken?: string | null;
+}
+
+@doc("Request body for logging in.")
+model LoginRequestBody {
+  @doc("Email address.")
+  email: string;
+  @doc("Plain text password.")
+  password: string;
+}
+
+@doc("Request body for switching the active identity.")
+model SwitchIdentityRequestBody {
+  @doc("Delegation identifier to switch into. Null means returning to the original identity.")
+  targetDelegationIdentifier?: Uuid | null;
+}
+
+@doc("Response returned when an endpoint succeeds with an empty JSON object.")
+model OkEmptyResponse {
+  @statusCode statusCode: 200;
+  @body body: EmptyJsonObject;
+}
+
+@doc("Response returned when an identity is created.")
+model CreateIdentityResponse {
+  @statusCode statusCode: 201;
+  @body body: IdentitySummary;
+}
+
+@doc("Response returned when an identity operation succeeds.")
+model OkIdentityResponse {
+  @statusCode statusCode: 200;
+  @body body: IdentitySummary;
+}
+
+@doc("Response returned when email verification succeeds.")
+model VerifyEmailResponse {
+  @statusCode statusCode: 200;
+  @body body: VerifyEmailResult;
+}
+
+@doc("Response returned when identity switching succeeds.")
+model SwitchIdentityResponse {
+  @statusCode statusCode: 200;
+  @body body: SwitchedIdentitySummary;
+}
+
+@doc("Response returned by social login endpoints.")
+model RedirectUrlResponse {
+  @statusCode statusCode: 200;
+  @body body: RedirectUrlResult;
+}
+
+@route("/auth")
+interface IdentityAuthOperations {
+  @post
+  @route("/send-auth-code")
+  @doc("Send an auth code to the specified email address.")
+  sendAuthCode(
+    @body body: SendAuthCodeRequestBody,
+  ): OkEmptyResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/verify-email")
+  @doc("Verify an email address using the issued auth code.")
+  verifyEmail(
+    @body body: VerifyEmailRequestBody,
+  ): VerifyEmailResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/register")
+  @doc("Register a new identity.")
+  createIdentity(
+    @body body: CreateIdentityRequestBody,
+  ): CreateIdentityResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/login")
+  @doc("Authenticate with email and password.")
+  login(
+    @body body: LoginRequestBody,
+  ): OkIdentityResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/social/{provider}/redirect")
+  @doc("Create an OAuth redirect URL for the selected social provider.")
+  socialLoginRedirect(
+    @path provider: string,
+    @query accountType?: string,
+    @query invitationToken?: string,
+  ): RedirectUrlResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/social/{provider}/callback")
+  @doc("Handle the social login callback and return the client redirect URL.")
+  socialLoginCallback(
+    @path provider: string,
+    @query code: string,
+    @query state: string,
+  ): RedirectUrlResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/logout")
+  @doc("Log out the current authenticated identity.")
+  logout(): OkEmptyResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/switch-identity")
+  @doc("Switch the current authenticated identity or clear delegation.")
+  switchIdentity(
+    @body body: SwitchIdentityRequestBody,
+  ): SwitchIdentityResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}


### PR DESCRIPTION
## 📝 変更内容

- Identity API 向けの TypeSpec 定義を追加
- 認証・本人確認・ソーシャルログイン・委譲切替に関するエンドポイントを定義
- 追加した TypeSpec から生成される OpenAPI YAML を更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Identity API についても他 API と同様に TypeSpec ベースで仕様を管理し、OpenAPI を一貫した形で生成できるようにするためです。これにより、認証系エンドポイントの入出力とエラー応答を明文化できます。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `typespec/services/identity-api.tsp` のエンドポイント定義が既存の Laravel 実装と一致しているか
- 各 request/response モデルの必須・nullable 設定が実 API の契約と一致しているか
- OpenAPI 生成結果に不足や過剰な schema 定義がないか
- 認証系の異常系レスポンスコード定義が妥当か

## 📖 関連情報

### 関連Issue・タスク

Closes #303

## ⚠️ 注意事項

- OpenAPI 生成物を含むため差分量が大きいです
- 破壊的変更やマイグレーションは特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した