### PR TITLE
Add: Monetization APIの TypeSpec 定義を追加

### DIFF
--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -49,7 +49,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an account verification operation succeeds.
@@ -96,7 +96,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an account verification operation succeeds.
@@ -185,7 +185,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an account operation succeeds.
@@ -274,7 +274,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an affiliation operation succeeds.
@@ -327,7 +327,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -376,7 +376,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an affiliation operation succeeds.
@@ -471,7 +471,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -550,7 +550,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when a delegation operation succeeds.
@@ -603,7 +603,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when a delegation operation succeeds.
@@ -692,7 +692,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -729,7 +729,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an identity group operation succeeds.
@@ -776,7 +776,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an identity group operation succeeds.
@@ -871,7 +871,7 @@ components:
       properties:
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier.
         email:
           type: string
@@ -899,11 +899,11 @@ components:
       properties:
         verificationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Verification identifier.
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier under review.
         verificationType:
           type: string
@@ -916,18 +916,18 @@ components:
           description: Applicant full name.
         requestedAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Timestamp when the verification was requested.
         reviewedBy:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           nullable: true
           description: Reviewer account identifier.
         reviewedAt:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           nullable: true
           description: Timestamp when the verification was reviewed.
         rejectionReason:
@@ -954,19 +954,19 @@ components:
       properties:
         affiliationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Affiliation identifier.
         agencyAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Agency account identifier.
         talentAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Talent account identifier.
         requestedBy:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account that initiated the affiliation workflow.
         status:
           type: string
@@ -979,18 +979,18 @@ components:
           description: Optional affiliation terms.
         requestedAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Timestamp when the affiliation was requested.
         activatedAt:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           nullable: true
           description: Timestamp when the affiliation was activated.
         terminatedAt:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           nullable: true
           description: Timestamp when the affiliation was terminated.
       description: Affiliation state.
@@ -1012,7 +1012,7 @@ components:
       properties:
         approverAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Approver account identifier.
       description: Request body for approving an affiliation.
     ApproveDelegationRequestBody:
@@ -1022,7 +1022,7 @@ components:
       properties:
         approverIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier approving the delegation.
       description: Request body for approving a delegation.
     ApproveVerificationRequestBody:
@@ -1032,7 +1032,7 @@ components:
       properties:
         reviewerAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Reviewer account identifier.
       description: Request body for approving account verification.
     CreateAccountRequestBody:
@@ -1054,7 +1054,7 @@ components:
         identityIdentifier:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           nullable: true
           description: Identity identifier to attach to the account.
       description: Request body for creating an account.
@@ -1067,7 +1067,7 @@ components:
       properties:
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Owning account identifier.
         name:
           type: string
@@ -1085,11 +1085,11 @@ components:
       properties:
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier that owns the invitations.
         inviterIdentityIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier sending the invitations.
         emails:
           type: array
@@ -1115,7 +1115,7 @@ components:
       properties:
         createdAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Timestamp when the identity group was created.
       allOf:
         - $ref: '#/components/schemas/IdentityGroupSummary'
@@ -1131,23 +1131,23 @@ components:
       properties:
         delegationPermissionIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Delegation permission identifier.
         identityGroupIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity group identifier that owns the permission.
         targetAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Target account identifier.
         affiliationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Affiliation identifier covered by the permission.
         createdAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Timestamp when the permission was created.
       description: Delegation permission state.
     DelegationSummary:
@@ -1163,19 +1163,19 @@ components:
       properties:
         delegationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Delegation identifier.
         affiliationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Affiliation identifier backing the delegation.
         delegateIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Delegate identity identifier.
         delegatorIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Delegator identity identifier.
         status:
           type: string
@@ -1185,18 +1185,18 @@ components:
           description: Delegation direction.
         requestedAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Timestamp when the delegation was requested.
         approvedAt:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           nullable: true
           description: Timestamp when the delegation was approved.
         revokedAt:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           nullable: true
           description: Timestamp when the delegation was revoked.
       description: Delegation state.
@@ -1209,15 +1209,15 @@ components:
       properties:
         identityGroupIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity group identifier receiving the permission.
         targetAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier that can be delegated.
         affiliationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Affiliation identifier covered by the permission.
       description: Request body for granting a delegation permission.
     IdentityGroupSummary:
@@ -1231,11 +1231,11 @@ components:
       properties:
         identityGroupIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity group identifier.
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Owning account identifier.
         name:
           type: string
@@ -1249,7 +1249,7 @@ components:
         members:
           type: array
           items:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifiers currently assigned to the group.
       description: Identity group snapshot returned after updates.
     InvitationSummary:
@@ -1266,15 +1266,15 @@ components:
       properties:
         invitationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Invitation identifier.
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Target account identifier.
         invitedByIdentityIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier that created the invitation.
         email:
           type: string
@@ -1287,11 +1287,11 @@ components:
           description: Invitation status.
         expiresAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Invitation expiration timestamp.
         createdAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Invitation creation timestamp.
       description: Invitation state.
     KPool.Common.ProblemDetails:
@@ -1314,6 +1314,13 @@ components:
           type: string
           description: URI reference identifying the specific occurrence.
       description: RFC 9457 Problem Details payload shared by JSON error responses.
+    KPool.Common.Timestamp:
+      type: string
+      description: Timestamp in ISO 8601 format.
+    KPool.Common.Uuid:
+      type: string
+      format: uuid
+      description: UUID identifier.
     MutateIdentityGroupMemberRequestBody:
       type: object
       required:
@@ -1321,7 +1328,7 @@ components:
       properties:
         identityIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier to add or remove.
       description: Request body for mutating identity group membership.
     RejectAffiliationRequestBody:
@@ -1331,7 +1338,7 @@ components:
       properties:
         rejectorAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Rejector account identifier.
       description: Request body for rejecting an affiliation.
     RejectVerificationRequestBody:
@@ -1342,7 +1349,7 @@ components:
       properties:
         reviewerAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Reviewer account identifier.
         rejectionReasonCode:
           type: string
@@ -1361,15 +1368,15 @@ components:
       properties:
         agencyAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Agency account identifier.
         talentAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Talent account identifier.
         requestedBy:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier that requested the affiliation.
         terms:
           type: object
@@ -1387,15 +1394,15 @@ components:
       properties:
         affiliationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Affiliation identifier used for delegation.
         delegateIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier of the delegate.
         delegatorIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier of the delegator.
       description: Request body for requesting a delegation.
     RequestVerificationRequestBody:
@@ -1408,7 +1415,7 @@ components:
       properties:
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier under review.
         verificationType:
           type: string
@@ -1429,7 +1436,7 @@ components:
       properties:
         revokerIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier revoking the delegation.
       description: Request body for revoking a delegation.
     TerminateAffiliationRequestBody:
@@ -1439,16 +1446,9 @@ components:
       properties:
         terminatorAccountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Terminator account identifier.
       description: Request body for terminating an affiliation.
-    Timestamp:
-      type: string
-      description: Timestamp in ISO 8601 format.
-    Uuid:
-      type: string
-      format: uuid
-      description: UUID identifier.
     VerificationDocumentSummary:
       type: object
       required:
@@ -1461,7 +1461,7 @@ components:
       properties:
         documentIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Document identifier.
         documentType:
           type: string
@@ -1478,7 +1478,7 @@ components:
           description: Document size in bytes.
         uploadedAt:
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           description: Timestamp when the document was uploaded.
       description: Verification document state.
     VerificationDocumentUploadRequestBody:

--- a/doc/openapi/KPool.IdentityApi.openapi.yaml
+++ b/doc/openapi/KPool.IdentityApi.openapi.yaml
@@ -51,7 +51,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmptyJsonObject'
+                $ref: '#/components/schemas/KPool.Common.EmptyJsonObject'
         '401':
           description: Access is unauthorized.
           content:
@@ -123,7 +123,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EmptyJsonObject'
+                $ref: '#/components/schemas/KPool.Common.EmptyJsonObject'
         '422':
           description: Client error
           content:
@@ -333,9 +333,6 @@ components:
           nullable: true
           description: Invitation token used during signup.
       description: Request body for registering a new identity.
-    EmptyJsonObject:
-      type: object
-      description: Empty JSON object returned by endpoints with no payload.
     IdentitySummary:
       type: object
       required:
@@ -346,7 +343,7 @@ components:
       properties:
         identityIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier.
         username:
           type: string
@@ -362,6 +359,9 @@ components:
           nullable: true
           description: Profile image path.
       description: Identity summary returned after authentication-related operations.
+    KPool.Common.EmptyJsonObject:
+      type: object
+      description: Empty JSON object returned by endpoints with no payload.
     KPool.Common.ProblemDetails:
       type: object
       properties:
@@ -382,6 +382,13 @@ components:
           type: string
           description: URI reference identifying the specific occurrence.
       description: RFC 9457 Problem Details payload shared by JSON error responses.
+    KPool.Common.Timestamp:
+      type: string
+      description: Timestamp in ISO 8601 format.
+    KPool.Common.Uuid:
+      type: string
+      format: uuid
+      description: UUID identifier.
     LoginRequestBody:
       type: object
       required:
@@ -419,7 +426,7 @@ components:
         targetDelegationIdentifier:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           nullable: true
           description: Delegation identifier to switch into. Null means returning to the original identity.
       description: Request body for switching the active identity.
@@ -434,13 +441,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/IdentitySummary'
       description: Identity summary returned after switching active identity.
-    Timestamp:
-      type: string
-      description: Timestamp in ISO 8601 format.
-    Uuid:
-      type: string
-      format: uuid
-      description: UUID identifier.
     VerifyEmailRequestBody:
       type: object
       required:
@@ -465,7 +465,7 @@ components:
         verifiedAt:
           type: string
           allOf:
-            - $ref: '#/components/schemas/Timestamp'
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
           nullable: true
           description: Timestamp when the email was verified.
       description: Email verification result.

--- a/doc/openapi/KPool.MonetizationApi.openapi.yaml
+++ b/doc/openapi/KPool.MonetizationApi.openapi.yaml
@@ -3,8 +3,1239 @@ info:
   title: k-pool Monetization API
   version: 0.0.0
 tags: []
-paths: {}
-components: {}
+paths:
+  /accounts:
+    post:
+      operationId: MonetizationAccountOperations_provisionMonetizationAccount
+      description: Provision a monetization account for an existing account.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when a monetization account is provisioned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MonetizationAccountSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionMonetizationAccountRequestBody'
+  /accounts/sync-payout-account:
+    post:
+      operationId: MonetizationAccountOperations_syncPayoutAccount
+      description: Synchronize payout account data from a gateway event payload.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when a command succeeds without a payload.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {}
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncPayoutAccountRequestBody'
+  /accounts/{monetizationAccountId}/onboard-seller:
+    post:
+      operationId: MonetizationAccountOperations_onboardSeller
+      description: Create a seller onboarding URL for the specified monetization account.
+      parameters:
+        - name: monetizationAccountId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when seller onboarding succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SellerOnboardingSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnboardSellerRequestBody'
+  /accounts/{monetizationAccountId}/register-payment-method:
+    post:
+      operationId: MonetizationAccountOperations_registerPaymentMethod
+      description: Register a payment method on the specified monetization account.
+      parameters:
+        - name: monetizationAccountId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '201':
+          description: Response returned when a payment method is registered.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisteredPaymentMethodSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterPaymentMethodRequestBody'
+  /invoices:
+    post:
+      operationId: MonetizationBillingOperations_createInvoice
+      description: Create an invoice for an order.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when an invoice is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateInvoiceRequestBody'
+  /invoices/{invoiceId}/record-payment:
+    post:
+      operationId: MonetizationBillingOperations_recordPayment
+      description: Record a captured payment against an invoice.
+      parameters:
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when an invoice command succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordPaymentRequestBody'
+  /payments/authorize:
+    post:
+      operationId: MonetizationPaymentOperations_authorizePayment
+      description: Authorize a payment for an order.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when a payment command creates a payment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizePaymentRequestBody'
+  /payments/{paymentId}/capture:
+    post:
+      operationId: MonetizationPaymentOperations_capturePayment
+      description: Capture a previously authorized payment.
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when a payment command succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /payments/{paymentId}/refund:
+    post:
+      operationId: MonetizationPaymentOperations_refundPayment
+      description: Refund a captured payment.
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when a payment command succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundPaymentRequestBody'
+  /settlements/settle-revenue:
+    post:
+      operationId: MonetizationSettlementOperations_settleRevenue
+      description: Create a settlement batch and transfer from paid amounts.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when revenue settlement succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettlementResultSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SettleRevenueRequestBody'
+  /transfers/{transferId}/execute:
+    post:
+      operationId: MonetizationSettlementOperations_executeTransfer
+      description: Execute a pending transfer.
+      parameters:
+        - name: transferId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when a command succeeds without a payload.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {}
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+components:
+  schemas:
+    AccountHolderType:
+      type: string
+      enum:
+        - individual
+        - company
+      description: Account holder classification for payout accounts.
+    AccountPaymentMethodType:
+      type: string
+      enum:
+        - card
+      description: Account payment method type accepted by registration.
+    AuthorizePaymentRequestBody:
+      type: object
+      required:
+        - orderId
+        - buyerMonetizationAccountId
+        - amount
+        - currency
+        - paymentMethodId
+        - paymentMethodType
+        - paymentMethodLabel
+        - paymentMethodRecurringEnabled
+      properties:
+        orderId:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Order identifier.
+        buyerMonetizationAccountId:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Buyer monetization account identifier.
+        amount:
+          type: integer
+          format: int32
+          description: Payment amount.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Payment currency.
+        paymentMethodId:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Payment method identifier.
+        paymentMethodType:
+          allOf:
+            - $ref: '#/components/schemas/PaymentMethodType'
+          description: Payment method type.
+        paymentMethodLabel:
+          type: string
+          description: Human-readable payment method label.
+        paymentMethodRecurringEnabled:
+          type: boolean
+          description: Whether recurring usage is enabled.
+      description: Request body for authorizing a payment.
+    CreateInvoiceRequestBody:
+      type: object
+      required:
+        - orderIdentifier
+        - buyerMonetizationAccountIdentifier
+        - lines
+        - shippingCostAmount
+        - currency
+        - sellerCountry
+        - sellerRegistered
+        - qualifiedInvoiceRequired
+        - buyerCountry
+        - buyerIsBusiness
+        - paidByCard
+      properties:
+        orderIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Order identifier.
+        buyerMonetizationAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Buyer monetization account identifier.
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceLineRequestItem'
+          description: Invoice lines.
+        shippingCostAmount:
+          type: integer
+          format: int32
+          description: Shipping cost amount.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Invoice currency.
+        discountPercentage:
+          type: integer
+          format: int32
+          nullable: true
+          description: Optional discount percentage.
+        discountCode:
+          type: string
+          nullable: true
+          description: Optional discount code.
+        taxLines:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceTaxLineRequestItem'
+          nullable: true
+          description: Optional tax lines.
+        sellerCountry:
+          type: string
+          description: Seller country code.
+        sellerRegistered:
+          type: boolean
+          description: Whether the seller is tax registered.
+        qualifiedInvoiceRequired:
+          type: boolean
+          description: Whether a qualified invoice is required.
+        buyerCountry:
+          type: string
+          description: Buyer country code.
+        buyerIsBusiness:
+          type: boolean
+          description: Whether the buyer is a business.
+        paidByCard:
+          type: boolean
+          description: Whether the invoice is paid by card.
+        registrationNumber:
+          type: string
+          nullable: true
+          description: Optional seller registration number.
+      description: Request body for creating an invoice.
+    CurrencyCode:
+      type: string
+      enum:
+        - JPY
+        - USD
+        - KRW
+      description: Supported currency codes used by monetization value objects.
+    InvoiceLineRequestItem:
+      type: object
+      required:
+        - description
+        - unitPriceAmount
+        - quantity
+      properties:
+        description:
+          type: string
+          description: Line item description.
+        unitPriceAmount:
+          type: integer
+          format: int32
+          description: Unit price amount.
+        quantity:
+          type: integer
+          format: int32
+          description: Purchased quantity.
+      description: Invoice line request item.
+    InvoiceStatus:
+      type: string
+      description: Invoice lifecycle status.
+    InvoiceSummary:
+      type: object
+      required:
+        - invoiceIdentifier
+        - orderIdentifier
+        - buyerMonetizationAccountIdentifier
+        - subtotal
+        - discountAmount
+        - taxAmount
+        - total
+        - currency
+        - status
+        - issuedAt
+        - dueDate
+      properties:
+        invoiceIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Invoice identifier.
+        orderIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Order identifier.
+        buyerMonetizationAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Buyer monetization account identifier.
+        subtotal:
+          type: integer
+          format: int32
+          description: Subtotal amount before discount and tax.
+        discountAmount:
+          type: integer
+          format: int32
+          description: Discount amount applied to the invoice.
+        taxAmount:
+          type: integer
+          format: int32
+          description: Tax amount applied to the invoice.
+        total:
+          type: integer
+          format: int32
+          description: Total invoice amount.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Invoice currency.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/InvoiceStatus'
+          description: Current invoice status.
+        issuedAt:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          description: Issuance timestamp.
+        dueDate:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          description: Payment due timestamp.
+        paidAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          nullable: true
+          description: Payment completion timestamp.
+      description: Invoice snapshot returned by create/record-payment commands.
+    InvoiceTaxLineRequestItem:
+      type: object
+      required:
+        - label
+        - rate
+        - inclusive
+      properties:
+        label:
+          type: string
+          description: Tax label.
+        rate:
+          type: integer
+          format: int32
+          description: Tax rate percentage.
+        inclusive:
+          type: boolean
+          description: Whether the tax is inclusive.
+      description: Tax line request item.
+    KPool.Common.DateString:
+      type: string
+      description: ISO 8601 date string.
+    KPool.Common.ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          description: URI reference identifying the problem type.
+        status:
+          type: integer
+          format: int32
+          description: HTTP status code.
+        title:
+          type: string
+          description: Short error title.
+        detail:
+          type: string
+          description: Human-readable error detail.
+        instance:
+          type: string
+          description: URI reference identifying the specific occurrence.
+      description: RFC 9457 Problem Details payload shared by JSON error responses.
+    KPool.Common.Timestamp:
+      type: string
+      description: Timestamp in ISO 8601 format.
+    KPool.Common.Uuid:
+      type: string
+      format: uuid
+      description: UUID identifier.
+    MonetizationAccountSummary:
+      type: object
+      required:
+        - monetizationAccountIdentifier
+        - accountIdentifier
+        - capabilities
+      properties:
+        monetizationAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Monetization account identifier.
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Owning account identifier.
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/MonetizationCapability'
+          description: Granted capabilities.
+        stripeCustomerId:
+          type: string
+          nullable: true
+          description: Stripe customer identifier, when available.
+        stripeConnectedAccountId:
+          type: string
+          nullable: true
+          description: Stripe connected account identifier, when available.
+      description: Monetization account snapshot returned after provisioning.
+    MonetizationCapability:
+      type: string
+      enum:
+        - purchase
+        - sell
+        - receive_payout
+      description: Capabilities granted to a monetization account.
+    OnboardSellerRequestBody:
+      type: object
+      required:
+        - email
+        - countryCode
+        - refreshUrl
+        - returnUrl
+      properties:
+        email:
+          type: string
+          description: Seller email address.
+        countryCode:
+          allOf:
+            - $ref: '#/components/schemas/SellerOnboardingCountryCode'
+          description: Country code used for Stripe onboarding.
+        refreshUrl:
+          type: string
+          description: Refresh URL returned to Stripe Connect.
+        returnUrl:
+          type: string
+          description: Return URL returned to Stripe Connect.
+      description: Request body for onboarding a seller.
+    PaidAmountRequestItem:
+      type: object
+      required:
+        - amount
+        - currency
+      properties:
+        amount:
+          type: integer
+          format: int32
+          description: Paid amount.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Currency for the paid amount.
+      description: Paid amount entry used during settlement.
+    PaymentMethodType:
+      type: string
+      enum:
+        - card
+        - bank_transfer
+        - wallet
+      description: Supported payment method types.
+    PaymentStatus:
+      type: string
+      enum:
+        - pending
+        - authorized
+        - captured
+        - partially_refunded
+        - refunded
+        - failed
+      description: Payment lifecycle status.
+    PaymentSummary:
+      type: object
+      required:
+        - paymentId
+        - orderIdentifier
+        - buyerMonetizationAccountIdentifier
+        - amount
+        - currency
+        - paymentMethodIdentifier
+        - paymentMethodType
+        - paymentMethodLabel
+        - paymentMethodRecurringEnabled
+        - status
+        - createdAt
+        - refundedAmount
+        - refundedCurrency
+      properties:
+        paymentId:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Payment identifier.
+        orderIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Order identifier.
+        buyerMonetizationAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Buyer monetization account identifier.
+        amount:
+          type: integer
+          format: int32
+          description: Authorized payment amount.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Currency for the payment amount.
+        paymentMethodIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Payment method identifier.
+        paymentMethodType:
+          allOf:
+            - $ref: '#/components/schemas/PaymentMethodType'
+          description: Payment method type.
+        paymentMethodLabel:
+          type: string
+          description: Human-readable payment method label.
+        paymentMethodRecurringEnabled:
+          type: boolean
+          description: Whether recurring usage is enabled.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/PaymentStatus'
+          description: Current payment status.
+        createdAt:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          description: Creation timestamp.
+        authorizedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          nullable: true
+          description: Authorization timestamp.
+        capturedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          nullable: true
+          description: Capture timestamp.
+        failedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          nullable: true
+          description: Failure timestamp.
+        failureReason:
+          type: string
+          nullable: true
+          description: Failure reason when the payment failed.
+        refundedAmount:
+          type: integer
+          format: int32
+          description: Total refunded amount.
+        refundedCurrency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Currency for the refunded amount.
+        lastRefundedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          nullable: true
+          description: Timestamp of the latest refund.
+        lastRefundReason:
+          type: string
+          nullable: true
+          description: Reason for the latest refund.
+      description: Payment snapshot returned by authorize/capture/refund commands.
+    ProvisionMonetizationAccountRequestBody:
+      type: object
+      required:
+        - accountId
+      properties:
+        accountId:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Account identifier to provision.
+      description: Request body for provisioning a monetization account.
+    RecordPaymentRequestBody:
+      type: object
+      required:
+        - paymentIdentifier
+      properties:
+        paymentIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Captured payment identifier.
+      description: Request body for recording a payment against an invoice.
+    RefundPaymentRequestBody:
+      type: object
+      required:
+        - refundAmount
+        - refundCurrency
+        - reason
+      properties:
+        refundAmount:
+          type: integer
+          format: int32
+          description: Refund amount.
+        refundCurrency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Refund currency.
+        reason:
+          type: string
+          description: Refund reason.
+      description: Request body for refunding a payment.
+    RegisterPaymentMethodRequestBody:
+      type: object
+      required:
+        - paymentMethodId
+        - type
+      properties:
+        paymentMethodId:
+          type: string
+          description: Gateway payment method identifier.
+        type:
+          allOf:
+            - $ref: '#/components/schemas/AccountPaymentMethodType'
+          description: Payment method type.
+      description: Request body for registering a payment method.
+    RegisteredPaymentMethodSummary:
+      type: object
+      required:
+        - registeredPaymentMethodIdentifier
+        - paymentMethodId
+        - type
+        - isDefault
+        - skipped
+      properties:
+        registeredPaymentMethodIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Registered payment method identifier.
+        paymentMethodId:
+          type: string
+          description: Gateway payment method identifier.
+        type:
+          allOf:
+            - $ref: '#/components/schemas/AccountPaymentMethodType'
+          description: Registered payment method type.
+        brand:
+          type: string
+          nullable: true
+          description: Card brand returned from metadata.
+        last4:
+          type: string
+          nullable: true
+          description: Last four digits returned from metadata.
+        expMonth:
+          type: integer
+          format: int32
+          nullable: true
+          description: Expiration month returned from metadata.
+        expYear:
+          type: integer
+          format: int32
+          nullable: true
+          description: Expiration year returned from metadata.
+        isDefault:
+          type: boolean
+          description: Whether the method is the default one.
+        skipped:
+          type: boolean
+          description: Whether registration was skipped because the method already existed.
+      description: Registered payment method snapshot.
+    SellerOnboardingCountryCode:
+      type: string
+      enum:
+        - JP
+        - KR
+        - US
+      description: Country codes accepted by seller onboarding.
+    SellerOnboardingSummary:
+      type: object
+      properties:
+        onboardingUrl:
+          type: string
+          nullable: true
+          description: Stripe onboarding URL.
+      description: Seller onboarding URL payload.
+    SettleRevenueRequestBody:
+      type: object
+      required:
+        - settlementScheduleId
+        - paidAmounts
+        - gatewayFeeRate
+        - platformFeeRate
+        - periodStart
+        - periodEnd
+      properties:
+        settlementScheduleId:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Settlement schedule identifier.
+        paidAmounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaidAmountRequestItem'
+          description: Paid amount breakdown used for settlement.
+        gatewayFeeRate:
+          type: integer
+          format: int32
+          description: Gateway fee rate percentage.
+        platformFeeRate:
+          type: integer
+          format: int32
+          description: Platform fee rate percentage.
+        fixedFeeAmount:
+          type: integer
+          format: int32
+          nullable: true
+          description: Optional fixed fee amount.
+        fixedFeeCurrency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          nullable: true
+          description: Currency for the optional fixed fee.
+        periodStart:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.DateString'
+          description: Settlement period start date.
+        periodEnd:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.DateString'
+          description: Settlement period end date.
+      description: Request body for settling revenue.
+    SettlementResultSummary:
+      type: object
+      required:
+        - settlementBatchIdentifier
+        - monetizationAccountIdentifier
+        - currency
+        - grossAmount
+        - feeAmount
+        - netAmount
+        - status
+        - periodStart
+        - periodEnd
+        - transferIdentifier
+        - transferStatus
+      properties:
+        settlementBatchIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Settlement batch identifier.
+        monetizationAccountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Beneficiary monetization account identifier.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: Settlement currency.
+        grossAmount:
+          type: integer
+          format: int32
+          description: Gross settled amount.
+        feeAmount:
+          type: integer
+          format: int32
+          description: Aggregated fee amount.
+        netAmount:
+          type: integer
+          format: int32
+          description: Net amount to transfer.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/SettlementStatus'
+          description: Settlement batch status.
+        periodStart:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          description: Settlement period start timestamp.
+        periodEnd:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          description: Settlement period end timestamp.
+        transferIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Transfer identifier created for the batch.
+        transferStatus:
+          allOf:
+            - $ref: '#/components/schemas/TransferStatus'
+          description: Transfer status.
+      description: Settlement batch result returned after settling revenue.
+    SettlementStatus:
+      type: string
+      enum:
+        - pending
+        - processing
+        - paid
+        - failed
+      description: Settlement batch status.
+    SyncPayoutAccountRequestBody:
+      type: object
+      required:
+        - connectedAccountId
+        - externalAccountId
+        - eventType
+      properties:
+        connectedAccountId:
+          type: string
+          description: Connected account identifier from the payment gateway.
+        externalAccountId:
+          type: string
+          description: External account identifier from the payment gateway.
+        eventType:
+          type: string
+          description: Gateway event type.
+        bankName:
+          type: string
+          nullable: true
+          description: Bank name.
+        last4:
+          type: string
+          nullable: true
+          description: Last four digits of the payout account.
+        country:
+          type: string
+          nullable: true
+          description: Country code reported by the gateway.
+        currency:
+          type: string
+          nullable: true
+          description: Currency reported by the gateway.
+        accountHolderType:
+          allOf:
+            - $ref: '#/components/schemas/AccountHolderType'
+          nullable: true
+          description: Account holder type reported by the gateway.
+        isDefault:
+          type: boolean
+          description: Whether the payout account is the default one.
+      description: Request body for syncing a payout account webhook payload.
+    TransferStatus:
+      type: string
+      enum:
+        - pending
+        - sent
+        - failed
+      description: Transfer execution status.
 servers:
   - url: /api/monetization
     description: Laravel route prefix from bootstrap/app.php.

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -49,7 +49,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -86,7 +86,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when a draft image is created.
@@ -133,7 +133,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an image hide request is reviewed.
@@ -186,7 +186,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an image operation succeeds.
@@ -233,7 +233,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an image hide request is reviewed.
@@ -286,7 +286,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when an image hide request is created.
@@ -333,7 +333,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an image operation succeeds.
@@ -410,7 +410,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an official certification operation succeeds.
@@ -451,7 +451,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when an official certification operation succeeds.
@@ -522,7 +522,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -589,7 +589,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -626,7 +626,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when a principal group operation succeeds.
@@ -673,7 +673,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -710,7 +710,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -747,7 +747,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
           description: Response returned when a principal group operation succeeds.
@@ -860,7 +860,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -897,7 +897,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -934,7 +934,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '204':
           description: Response with no content.
@@ -1075,7 +1075,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when a wiki draft is created or updated.
@@ -1128,7 +1128,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when a wiki draft is created or updated.
@@ -1175,7 +1175,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when a wiki draft is created or updated.
@@ -1228,7 +1228,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when a wiki is published.
@@ -1281,7 +1281,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when a wiki draft is created or updated.
@@ -1334,7 +1334,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when wiki rollback succeeds.
@@ -1387,7 +1387,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when a wiki draft is created or updated.
@@ -1440,7 +1440,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '201':
           description: Response returned when wiki translation succeeds.
@@ -1493,7 +1493,7 @@ components:
       properties:
         policyIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Policy identifier to mutate.
       description: Request body for attaching or detaching a policy from a role.
     AttachRoleToPrincipalGroupRequestBody:
@@ -1503,7 +1503,7 @@ components:
       properties:
         roleIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Role identifier to mutate.
       description: Request body for attaching or detaching a role from a principal group.
     AutoCreateWikiRequestBody:
@@ -1552,7 +1552,7 @@ components:
       properties:
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier that owns the principal group.
         name:
           type: string
@@ -1566,11 +1566,11 @@ components:
       properties:
         identityIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier to bind to the principal.
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Account identifier that owns the principal.
       description: Request body for creating a principal.
     CreateRoleRequestBody:
@@ -1585,7 +1585,7 @@ components:
         policies:
           type: array
           items:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Policy identifiers attached to the role.
         isSystemRole:
           type: boolean
@@ -1619,7 +1619,7 @@ components:
           description: Theme color applied to the wiki.
         publishedWikiIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Published wiki identifier to branch from.
       allOf:
         - $ref: '#/components/schemas/WikiAssociationTargets'
@@ -1655,7 +1655,7 @@ components:
       properties:
         imageIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Image identifier.
         resourceType:
           type: string
@@ -1678,7 +1678,7 @@ components:
       properties:
         imageIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Image identifier.
         requesterName:
           type: string
@@ -1703,7 +1703,7 @@ components:
       properties:
         imageIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Image identifier.
         status:
           type: string
@@ -1725,7 +1725,7 @@ components:
       properties:
         imageIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Image identifier.
         resourceType:
           type: string
@@ -1757,6 +1757,10 @@ components:
           type: string
           description: URI reference identifying the specific occurrence.
       description: RFC 9457 Problem Details payload shared by JSON error responses.
+    KPool.Common.Uuid:
+      type: string
+      format: uuid
+      description: UUID identifier.
     MutatePrincipalGroupMemberRequestBody:
       type: object
       required:
@@ -1764,7 +1768,7 @@ components:
       properties:
         principalIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Principal identifier to mutate.
       description: Request body for adding or removing a principal group member.
     OfficialCertificationSummary:
@@ -1777,14 +1781,14 @@ components:
       properties:
         certificationIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Certification identifier.
         resourceType:
           type: string
           description: Resource type that the certification belongs to.
         wikiIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Wiki identifier related to the certification.
         status:
           type: string
@@ -1851,7 +1855,7 @@ components:
       properties:
         policyIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Policy identifier.
         name:
           type: string
@@ -1875,11 +1879,11 @@ components:
       properties:
         principalGroupIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Principal group identifier.
         accountIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Owning account identifier.
         name:
           type: string
@@ -1905,11 +1909,11 @@ components:
       properties:
         principalIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Principal identifier.
         identityIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier linked to the principal.
         isDelegatedPrincipal:
           type: boolean
@@ -1928,7 +1932,7 @@ components:
           description: Resource type that the wiki belongs to.
         publishedWikiIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Published wiki identifier to update.
       allOf:
         - $ref: '#/components/schemas/WikiAssociationTargets'
@@ -1967,11 +1971,11 @@ components:
           description: Resource type that the certification belongs to.
         wikiId:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Wiki identifier to certify.
         ownerAccountId:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Owner account identifier for the certification.
       description: Request body for creating an official certification request.
     RequestImageHideRequestBody:
@@ -2010,7 +2014,7 @@ components:
       properties:
         roleIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Role identifier.
         name:
           type: string
@@ -2061,7 +2065,7 @@ components:
           description: Resource type that the video links belong to.
         wikiIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Wiki identifier that the video links belong to.
         videoLinks:
           type: array
@@ -2116,14 +2120,14 @@ components:
       properties:
         publishedImageIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Published image identifier to replace.
         resourceType:
           type: string
           description: Resource type that the image belongs to.
         wikiIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Wiki identifier that the image belongs to.
         base64EncodedImage:
           type: string
@@ -2148,10 +2152,6 @@ components:
           type: string
           description: Timestamp when the uploader agreed to the terms.
       description: Request body for uploading an image.
-    Uuid:
-      type: string
-      format: uuid
-      description: UUID identifier.
     VideoLinkInput:
       type: object
       required:
@@ -2184,17 +2184,17 @@ components:
       properties:
         agencyIdentifier:
           allOf:
-            - $ref: '#/components/schemas/Uuid'
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Associated agency identifier.
         groupIdentifiers:
           type: array
           items:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Associated group identifiers.
         talentIdentifiers:
           type: array
           items:
-            $ref: '#/components/schemas/Uuid'
+            $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Associated talent identifiers.
       description: Association targets that link a wiki to related agencies, groups, or talents.
     WikiWorkflowRequestBody:

--- a/typespec/common/core.tsp
+++ b/typespec/common/core.tsp
@@ -1,0 +1,21 @@
+using TypeSpec.Http;
+
+namespace KPool.Common;
+
+@format("uuid")
+@doc("UUID identifier.")
+scalar Uuid extends string;
+
+@doc("Timestamp in ISO 8601 format.")
+scalar Timestamp extends string;
+
+@doc("ISO 8601 date string.")
+scalar DateString extends string;
+
+@doc("Empty JSON object returned by endpoints with no payload.")
+model EmptyJsonObject {}
+
+@doc("Response with no content.")
+model NoContentResponse {
+  @statusCode statusCode: 204;
+}

--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -2,6 +2,7 @@ import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/openapi3";
 
+import "./common/core.tsp";
 import "./common/problem-details.tsp";
 import "./services/account-api.tsp";
 import "./services/identity-api.tsp";

--- a/typespec/services/account-api/account-verification.tsp
+++ b/typespec/services/account-api/account-verification.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
 

--- a/typespec/services/account-api/account.tsp
+++ b/typespec/services/account-api/account.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
 

--- a/typespec/services/account-api/affiliation.tsp
+++ b/typespec/services/account-api/affiliation.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
 
@@ -66,7 +67,7 @@ interface AffiliationOperations {
   rejectAffiliation(
     @path affiliationId: Uuid,
     @body body: RejectAffiliationRequestBody,
-  ): NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/{affiliationId}/terminate")

--- a/typespec/services/account-api/common.tsp
+++ b/typespec/services/account-api/common.tsp
@@ -1,18 +1,7 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
-
-@format("uuid")
-@doc("UUID identifier.")
-scalar Uuid extends string;
-
-@doc("Timestamp in ISO 8601 format.")
-scalar Timestamp extends string;
-
-@doc("Response with no content.")
-model NoContentResponse {
-  @statusCode statusCode: 204;
-}
 
 @doc("Current account state.")
 model AccountSummary {

--- a/typespec/services/account-api/delegation-permission.tsp
+++ b/typespec/services/account-api/delegation-permission.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
 
@@ -31,5 +32,5 @@ interface DelegationPermissionOperations {
   @doc("Revoke a delegation permission.")
   revokeDelegationPermission(
     @path delegationPermissionId: Uuid,
-  ): NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }

--- a/typespec/services/account-api/delegation.tsp
+++ b/typespec/services/account-api/delegation.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
 

--- a/typespec/services/account-api/identity-group.tsp
+++ b/typespec/services/account-api/identity-group.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
 
@@ -59,5 +60,5 @@ interface IdentityGroupOperations {
   @doc("Delete an identity group.")
   deleteIdentityGroup(
     @path identityGroupId: Uuid,
-  ): NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }

--- a/typespec/services/account-api/invitation.tsp
+++ b/typespec/services/account-api/invitation.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.AccountApi;
 

--- a/typespec/services/identity-api.tsp
+++ b/typespec/services/identity-api.tsp
@@ -1,18 +1,9 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 @service(#{ title: "k-pool Identity API" })
 @server("/api/identity", "Laravel route prefix from bootstrap/app.php.")
 namespace KPool.IdentityApi;
-
-@format("uuid")
-@doc("UUID identifier.")
-scalar Uuid extends string;
-
-@doc("Timestamp in ISO 8601 format.")
-scalar Timestamp extends string;
-
-@doc("Empty JSON object returned by endpoints with no payload.")
-model EmptyJsonObject {}
 
 @doc("Identity summary returned after authentication-related operations.")
 model IdentitySummary {

--- a/typespec/services/monetization-api.tsp
+++ b/typespec/services/monetization-api.tsp
@@ -1,5 +1,524 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 @service(#{ title: "k-pool Monetization API" })
 @server("/api/monetization", "Laravel route prefix from bootstrap/app.php.")
 namespace KPool.MonetizationApi;
+
+@doc("Supported currency codes used by monetization value objects.")
+enum CurrencyCode {
+  JPY,
+  USD,
+  KRW,
+}
+
+@doc("Country codes accepted by seller onboarding.")
+enum SellerOnboardingCountryCode {
+  JP,
+  KR,
+  US,
+}
+
+@doc("Capabilities granted to a monetization account.")
+enum MonetizationCapability {
+  purchase,
+  sell,
+  receive_payout,
+}
+
+@doc("Supported payment method types.")
+enum PaymentMethodType {
+  card,
+  bank_transfer,
+  wallet,
+}
+
+@doc("Account payment method type accepted by registration.")
+enum AccountPaymentMethodType {
+  card,
+}
+
+@doc("Account holder classification for payout accounts.")
+enum AccountHolderType {
+  individual,
+  company,
+}
+
+@doc("Payment lifecycle status.")
+enum PaymentStatus {
+  pending,
+  authorized,
+  captured,
+  partially_refunded,
+  refunded,
+  failed,
+}
+
+@doc("Invoice lifecycle status.")
+scalar InvoiceStatus extends string;
+
+@doc("Settlement batch status.")
+enum SettlementStatus {
+  pending,
+  processing,
+  paid,
+  failed,
+}
+
+@doc("Transfer execution status.")
+enum TransferStatus {
+  pending,
+  sent,
+  failed,
+}
+
+alias EmptyJsonArray = unknown[];
+
+@doc("Monetization account snapshot returned after provisioning.")
+model MonetizationAccountSummary {
+  @doc("Monetization account identifier.")
+  monetizationAccountIdentifier: Uuid;
+  @doc("Owning account identifier.")
+  accountIdentifier: Uuid;
+  @doc("Granted capabilities.")
+  capabilities: MonetizationCapability[];
+  @doc("Stripe customer identifier, when available.")
+  stripeCustomerId?: string | null;
+  @doc("Stripe connected account identifier, when available.")
+  stripeConnectedAccountId?: string | null;
+}
+
+@doc("Seller onboarding URL payload.")
+model SellerOnboardingSummary {
+  @doc("Stripe onboarding URL.")
+  onboardingUrl?: string | null;
+}
+
+@doc("Registered payment method snapshot.")
+model RegisteredPaymentMethodSummary {
+  @doc("Registered payment method identifier.")
+  registeredPaymentMethodIdentifier: Uuid;
+  @doc("Gateway payment method identifier.")
+  paymentMethodId: string;
+  @doc("Registered payment method type.")
+  type: AccountPaymentMethodType;
+  @doc("Card brand returned from metadata.")
+  brand?: string | null;
+  @doc("Last four digits returned from metadata.")
+  last4?: string | null;
+  @doc("Expiration month returned from metadata.")
+  expMonth?: int32 | null;
+  @doc("Expiration year returned from metadata.")
+  expYear?: int32 | null;
+  @doc("Whether the method is the default one.")
+  isDefault: boolean;
+  @doc("Whether registration was skipped because the method already existed.")
+  skipped: boolean;
+}
+
+@doc("Payment snapshot returned by authorize/capture/refund commands.")
+model PaymentSummary {
+  @doc("Payment identifier.")
+  paymentId: Uuid;
+  @doc("Order identifier.")
+  orderIdentifier: Uuid;
+  @doc("Buyer monetization account identifier.")
+  buyerMonetizationAccountIdentifier: Uuid;
+  @doc("Authorized payment amount.")
+  amount: int32;
+  @doc("Currency for the payment amount.")
+  currency: CurrencyCode;
+  @doc("Payment method identifier.")
+  paymentMethodIdentifier: Uuid;
+  @doc("Payment method type.")
+  paymentMethodType: PaymentMethodType;
+  @doc("Human-readable payment method label.")
+  paymentMethodLabel: string;
+  @doc("Whether recurring usage is enabled.")
+  paymentMethodRecurringEnabled: boolean;
+  @doc("Current payment status.")
+  status: PaymentStatus;
+  @doc("Creation timestamp.")
+  createdAt: Timestamp;
+  @doc("Authorization timestamp.")
+  authorizedAt?: Timestamp | null;
+  @doc("Capture timestamp.")
+  capturedAt?: Timestamp | null;
+  @doc("Failure timestamp.")
+  failedAt?: Timestamp | null;
+  @doc("Failure reason when the payment failed.")
+  failureReason?: string | null;
+  @doc("Total refunded amount.")
+  refundedAmount: int32;
+  @doc("Currency for the refunded amount.")
+  refundedCurrency: CurrencyCode;
+  @doc("Timestamp of the latest refund.")
+  lastRefundedAt?: Timestamp | null;
+  @doc("Reason for the latest refund.")
+  lastRefundReason?: string | null;
+}
+
+@doc("Invoice snapshot returned by create/record-payment commands.")
+model InvoiceSummary {
+  @doc("Invoice identifier.")
+  invoiceIdentifier: Uuid;
+  @doc("Order identifier.")
+  orderIdentifier: Uuid;
+  @doc("Buyer monetization account identifier.")
+  buyerMonetizationAccountIdentifier: Uuid;
+  @doc("Subtotal amount before discount and tax.")
+  subtotal: int32;
+  @doc("Discount amount applied to the invoice.")
+  discountAmount: int32;
+  @doc("Tax amount applied to the invoice.")
+  taxAmount: int32;
+  @doc("Total invoice amount.")
+  total: int32;
+  @doc("Invoice currency.")
+  currency: CurrencyCode;
+  @doc("Current invoice status.")
+  status: InvoiceStatus;
+  @doc("Issuance timestamp.")
+  issuedAt: Timestamp;
+  @doc("Payment due timestamp.")
+  dueDate: Timestamp;
+  @doc("Payment completion timestamp.")
+  paidAt?: Timestamp | null;
+}
+
+@doc("Settlement batch result returned after settling revenue.")
+model SettlementResultSummary {
+  @doc("Settlement batch identifier.")
+  settlementBatchIdentifier: Uuid;
+  @doc("Beneficiary monetization account identifier.")
+  monetizationAccountIdentifier: Uuid;
+  @doc("Settlement currency.")
+  currency: CurrencyCode;
+  @doc("Gross settled amount.")
+  grossAmount: int32;
+  @doc("Aggregated fee amount.")
+  feeAmount: int32;
+  @doc("Net amount to transfer.")
+  netAmount: int32;
+  @doc("Settlement batch status.")
+  status: SettlementStatus;
+  @doc("Settlement period start timestamp.")
+  periodStart: Timestamp;
+  @doc("Settlement period end timestamp.")
+  periodEnd: Timestamp;
+  @doc("Transfer identifier created for the batch.")
+  transferIdentifier: Uuid;
+  @doc("Transfer status.")
+  transferStatus: TransferStatus;
+}
+
+@doc("Invoice line request item.")
+model InvoiceLineRequestItem {
+  @doc("Line item description.")
+  description: string;
+  @doc("Unit price amount.")
+  unitPriceAmount: int32;
+  @doc("Purchased quantity.")
+  quantity: int32;
+}
+
+@doc("Tax line request item.")
+model InvoiceTaxLineRequestItem {
+  @doc("Tax label.")
+  label: string;
+  @doc("Tax rate percentage.")
+  rate: int32;
+  @doc("Whether the tax is inclusive.")
+  inclusive: boolean;
+}
+
+@doc("Paid amount entry used during settlement.")
+model PaidAmountRequestItem {
+  @doc("Paid amount.")
+  amount: int32;
+  @doc("Currency for the paid amount.")
+  currency: CurrencyCode;
+}
+
+@doc("Request body for provisioning a monetization account.")
+model ProvisionMonetizationAccountRequestBody {
+  @doc("Account identifier to provision.")
+  accountId: Uuid;
+}
+
+@doc("Request body for onboarding a seller.")
+model OnboardSellerRequestBody {
+  @doc("Seller email address.")
+  email: string;
+  @doc("Country code used for Stripe onboarding.")
+  countryCode: SellerOnboardingCountryCode;
+  @doc("Refresh URL returned to Stripe Connect.")
+  refreshUrl: string;
+  @doc("Return URL returned to Stripe Connect.")
+  returnUrl: string;
+}
+
+@doc("Request body for registering a payment method.")
+model RegisterPaymentMethodRequestBody {
+  @doc("Gateway payment method identifier.")
+  paymentMethodId: string;
+  @doc("Payment method type.")
+  type: AccountPaymentMethodType;
+}
+
+@doc("Request body for syncing a payout account webhook payload.")
+model SyncPayoutAccountRequestBody {
+  @doc("Connected account identifier from the payment gateway.")
+  connectedAccountId: string;
+  @doc("External account identifier from the payment gateway.")
+  externalAccountId: string;
+  @doc("Gateway event type.")
+  eventType: string;
+  @doc("Bank name.")
+  bankName?: string | null;
+  @doc("Last four digits of the payout account.")
+  last4?: string | null;
+  @doc("Country code reported by the gateway.")
+  country?: string | null;
+  @doc("Currency reported by the gateway.")
+  currency?: string | null;
+  @doc("Account holder type reported by the gateway.")
+  accountHolderType?: AccountHolderType | null;
+  @doc("Whether the payout account is the default one.")
+  isDefault?: boolean;
+}
+
+@doc("Request body for authorizing a payment.")
+model AuthorizePaymentRequestBody {
+  @doc("Order identifier.")
+  orderId: Uuid;
+  @doc("Buyer monetization account identifier.")
+  buyerMonetizationAccountId: Uuid;
+  @doc("Payment amount.")
+  amount: int32;
+  @doc("Payment currency.")
+  currency: CurrencyCode;
+  @doc("Payment method identifier.")
+  paymentMethodId: Uuid;
+  @doc("Payment method type.")
+  paymentMethodType: PaymentMethodType;
+  @doc("Human-readable payment method label.")
+  paymentMethodLabel: string;
+  @doc("Whether recurring usage is enabled.")
+  paymentMethodRecurringEnabled: boolean;
+}
+
+@doc("Request body for refunding a payment.")
+model RefundPaymentRequestBody {
+  @doc("Refund amount.")
+  refundAmount: int32;
+  @doc("Refund currency.")
+  refundCurrency: CurrencyCode;
+  @doc("Refund reason.")
+  reason: string;
+}
+
+@doc("Request body for creating an invoice.")
+model CreateInvoiceRequestBody {
+  @doc("Order identifier.")
+  orderIdentifier: Uuid;
+  @doc("Buyer monetization account identifier.")
+  buyerMonetizationAccountIdentifier: Uuid;
+  @doc("Invoice lines.")
+  lines: InvoiceLineRequestItem[];
+  @doc("Shipping cost amount.")
+  shippingCostAmount: int32;
+  @doc("Invoice currency.")
+  currency: CurrencyCode;
+  @doc("Optional discount percentage.")
+  discountPercentage?: int32 | null;
+  @doc("Optional discount code.")
+  discountCode?: string | null;
+  @doc("Optional tax lines.")
+  taxLines?: InvoiceTaxLineRequestItem[] | null;
+  @doc("Seller country code.")
+  sellerCountry: string;
+  @doc("Whether the seller is tax registered.")
+  sellerRegistered: boolean;
+  @doc("Whether a qualified invoice is required.")
+  qualifiedInvoiceRequired: boolean;
+  @doc("Buyer country code.")
+  buyerCountry: string;
+  @doc("Whether the buyer is a business.")
+  buyerIsBusiness: boolean;
+  @doc("Whether the invoice is paid by card.")
+  paidByCard: boolean;
+  @doc("Optional seller registration number.")
+  registrationNumber?: string | null;
+}
+
+@doc("Request body for recording a payment against an invoice.")
+model RecordPaymentRequestBody {
+  @doc("Captured payment identifier.")
+  paymentIdentifier: Uuid;
+}
+
+@doc("Request body for settling revenue.")
+model SettleRevenueRequestBody {
+  @doc("Settlement schedule identifier.")
+  settlementScheduleId: Uuid;
+  @doc("Paid amount breakdown used for settlement.")
+  paidAmounts: PaidAmountRequestItem[];
+  @doc("Gateway fee rate percentage.")
+  gatewayFeeRate: int32;
+  @doc("Platform fee rate percentage.")
+  platformFeeRate: int32;
+  @doc("Optional fixed fee amount.")
+  fixedFeeAmount?: int32 | null;
+  @doc("Currency for the optional fixed fee.")
+  fixedFeeCurrency?: CurrencyCode | null;
+  @doc("Settlement period start date.")
+  periodStart: DateString;
+  @doc("Settlement period end date.")
+  periodEnd: DateString;
+}
+
+@doc("Response returned when a monetization account is provisioned.")
+model ProvisionMonetizationAccountResponse {
+  @statusCode statusCode: 201;
+  @body body: MonetizationAccountSummary;
+}
+
+@doc("Response returned when seller onboarding succeeds.")
+model OnboardSellerResponse {
+  @statusCode statusCode: 200;
+  @body body: SellerOnboardingSummary;
+}
+
+@doc("Response returned when a payment method is registered.")
+model RegisterPaymentMethodResponse {
+  @statusCode statusCode: 201;
+  @body body: RegisteredPaymentMethodSummary;
+}
+
+@doc("Response returned when a command succeeds without a payload.")
+model OkEmptyArrayResponse {
+  @statusCode statusCode: 200;
+  @body body: EmptyJsonArray;
+}
+
+@doc("Response returned when a payment command creates a payment.")
+model CreatedPaymentResponse {
+  @statusCode statusCode: 201;
+  @body body: PaymentSummary;
+}
+
+@doc("Response returned when a payment command succeeds.")
+model OkPaymentResponse {
+  @statusCode statusCode: 200;
+  @body body: PaymentSummary;
+}
+
+@doc("Response returned when an invoice is created.")
+model CreateInvoiceResponse {
+  @statusCode statusCode: 201;
+  @body body: InvoiceSummary;
+}
+
+@doc("Response returned when an invoice command succeeds.")
+model OkInvoiceResponse {
+  @statusCode statusCode: 200;
+  @body body: InvoiceSummary;
+}
+
+@doc("Response returned when revenue settlement succeeds.")
+model SettleRevenueResponse {
+  @statusCode statusCode: 201;
+  @body body: SettlementResultSummary;
+}
+
+@route("/accounts")
+interface MonetizationAccountOperations {
+  @post
+  @doc("Provision a monetization account for an existing account.")
+  provisionMonetizationAccount(
+    @body body: ProvisionMonetizationAccountRequestBody,
+  ): ProvisionMonetizationAccountResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{monetizationAccountId}/onboard-seller")
+  @doc("Create a seller onboarding URL for the specified monetization account.")
+  onboardSeller(
+    @path monetizationAccountId: Uuid,
+    @body body: OnboardSellerRequestBody,
+  ): OnboardSellerResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{monetizationAccountId}/register-payment-method")
+  @doc("Register a payment method on the specified monetization account.")
+  registerPaymentMethod(
+    @path monetizationAccountId: Uuid,
+    @body body: RegisterPaymentMethodRequestBody,
+  ): RegisterPaymentMethodResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/sync-payout-account")
+  @doc("Synchronize payout account data from a gateway event payload.")
+  syncPayoutAccount(
+    @body body: SyncPayoutAccountRequestBody,
+  ): OkEmptyArrayResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+
+@route("/payments")
+interface MonetizationPaymentOperations {
+  @post
+  @route("/authorize")
+  @doc("Authorize a payment for an order.")
+  authorizePayment(
+    @body body: AuthorizePaymentRequestBody,
+  ): CreatedPaymentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{paymentId}/capture")
+  @doc("Capture a previously authorized payment.")
+  capturePayment(
+    @path paymentId: Uuid,
+  ): OkPaymentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{paymentId}/refund")
+  @doc("Refund a captured payment.")
+  refundPayment(
+    @path paymentId: Uuid,
+    @body body: RefundPaymentRequestBody,
+  ): OkPaymentResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+
+@route("/invoices")
+interface MonetizationBillingOperations {
+  @post
+  @doc("Create an invoice for an order.")
+  createInvoice(
+    @body body: CreateInvoiceRequestBody,
+  ): CreateInvoiceResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{invoiceId}/record-payment")
+  @doc("Record a captured payment against an invoice.")
+  recordPayment(
+    @path invoiceId: Uuid,
+    @body body: RecordPaymentRequestBody,
+  ): OkInvoiceResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+
+@route("/")
+interface MonetizationSettlementOperations {
+  @post
+  @route("/transfers/{transferId}/execute")
+  @doc("Execute a pending transfer.")
+  executeTransfer(
+    @path transferId: Uuid,
+  ): OkEmptyArrayResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/settlements/settle-revenue")
+  @doc("Create a settlement batch and transfer from paid amounts.")
+  settleRevenue(
+    @body body: SettleRevenueRequestBody,
+  ): SettleRevenueResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -1,15 +1,7 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.WikiPrivateApi;
-
-@format("uuid")
-@doc("UUID identifier.")
-scalar Uuid extends string;
-
-@doc("Response with no content.")
-model NoContentResponse {
-  @statusCode statusCode: 204;
-}
 
 @doc("Association targets that link a wiki to related agencies, groups, or talents.")
 model WikiAssociationTargets {

--- a/typespec/services/wiki-private-api/image.tsp
+++ b/typespec/services/wiki-private-api/image.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.WikiPrivateApi;
 
@@ -80,7 +81,7 @@ interface ImageOperations {
   @doc("Delete an image.")
   deleteImage(
     @path imageId: Uuid,
-  ): NoContentResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/{imageId}/reject")

--- a/typespec/services/wiki-private-api/official-certification.tsp
+++ b/typespec/services/wiki-private-api/official-certification.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.WikiPrivateApi;
 

--- a/typespec/services/wiki-private-api/principal.tsp
+++ b/typespec/services/wiki-private-api/principal.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.WikiPrivateApi;
 
@@ -123,7 +124,7 @@ interface PrincipalOperations {
   @doc("Delete a principal group.")
   deletePrincipalGroup(
     @path principalGroupId: Uuid,
-  ): NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/principal-group/{principalGroupId}/attach-role")
@@ -131,7 +132,7 @@ interface PrincipalOperations {
   attachRoleToPrincipalGroup(
     @path principalGroupId: Uuid,
     @body body: AttachRoleToPrincipalGroupRequestBody,
-  ): NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/principal-group/{principalGroupId}/detach-role")
@@ -139,7 +140,7 @@ interface PrincipalOperations {
   detachRoleFromPrincipalGroup(
     @path principalGroupId: Uuid,
     @body body: AttachRoleToPrincipalGroupRequestBody,
-  ): NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/role/create")
@@ -153,7 +154,7 @@ interface PrincipalOperations {
   @doc("Delete a role.")
   deleteRole(
     @path roleId: Uuid,
-  ): NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/role/{roleId}/attach-policy")
@@ -161,7 +162,7 @@ interface PrincipalOperations {
   attachPolicyToRole(
     @path roleId: Uuid,
     @body body: AttachPolicyToRoleRequestBody,
-  ): NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/role/{roleId}/detach-policy")
@@ -169,7 +170,7 @@ interface PrincipalOperations {
   detachPolicyFromRole(
     @path roleId: Uuid,
     @body body: AttachPolicyToRoleRequestBody,
-  ): NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/policy/create")
@@ -183,5 +184,5 @@ interface PrincipalOperations {
   @doc("Delete a policy.")
   deletePolicy(
     @path policyId: Uuid,
-  ): NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }

--- a/typespec/services/wiki-private-api/video-link.tsp
+++ b/typespec/services/wiki-private-api/video-link.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.WikiPrivateApi;
 
@@ -35,5 +36,5 @@ interface VideoLinkOperations {
   @doc("Save video links for a wiki.")
   saveVideoLinks(
     @body body: SaveVideoLinksRequestBody,
-  ): NoContentResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): KPool.Common.NoContentResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -1,4 +1,5 @@
 using TypeSpec.Http;
+using KPool.Common;
 
 namespace KPool.WikiPrivateApi;
 


### PR DESCRIPTION
## 📝 変更内容

- Monetization API の TypeSpec 定義を追加し、アカウント作成、出品者オンボーディング、決済手段登録、支払い、請求、精算、送金実行のエンドポイントを記述
- Monetization API で利用する enum / request / response model を追加し、OpenAPI を再生成
- `Uuid`、`Timestamp`、`DateString`、`NoContentResponse` などの共通定義を `typespec/common/core.tsp` に切り出し、既存の Account / Identity / Wiki Private API 側から参照する構成に整理

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Monetization API についても既存の Account / Identity / Wiki Private API と同様に TypeSpec ベースで API 契約を管理できるようにし、OpenAPI を生成可能にするためです。あわせて各 API で重複していた基本 scalar / response 定義を共通化し、今後の TypeSpec 拡張時の保守コストを下げています。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Monetization API のエンドポイント設計と request / response schema がドメイン意図に沿っているか
- `typespec/common/core.tsp` への共通定義の切り出しで、既存 API の OpenAPI 生成結果に意図しない差分が出ていないか
- `KPool.MonetizationApi.openapi.yaml` に生成された schema 名・nullable・status code が想定どおりか

## 📖 関連情報

### 関連Issue・タスク

Closes #145
Closes #302

## ⚠️ 注意事項

- OpenAPI 生成物として `doc/openapi/KPool.AccountApi.openapi.yaml`、`doc/openapi/KPool.IdentityApi.openapi.yaml`、`doc/openapi/KPool.WikiPrivateApi.openapi.yaml` にも差分があります
- 破壊的変更やマイグレーションはありません

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した