### PR TITLE
Laravel API サーバーを Docker の nginx + php-fpm 構成で起動可能にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM php:8.5-cli
+FROM php:8.5-fpm
 
 # 必要なパッケージのインストール
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        bash \
         build-essential \
         autoconf \
+        curl \
         libzip-dev \
         libpq-dev \
         libpng-dev \
@@ -33,12 +35,10 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 # 作業ディレクトリの設定
 WORKDIR /var/www/html
 
-# PHPUnitのインストール
-RUN composer require --dev phpunit/phpunit
-
-# テスト実行用のエントリーポイント
+# CLI実行とphp-fpm起動を兼ねるエントリーポイント
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh \
     && chmod +x /usr/local/bin/docker-entrypoint.sh
 
-ENTRYPOINT ["docker-entrypoint.sh"] 
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["php-fpm", "-F"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ REDIS_PORT=6379
 APP_ENV=local
 APP_DEBUG=true
 APP_KEY=
+APP_URL=http://localhost:8080
+FRONTEND_URL=http://localhost:3000
 
 # Logging
 LOG_CHANNEL=stack
@@ -33,17 +35,39 @@ LOG_LEVEL=debug
 
 ### Running with Docker
 
-1. Start the services:
+1. Start the Laravel API stack (`nginx + php-fpm + postgres + redis + mailpit`):
 ```bash
-docker-compose up -d
+task up
 ```
 
-2. Install PHP dependencies:
+2. Install PHP dependencies if `vendor/` is not present yet:
 ```bash
-docker-compose exec php composer install
+task install
 ```
 
-3. Run tests:
+3. Confirm the API server is reachable from the host:
+```bash
+curl -i http://localhost:8080/
+```
+
+`/` has no application route by default, so a `404 Not Found` response still confirms that `nginx -> php-fpm -> Laravel` is working.
+
+4. Confirm an `/api/...` endpoint is reachable from the host:
+```bash
+curl -i -X POST http://localhost:8080/api/identity/auth/send-auth-code \
+  -H 'Content-Type: application/json' \
+  --data '{"email":"demo@example.com"}'
+```
+
+5. Confirm another container on the same Docker network can reach the backend:
+```bash
+docker run --rm --network kpool-network curlimages/curl:8.13.0 \
+  -i http://nginx/api/identity/auth/send-auth-code \
+  -H 'Content-Type: application/json' \
+  --data '{"email":"demo@example.com"}'
+```
+
+6. Run tests:
 ```bash
 # Run all tests (including database tests)
 task test
@@ -51,9 +75,23 @@ task test
 # Run tests without database
 task test-no-db
 
-# Run only database tests
-task test-db
 ```
+
+### API Operations
+
+Use these tasks during development:
+
+```bash
+task up
+task down
+task restart
+task logs
+task shell
+```
+
+The backend is published on `http://localhost:8080`, and containers joined to the shared Docker network can reach it via `http://nginx`. The network name is fixed to `kpool-network` so a separate Next.js compose stack can join it as an external network.
+
+If the frontend runs on another origin, set `FRONTEND_URL` in `.env` so CORS permits requests from that origin.
 
 ### Test Organization
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,10 @@ version: '3'
 vars:
   PHPUNIT: ./vendor/bin/phpunit
   SLEEP_SECONDS: 5
+  API_SERVICES: php nginx testing_db redis mail
+  TEST_SERVICES: testing_db redis
+  PHP_RUN: docker-compose run --rm php
+  PHP_EXEC: docker-compose exec php
 
 tasks:
   wait-for-test-db:
@@ -15,16 +19,16 @@ tasks:
   test:
     desc: "Run all PHPUnit tests (DB tests + non-DB tests). Usage: task test [filter=TestClassName] [keepdb=1]"
     cmds:
-      - docker-compose up -d testing_db redis
+      - docker-compose up -d {{.TEST_SERVICES}}
       - task: wait-for-test-db
       - defer: '{{if not .keepdb}}docker-compose stop testing_db redis && docker-compose rm -v -f testing_db redis{{end}}'
-      - docker-compose run --rm php bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --coverage-html coverage-html"
+      - '{{.PHP_RUN}} bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --coverage-html coverage-html"'
 
   test-no-db:
     desc: "Run PHPUnit tests excluding 'useDb' group. Usage: task test-no-db [filter=TestClassName]"
     cmds:
       - docker-compose stop testing_db 2>/dev/null || true
-      - docker-compose run --rm php bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --exclude-group useDb --coverage-html coverage-html"
+      - '{{.PHP_RUN}} bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --exclude-group useDb --coverage-html coverage-html"'
 
   check:
     desc: Run code style fix, static analysis, and all tests
@@ -33,55 +37,50 @@ tasks:
       - task: phpstan
       - task: test
 
-  db-up:
-    desc: Start PostgreSQL testing service
+  up:
+    desc: Start Laravel API server with nginx + php-fpm
     cmds:
-      - docker-compose up -d testing_db
+      - docker-compose up -d {{.API_SERVICES}}
 
-  db-down:
-    desc: Stop all services
+  down:
+    desc: Stop the API stack
     cmds:
-      - docker-compose down
+      - docker-compose stop {{.API_SERVICES}}
 
-  db-restart:
-    desc: Restart PostgreSQL testing service
+  restart:
+    desc: Restart the API stack
     cmds:
-      - docker-compose restart testing_db
+      - docker-compose restart {{.API_SERVICES}}
 
-  db-logs:
-    desc: View PostgreSQL testing logs
+  logs:
+    desc: View Laravel API server logs
     cmds:
-      - docker-compose logs -f testing_db
+      - docker-compose logs -f {{.API_SERVICES}}
 
-  db-shell:
-    desc: Connect to PostgreSQL testing shell
+  shell:
+    desc: Open a shell in the php container
     cmds:
-      - docker-compose exec testing_db psql -U kpool -d kpool
+      - '{{.PHP_EXEC}} bash'
 
-  db-clean:
-    desc: Stop services and remove testing database volumes
+  reset:
+    desc: Stop the API stack and remove local Docker volumes
     cmds:
       - docker-compose down -v --remove-orphans
 
-  mail-up:
-    desc: Start Mailpit and php (php will pull up testing_db via depends_on)
+  curl:
+    desc: "Call a Laravel API endpoint from the host network. Usage: task curl path=/api/identity/auth/send-auth-code method=POST data='{\"email\":\"foo@example.com\"}'"
     cmds:
-      - docker-compose up -d mail php
+      - 'curl -i -X {{.method | default "GET"}} "http://localhost:{{.APP_PORT | default "8080"}}{{.path}}"{{if .data}} -H "Content-Type: application/json" --data "{{.data}}"{{end}}'
 
-  mail-down:
-    desc: Stop Mailpit and php
+  curl-from-docker:
+    desc: "Call the API from another container on the shared Docker network. Usage: task curl-from-docker path=/api/identity/auth/send-auth-code method=POST data='{\"email\":\"foo@example.com\"}'"
     cmds:
-      - docker-compose stop mail php
-
-  up:
-    desc: Start all services
-    cmds:
-      - docker-compose up -d
+      - 'docker run --rm --network kpool-network curlimages/curl:8.13.0 -i -X {{.method | default "GET"}} "http://nginx{{.path}}"{{if .data}} -H "Content-Type: application/json" --data "{{.data}}"{{end}}'
 
   install:
     desc: Install composer dependencies
     cmds:
-      - docker-compose run --rm php composer install
+      - '{{.PHP_RUN}} composer install'
 
   openapi:
     desc: Install TypeSpec dependencies and generate OpenAPI specs
@@ -97,19 +96,19 @@ tasks:
   phpstan:
     desc: Run PHPStan static analysis
     cmds:
-      - docker-compose run --rm php composer phpstan
+      - '{{.PHP_RUN}} composer phpstan'
 
   cs-fix:
     desc: Fix code style using PHP CS Fixer
     cmds:
-      - docker-compose run --rm php composer cs-fix
+      - '{{.PHP_RUN}} composer cs-fix'
 
   process-due-transfers:
     desc: "Execute due transfer batch processing. Usage: task process-due-transfers [date=2024-02-10] [dry-run=1]"
     cmds:
-      - docker-compose up -d testing_db redis
+      - docker-compose up -d {{.TEST_SERVICES}}
       - task: wait-for-test-db
-      - docker-compose run --rm php php artisan settlement:process-due-transfers {{if .date}}--date={{.date}}{{end}} {{if (index . "dry-run")}}--dry-run{{end}}
+      - '{{.PHP_RUN}} php artisan settlement:process-due-transfers {{if .date}}--date={{.date}}{{end}} {{if (index . "dry-run")}}--dry-run{{end}}'
 
   help:
     desc: Show available tasks

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'paths' => ['api/*', 'webhook/*'],
+    'allowed_methods' => ['*'],
+    'allowed_origins' => array_filter([
+        env('FRONTEND_URL', 'http://localhost:3000'),
+        env('APP_URL', 'http://localhost:8080'),
+    ]),
+    'allowed_origins_patterns' => [],
+    'allowed_headers' => ['*'],
+    'exposed_headers' => [],
+    'max_age' => 0,
+    'supports_credentials' => false,
+];

--- a/config/view.php
+++ b/config/view.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'paths' => [
+        resource_path('views'),
+    ],
+
+    'compiled' => env(
+        'VIEW_COMPILED_PATH',
+        realpath(storage_path('framework/views')) ?: storage_path('framework/views'),
+    ),
+];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,23 +5,41 @@ services:
       - .:/var/www/html
     working_dir: /var/www/html
     environment:
-      - DB_CONNECTION=pgsql
-      - DB_HOST=testing_db
-      - DB_PORT=5432
-      - DB_DATABASE=kpool
-      - DB_USERNAME=kpool
-      - DB_PASSWORD=secret
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - MAIL_MAILER=smtp
-      - MAIL_HOST=mail
-      - MAIL_PORT=1025
-      - MAIL_FROM_ADDRESS=noreply@kpool.local
-      - MAIL_FROM_NAME=Kpool
-      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
+      APP_ENV: local
+      APP_DEBUG: "true"
+      APP_URL: ${APP_URL:-http://localhost:8080}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
+      DB_CONNECTION: pgsql
+      DB_HOST: testing_db
+      DB_PORT: 5432
+      DB_DATABASE: kpool
+      DB_USERNAME: kpool
+      DB_PASSWORD: secret
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      MAIL_MAILER: smtp
+      MAIL_HOST: mail
+      MAIL_PORT: 1025
+      MAIL_FROM_ADDRESS: noreply@kpool.local
+      MAIL_FROM_NAME: Kpool
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
     depends_on:
       - testing_db
       - redis
+    networks:
+      - kpool-network
+    expose:
+      - "9000"
+
+  nginx:
+    image: nginx:1.29-alpine
+    depends_on:
+      - php
+    ports:
+      - "${APP_PORT:-8080}:80"
+    volumes:
+      - .:/var/www/html:ro
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     networks:
       - kpool-network
 
@@ -67,4 +85,5 @@ volumes:
 
 networks:
   kpool-network:
-    driver: bridge 
+    name: kpool-network
+    driver: bridge

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
-# Composerの依存関係をインストール
-if [ -f "composer.json" ]; then
-    composer install
+set -eu
+
+# vendor 未生成時だけ依存を入れて、CLI運用はそのまま維持する
+if [ -f "composer.json" ] && [ ! -f "vendor/autoload.php" ] && [ "${1:-}" != "composer" ]; then
+    composer install --no-interaction --prefer-dist
 fi
 
-# コマンドが指定されていない場合はbashを実行
+# コマンドが指定されていない場合はphp-fpmを実行
 if [ $# -eq 0 ]; then
-    exec bash
+    exec php-fpm -F
 else
     exec "$@"
-fi 
+fi

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /var/www/html/public;
+    index index.php;
+
+    client_max_body_size 20m;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$app = require_once __DIR__ . '/../bootstrap/app.php';
+
+$kernel = $app->make(Kernel::class);
+
+$response = $kernel->handle(
+    $request = Request::capture(),
+);
+
+$response->send();
+
+$kernel->terminate($request, $response);

--- a/storage/app/.gitignore
+++ b/storage/app/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/.gitignore
+++ b/storage/framework/.gitignore
@@ -1,0 +1,6 @@
+*
+!cache/
+!sessions/
+!testing/
+!views/
+!.gitignore

--- a/storage/framework/cache/.gitignore
+++ b/storage/framework/cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!data/

--- a/storage/framework/cache/data/.gitignore
+++ b/storage/framework/cache/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/sessions/.gitignore
+++ b/storage/framework/sessions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/testing/.gitignore
+++ b/storage/framework/testing/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/views/.gitignore
+++ b/storage/framework/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/logs/.gitignore
+++ b/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## 📝 変更内容

- Docker 環境を `nginx + php-fpm + postgres + redis + mailpit` 構成に変更し、ホストの `http://localhost:8080` から Laravel API にアクセスできるようにしました
- `public/index.php` と nginx 設定を追加して HTTP エントリポイントを整備しました
- `Taskfile.yml` を整理し、API サーバー起動・停止・ログ確認・シェル起動・疎通確認を行いやすくしました
- `README.md` に起動手順、ホストおよび Docker ネットワーク内からの接続確認手順を追記しました
- CORS / view 設定と `storage` 配下の `.gitignore` を追加し、Laravel の HTTP 実行に必要な設定を補完しました
- GitHub Actions の CI に `contents: read` 権限を追加しました

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Laravel バックエンドを Docker 上で API サーバーとして常時起動し、ホスト環境や同一 Docker ネットワーク上の別コンテナから HTTP 経由で利用できる状態にする必要がありました。あわせて、起動導線と疎通確認手順を整理して、ローカル開発のセットアップを簡潔にするためです。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `docker-compose.yml` と `docker/nginx/default.conf` の構成で、`nginx -> php-fpm -> Laravel` の経路が意図どおりになっているか
- `Taskfile.yml` の `up` / `down` / `restart` / `logs` / `shell` / `curl-from-docker` が運用しやすい粒度になっているか
- `config/cors.php` の許可オリジン設定と `kpool-network` 固定化がローカル開発要件に合っているか

## 📖 関連情報

### 関連Issue・タスク

Closes #313

## ⚠️ 注意事項

- `FRONTEND_URL` を `.env` に設定しない場合、CORS 許可元は `http://localhost:3000` が使われます
- `task check` の実行結果はこの PR 本文では未反映です
- 破壊的変更やマイグレーションは特にありません

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
