### PR TITLE
refactor: WikiテーブルblockをTableCellベースに拡張

### DIFF
--- a/src/Wiki/Wiki/Domain/ValueObject/Block/TableBlock.php
+++ b/src/Wiki/Wiki/Domain/ValueObject/Block/TableBlock.php
@@ -7,13 +7,14 @@ namespace Source\Wiki\Wiki\Domain\ValueObject\Block;
 final readonly class TableBlock implements BlockInterface
 {
     /**
-     * @param array<array<string>> $rows
-     * @param array<string>|null $headers
+     * @param array<array<TableCell>> $rowCells
+     * @param array<TableCell>|null $headerCells
      */
     public function __construct(
         private int $displayOrder,
-        private array $rows,
-        private ?array $headers = null,
+        private array $rowCells,
+        private ?array $headerCells = null,
+        private ?string $tableWidth = null,
     ) {
     }
 
@@ -28,18 +29,23 @@ final readonly class TableBlock implements BlockInterface
     }
 
     /**
-     * @return array<array<string>>
+     * @return array<array<TableCell>>
      */
-    public function rows(): array
+    public function rowCells(): array
     {
-        return $this->rows;
+        return $this->rowCells;
     }
 
     /**
-     * @return array<string>|null
+     * @return array<TableCell>|null
      */
-    public function headers(): ?array
+    public function headerCells(): ?array
     {
-        return $this->headers;
+        return $this->headerCells;
+    }
+
+    public function tableWidth(): ?string
+    {
+        return $this->tableWidth;
     }
 }

--- a/src/Wiki/Wiki/Domain/ValueObject/Block/TableCell.php
+++ b/src/Wiki/Wiki/Domain/ValueObject/Block/TableCell.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Domain\ValueObject\Block;
+
+final readonly class TableCell
+{
+    public function __construct(
+        private string $content,
+        private ?int $colspan = null,
+    ) {
+    }
+
+    public function content(): string
+    {
+        return $this->content;
+    }
+
+    public function colspan(): ?int
+    {
+        return $this->colspan;
+    }
+
+    public function withContent(string $content): self
+    {
+        return new self($content, $this->colspan);
+    }
+
+    /**
+     * @param array{content?: string, colspan?: int} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['content'] ?? '',
+            $data['colspan'] ?? null,
+        );
+    }
+
+    /**
+     * @return array{content: string, colspan?: int}
+     */
+    public function toArray(): array
+    {
+        $data = ['content' => $this->content];
+        if ($this->colspan !== null) {
+            $data['colspan'] = $this->colspan;
+        }
+
+        return $data;
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Repository/SectionContentMapper.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/SectionContentMapper.php
@@ -16,6 +16,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\Block\ListType;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\ProfileCardListBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\QuoteBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TableBlock;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\TableCell;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TextBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\Section;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
@@ -84,8 +85,12 @@ final class SectionContentMapper
                         TableBlock::class => [
                             'block_type' => $content->blockType()->value,
                             'display_order' => $content->displayOrder(),
-                            'rows' => $content->rows(),
-                            'headers' => $content->headers(),
+                            'header_cells' => self::tableCellsToArray($content->headerCells()),
+                            'row_cells' => array_map(
+                                static fn (array $rowCells): array => self::tableCellsToArray($rowCells) ?? [],
+                                $content->rowCells(),
+                            ),
+                            'table_width' => $content->tableWidth(),
                         ],
                         ProfileCardListBlock::class => [
                             'block_type' => $content->blockType()->value,
@@ -158,8 +163,12 @@ final class SectionContentMapper
                     ),
                     BlockType::TABLE => new TableBlock(
                         displayOrder: $contentData['display_order'] ?? 0,
-                        rows: $contentData['rows'] ?? [],
-                        headers: $contentData['headers'] ?? null,
+                        rowCells: array_map(
+                            static fn (array $rowCells): array => self::tableCellsFromArray($rowCells) ?? [],
+                            $contentData['row_cells'] ?? [],
+                        ),
+                        headerCells: self::tableCellsFromArray($contentData['header_cells'] ?? null),
+                        tableWidth: $contentData['table_width'] ?? null,
                     ),
                     BlockType::PROFILE_CARD_LIST => new ProfileCardListBlock(
                         displayOrder: $contentData['display_order'] ?? 0,
@@ -175,5 +184,37 @@ final class SectionContentMapper
         );
 
         return new SectionContentCollection($contents);
+    }
+
+    /**
+     * @param array<TableCell>|null $cells
+     * @return array<array{content: string, colspan?: int}>|null
+     */
+    private static function tableCellsToArray(?array $cells): ?array
+    {
+        if ($cells === null) {
+            return null;
+        }
+
+        return array_map(
+            static fn (TableCell $cell): array => $cell->toArray(),
+            $cells,
+        );
+    }
+
+    /**
+     * @param array<array{content?: string, colspan?: int}>|null $cells
+     * @return array<TableCell>|null
+     */
+    private static function tableCellsFromArray(?array $cells): ?array
+    {
+        if ($cells === null) {
+            return null;
+        }
+
+        return array_map(
+            static fn (array $cell): TableCell => TableCell::fromArray($cell),
+            $cells,
+        );
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Service/TranslationService.php
+++ b/src/Wiki/Wiki/Infrastructure/Service/TranslationService.php
@@ -18,6 +18,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\TalentBasic;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\ListBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\QuoteBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TableBlock;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\TableCell;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TextBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\Section;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
@@ -98,15 +99,9 @@ readonly class TranslationService implements TranslationServiceInterface
                     $texts[] = $item;
                 }
             } elseif ($content instanceof TableBlock) {
-                if ($content->headers() !== null) {
-                    foreach ($content->headers() as $header) {
-                        $texts[] = $header;
-                    }
-                }
-                foreach ($content->rows() as $row) {
-                    foreach ($row as $cell) {
-                        $texts[] = $cell;
-                    }
+                $this->collectTableCellTexts($content->headerCells(), $texts);
+                foreach ($content->rowCells() as $row) {
+                    $this->collectTableCellTexts($row, $texts);
                 }
             }
         }
@@ -174,28 +169,56 @@ readonly class TranslationService implements TranslationServiceInterface
         }
 
         if ($content instanceof TableBlock) {
-            $translatedHeaders = null;
-            if ($content->headers() !== null) {
-                $translatedHeaders = [];
-                foreach ($content->headers() as $header) {
-                    $translatedHeaders[] = $translations[$offset] ?? $header;
-                    $offset++;
-                }
-            }
-            $translatedRows = [];
-            foreach ($content->rows() as $row) {
-                $translatedRow = [];
-                foreach ($row as $cell) {
-                    $translatedRow[] = $translations[$offset] ?? $cell;
-                    $offset++;
-                }
-                $translatedRows[] = $translatedRow;
+            $translatedHeaderCells = $this->translateTableCells($content->headerCells(), $translations, $offset);
+            $translatedRowCells = [];
+            foreach ($content->rowCells() as $row) {
+                $translatedRowCells[] = $this->translateTableCells($row, $translations, $offset) ?? [];
             }
 
-            return new TableBlock($content->displayOrder(), $translatedRows, $translatedHeaders);
+            return new TableBlock(
+                $content->displayOrder(),
+                $translatedRowCells,
+                $translatedHeaderCells,
+                $content->tableWidth(),
+            );
         }
 
         // 翻訳不要なブロック（ImageBlock, EmbedBlock等）はそのまま返す
         return $content;
+    }
+
+    /**
+     * @param array<TableCell>|null $cells
+     * @param string[] &$texts
+     */
+    private function collectTableCellTexts(?array $cells, array &$texts): void
+    {
+        if ($cells === null) {
+            return;
+        }
+
+        foreach ($cells as $cell) {
+            $texts[] = $cell->content();
+        }
+    }
+
+    /**
+     * @param array<TableCell>|null $cells
+     * @param string[] $translations
+     * @return array<TableCell>|null
+     */
+    private function translateTableCells(?array $cells, array $translations, int &$offset): ?array
+    {
+        if ($cells === null) {
+            return null;
+        }
+
+        $translatedCells = [];
+        foreach ($cells as $cell) {
+            $translatedCells[] = $cell->withContent($translations[$offset] ?? $cell->content());
+            $offset++;
+        }
+
+        return $translatedCells;
     }
 }

--- a/tests/Wiki/Wiki/Domain/ValueObject/Block/TableBlockTest.php
+++ b/tests/Wiki/Wiki/Domain/ValueObject/Block/TableBlockTest.php
@@ -7,6 +7,7 @@ namespace Tests\Wiki\Wiki\Domain\ValueObject\Block;
 use PHPUnit\Framework\TestCase;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\BlockType;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TableBlock;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\TableCell;
 
 class TableBlockTest extends TestCase
 {
@@ -16,22 +17,36 @@ class TableBlockTest extends TestCase
     public function test__constructWithHeaders(): void
     {
         $displayOrder = 1;
-        $rows = [
-            ['2018-06-13', 'デビュー', 'ミニアルバム発売'],
-            ['2020-02-21', '1stアルバム', 'フルアルバム発売'],
+        $rowCells = [
+            [
+                new TableCell('2018-06-13'),
+                new TableCell('デビュー'),
+                new TableCell('ミニアルバム発売'),
+            ],
+            [
+                new TableCell('2020-02-21'),
+                new TableCell('1stアルバム', 2),
+            ],
         ];
-        $headers = ['日付', 'タイトル', '説明'];
+        $headerCells = [
+            new TableCell('日付'),
+            new TableCell('タイトル'),
+            new TableCell('説明'),
+        ];
+        $tableWidth = '80%';
 
         $block = new TableBlock(
             displayOrder: $displayOrder,
-            rows: $rows,
-            headers: $headers,
+            rowCells: $rowCells,
+            headerCells: $headerCells,
+            tableWidth: $tableWidth,
         );
 
         $this->assertSame($displayOrder, $block->displayOrder());
         $this->assertSame(BlockType::TABLE, $block->blockType());
-        $this->assertSame($rows, $block->rows());
-        $this->assertSame($headers, $block->headers());
+        $this->assertSame($rowCells, $block->rowCells());
+        $this->assertSame($headerCells, $block->headerCells());
+        $this->assertSame($tableWidth, $block->tableWidth());
     }
 
     /**
@@ -41,10 +56,11 @@ class TableBlockTest extends TestCase
     {
         $block = new TableBlock(
             displayOrder: 0,
-            rows: [['セル1', 'セル2']],
+            rowCells: [[new TableCell('セル1'), new TableCell('セル2')]],
         );
 
-        $this->assertNull($block->headers());
+        $this->assertNull($block->headerCells());
+        $this->assertNull($block->tableWidth());
     }
 
     /**
@@ -54,9 +70,9 @@ class TableBlockTest extends TestCase
     {
         $block = new TableBlock(
             displayOrder: 0,
-            rows: [],
+            rowCells: [],
         );
 
-        $this->assertEmpty($block->rows());
+        $this->assertEmpty($block->rowCells());
     }
 }

--- a/tests/Wiki/Wiki/Domain/ValueObject/Block/TableCellTest.php
+++ b/tests/Wiki/Wiki/Domain/ValueObject/Block/TableCellTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Domain\ValueObject\Block;
+
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\TableCell;
+
+class TableCellTest extends TestCase
+{
+    public function testFromArrayAndToArray(): void
+    {
+        $cell = TableCell::fromArray([
+            'content' => 'タイトル',
+            'colspan' => 2,
+        ]);
+
+        $this->assertSame('タイトル', $cell->content());
+        $this->assertSame(2, $cell->colspan());
+        $this->assertSame(
+            ['content' => 'タイトル', 'colspan' => 2],
+            $cell->toArray()
+        );
+    }
+
+    public function testWithContentKeepsColspan(): void
+    {
+        $cell = new TableCell('原文', 3);
+
+        $translated = $cell->withContent('翻訳後');
+
+        $this->assertSame('翻訳後', $translated->content());
+        $this->assertSame(3, $translated->colspan());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Repository/SectionContentMapperTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Repository/SectionContentMapperTest.php
@@ -15,6 +15,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\Block\ListType;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\ProfileCardListBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\QuoteBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TableBlock;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\TableCell;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TextBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\Section;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
@@ -148,7 +149,15 @@ class SectionContentMapperTest extends TestCase
     public function testTableBlockRoundTrip(): void
     {
         $collection = new SectionContentCollection([
-            new TableBlock(displayOrder: 1, rows: [['A1', 'B1'], ['A2', 'B2']], headers: ['列A', '列B']),
+            new TableBlock(
+                displayOrder: 1,
+                rowCells: [
+                    [new TableCell('A1'), new TableCell('B1', 2)],
+                    [new TableCell('A2'), new TableCell('B2')],
+                ],
+                headerCells: [new TableCell('列A'), new TableCell('列B')],
+                tableWidth: '640px',
+            ),
         ]);
 
         $array = SectionContentMapper::collectionToArray($collection);
@@ -156,8 +165,15 @@ class SectionContentMapperTest extends TestCase
 
         $block = $restored->sorted()[0];
         $this->assertInstanceOf(TableBlock::class, $block);
-        $this->assertSame([['A1', 'B1'], ['A2', 'B2']], $block->rows());
-        $this->assertSame(['列A', '列B'], $block->headers());
+        $this->assertEquals(
+            [
+                [new TableCell('A1'), new TableCell('B1', 2)],
+                [new TableCell('A2'), new TableCell('B2')],
+            ],
+            $block->rowCells()
+        );
+        $this->assertEquals([new TableCell('列A'), new TableCell('列B')], $block->headerCells());
+        $this->assertSame('640px', $block->tableWidth());
     }
 
     /**

--- a/tests/Wiki/Wiki/Infrastructure/Service/TranslationServiceTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Service/TranslationServiceTest.php
@@ -31,6 +31,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\Block\ListBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\ListType;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\QuoteBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TableBlock;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\TableCell;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TextBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\Section;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
@@ -224,7 +225,12 @@ class TranslationServiceTest extends TestCase
                 new SectionContentCollection([
                     new QuoteBlock(0, '음악은 세계 공통 언어입니다.', '채영'),
                     new ListBlock(1, ListType::BULLET, ['항목1', '항목2']),
-                    new TableBlock(2, [['셀1', '셀2']], ['헤더1', '헤더2']),
+                    new TableBlock(
+                        2,
+                        [[new TableCell('셀1'), new TableCell('셀2', 2)]],
+                        [new TableCell('헤더1'), new TableCell('헤더2')],
+                        '75%',
+                    ),
                 ]),
             ),
         ]);
@@ -266,8 +272,12 @@ class TranslationServiceTest extends TestCase
 
         /** @var TableBlock $tableBlock */
         $tableBlock = $blocks[2];
-        $this->assertSame(['ヘッダー1', 'ヘッダー2'], $tableBlock->headers());
-        $this->assertSame([['セル1', 'セル2']], $tableBlock->rows());
+        $this->assertEquals([new TableCell('ヘッダー1'), new TableCell('ヘッダー2')], $tableBlock->headerCells());
+        $this->assertEquals(
+            [[new TableCell('セル1'), new TableCell('セル2', 2)]],
+            $tableBlock->rowCells()
+        );
+        $this->assertSame('75%', $tableBlock->tableWidth());
     }
 
     /**


### PR DESCRIPTION
## 📝 変更内容

- Wikiの `TableBlock` を文字列配列ベースから `TableCell` Value Object ベースへ変更
- `TableCell` を追加し、セルごとの `content` と `colspan` を扱えるようにした
- `TableBlock` に `tableWidth` を追加
- `SectionContentMapper` を更新し、テーブルを `header_cells` / `row_cells` / `table_width` 形式で相互変換できるようにした
- `TranslationService` を更新し、テーブルセルの文言だけを翻訳しつつ `colspan` と `tableWidth` を保持するようにした
- 関連ユニットテストを追加・更新した

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wikiのテーブル表現で、セル単位の属性とテーブル幅を保持できる構造が必要になったためです。既存の文字列配列では `colspan` のような表現情報を扱えないため、Value Object を導入してテーブル構造を拡張し、翻訳処理や永続化でもその情報を失わないようにしました。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `TableBlock` の新しい表現(`TableCell`, `tableWidth`)がドメインとして妥当か
- `SectionContentMapper` の配列変換形式が保存データ互換性の観点で問題ないか
- 翻訳処理でセル文言のみを差し替え、`colspan` / `tableWidth` が維持されること

## 📖 関連情報

### 関連Issue・タスク

Closes #317

## ⚠️ 注意事項

- テーブルのシリアライズ形式が `rows` / `headers` から `row_cells` / `header_cells` / `table_width` に変わっています
- 既存データとの互換性確認が必要な場合は別途確認してください

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
