### PR TITLE
add: Wiki編集画面確認用のサンプルSeederを追加

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,16 +3,16 @@ version: '3'
 vars:
   PHPUNIT: ./vendor/bin/phpunit
   SLEEP_SECONDS: 5
-  API_SERVICES: php nginx testing_db redis mail
+  API_SERVICES: php nginx db redis mail
   TEST_SERVICES: testing_db redis
-  PHP_RUN: docker-compose run --rm php
+  PHP_RUN: docker-compose run --rm --no-deps php
   PHP_EXEC: docker-compose exec php
 
 tasks:
-  wait-for-test-db:
-    desc: Wait for testing database to be ready
+  wait-for-db:
+    desc: Wait for database to be ready
     cmds:
-      - echo "Waiting for testing database to be ready..."
+      - echo "Waiting for database to be ready..."
       - '{{if eq OS "windows"}}powershell -Command "Start-Sleep -Seconds {{.SLEEP_SECONDS}}"{{else}}sleep {{.SLEEP_SECONDS}}{{end}}'
     silent: true
 
@@ -20,7 +20,7 @@ tasks:
     desc: "Run all PHPUnit tests (DB tests + non-DB tests). Usage: task test [filter=TestClassName] [keepdb=1]"
     cmds:
       - docker-compose up -d {{.TEST_SERVICES}}
-      - task: wait-for-test-db
+      - task: wait-for-db
       - defer: '{{if not .keepdb}}docker-compose stop testing_db redis && docker-compose rm -v -f testing_db redis{{end}}'
       - '{{.PHP_RUN}} bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --coverage-html coverage-html"'
 
@@ -41,6 +41,9 @@ tasks:
     desc: Start Laravel API server with nginx + php-fpm
     cmds:
       - docker-compose up -d {{.API_SERVICES}}
+      - task: wait-for-db
+      - '{{.PHP_RUN}} php artisan migrate --force'
+      - '{{.PHP_RUN}} php artisan db:seed'
 
   down:
     desc: Stop the API stack
@@ -106,9 +109,24 @@ tasks:
   process-due-transfers:
     desc: "Execute due transfer batch processing. Usage: task process-due-transfers [date=2024-02-10] [dry-run=1]"
     cmds:
-      - docker-compose up -d {{.TEST_SERVICES}}
-      - task: wait-for-test-db
+      - docker-compose up -d db redis
+      - task: wait-for-db
       - '{{.PHP_RUN}} php artisan settlement:process-due-transfers {{if .date}}--date={{.date}}{{end}} {{if (index . "dry-run")}}--dry-run{{end}}'
+
+  migrate:
+    desc: "Run database migrations on db. Usage: task migrate"
+    cmds:
+      - docker-compose up -d db
+      - task: wait-for-db
+      - '{{.PHP_RUN}} php artisan migrate --force'
+
+  seed:
+    desc: "Run database seeders. Usage: task seed [class=Database\\\\Seeders\\\\WikiEditorSampleSeeder]"
+    cmds:
+      - docker-compose up -d db
+      - task: wait-for-db
+      - 'docker-compose run --rm --no-deps php php artisan migrate --force'
+      - 'docker-compose run --rm --no-deps php php artisan db:seed{{if .class}} --class="{{.class}}"{{end}}'
 
   help:
     desc: Show available tasks

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         ],
         "psr-4": {
             "Source\\": "src/",
-            "Application\\": "application/"
+            "Application\\": "application/",
+            "Database\\Seeders\\": "database/seeders/"
         }
     },
     "autoload-dev": {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->call([
+            WikiEditorSampleSeeder::class,
+        ]);
+    }
+}

--- a/database/seeders/WikiEditorSampleSeeder.php
+++ b/database/seeders/WikiEditorSampleSeeder.php
@@ -1,0 +1,490 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class WikiEditorSampleSeeder extends Seeder
+{
+    private const string GROUP_PUBLISHED_WIKI_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f001';
+    private const string GROUP_DRAFT_WIKI_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f002';
+    private const string GROUP_TRANSLATION_SET_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f003';
+    private const string EDITOR_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f004';
+
+    /**
+     * Repo 内にフロントの mock fixture は見当たらないため、
+     * 編集画面確認に必要な TWICE の 9 メンバー構成を最小サンプルとして固定投入する。
+     *
+     * @var array<int, array{
+     *     key: string,
+     *     published_wiki_id: string,
+     *     draft_wiki_id: string,
+     *     translation_set_identifier: string,
+     *     slug: string,
+     *     name: string,
+     *     normalized_name: string,
+     *     real_name: string,
+     *     normalized_real_name: string,
+     *     birthday: string,
+     *     representative_symbol: string,
+     *     position: string,
+     *     mbti: ?string,
+     *     zodiac_sign: string,
+     *     height: int,
+     *     blood_type: string
+     * }>
+     */
+    private const array TALENTS = [
+        [
+            'key' => 'nayeon',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+            'slug' => 'nayeon',
+            'name' => 'Nayeon',
+            'normalized_name' => 'nayeon',
+            'real_name' => 'Im Nayeon',
+            'normalized_real_name' => 'im nayeon',
+            'birthday' => '1995-09-22',
+            'representative_symbol' => 'Bunny',
+            'position' => 'Lead Vocalist, Lead Dancer, Center',
+            'mbti' => 'ISFP',
+            'zodiac_sign' => 'Virgo',
+            'height' => 163,
+            'blood_type' => 'A',
+        ],
+        [
+            'key' => 'jeongyeon',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f111',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f112',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f113',
+            'slug' => 'jeongyeon',
+            'name' => 'Jeongyeon',
+            'normalized_name' => 'jeongyeon',
+            'real_name' => 'Yoo Jeongyeon',
+            'normalized_real_name' => 'yoo jeongyeon',
+            'birthday' => '1996-11-01',
+            'representative_symbol' => 'Dog',
+            'position' => 'Lead Vocalist',
+            'mbti' => 'ISFJ',
+            'zodiac_sign' => 'Scorpio',
+            'height' => 169,
+            'blood_type' => 'O',
+        ],
+        [
+            'key' => 'momo',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f121',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f122',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f123',
+            'slug' => 'momo',
+            'name' => 'Momo',
+            'normalized_name' => 'momo',
+            'real_name' => 'Hirai Momo',
+            'normalized_real_name' => 'hirai momo',
+            'birthday' => '1996-11-09',
+            'representative_symbol' => 'Peach',
+            'position' => 'Main Dancer, Sub Vocalist, Sub Rapper',
+            'mbti' => 'INFP',
+            'zodiac_sign' => 'Scorpio',
+            'height' => 167,
+            'blood_type' => 'A',
+        ],
+        [
+            'key' => 'sana',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f131',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f132',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f133',
+            'slug' => 'sana',
+            'name' => 'Sana',
+            'normalized_name' => 'sana',
+            'real_name' => 'Minatozaki Sana',
+            'normalized_real_name' => 'minatozaki sana',
+            'birthday' => '1996-12-29',
+            'representative_symbol' => 'Squirrel',
+            'position' => 'Sub Vocalist',
+            'mbti' => 'ENFP',
+            'zodiac_sign' => 'Capricorn',
+            'height' => 164,
+            'blood_type' => 'B',
+        ],
+        [
+            'key' => 'jihyo',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f141',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f142',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f143',
+            'slug' => 'jihyo',
+            'name' => 'Jihyo',
+            'normalized_name' => 'jihyo',
+            'real_name' => 'Park Jihyo',
+            'normalized_real_name' => 'park jihyo',
+            'birthday' => '1997-02-01',
+            'representative_symbol' => 'Apricot',
+            'position' => 'Leader, Main Vocalist',
+            'mbti' => 'ISFP',
+            'zodiac_sign' => 'Aquarius',
+            'height' => 160,
+            'blood_type' => 'O',
+        ],
+        [
+            'key' => 'mina',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f151',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f152',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f153',
+            'slug' => 'mina',
+            'name' => 'Mina',
+            'normalized_name' => 'mina',
+            'real_name' => 'Myoui Mina',
+            'normalized_real_name' => 'myoui mina',
+            'birthday' => '1997-03-24',
+            'representative_symbol' => 'Penguin',
+            'position' => 'Main Dancer, Sub Vocalist',
+            'mbti' => 'ISFP',
+            'zodiac_sign' => 'Aries',
+            'height' => 163,
+            'blood_type' => 'A',
+        ],
+        [
+            'key' => 'dahyun',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f161',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f162',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f163',
+            'slug' => 'dahyun',
+            'name' => 'Dahyun',
+            'normalized_name' => 'dahyun',
+            'real_name' => 'Kim Dahyun',
+            'normalized_real_name' => 'kim dahyun',
+            'birthday' => '1998-05-28',
+            'representative_symbol' => 'Tofu',
+            'position' => 'Lead Rapper, Sub Vocalist',
+            'mbti' => 'ISFJ',
+            'zodiac_sign' => 'Gemini',
+            'height' => 161,
+            'blood_type' => 'O',
+        ],
+        [
+            'key' => 'chaeyoung',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f171',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f172',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f173',
+            'slug' => 'chaeyoung',
+            'name' => 'Chaeyoung',
+            'normalized_name' => 'chaeyoung',
+            'real_name' => 'Son Chaeyoung',
+            'normalized_real_name' => 'son chaeyoung',
+            'birthday' => '1999-04-23',
+            'representative_symbol' => 'Tiger',
+            'position' => 'Main Rapper, Sub Vocalist',
+            'mbti' => 'INFP',
+            'zodiac_sign' => 'Taurus',
+            'height' => 159,
+            'blood_type' => 'B',
+        ],
+        [
+            'key' => 'tzuyu',
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f181',
+            'draft_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f182',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f183',
+            'slug' => 'tzuyu',
+            'name' => 'Tzuyu',
+            'normalized_name' => 'tzuyu',
+            'real_name' => 'Chou Tzuyu',
+            'normalized_real_name' => 'chou tzuyu',
+            'birthday' => '1999-06-14',
+            'representative_symbol' => 'Yoda',
+            'position' => 'Lead Dancer, Sub Vocalist, Visual',
+            'mbti' => 'ISFP',
+            'zodiac_sign' => 'Gemini',
+            'height' => 172,
+            'blood_type' => 'A',
+        ],
+    ];
+
+    public function run(): void
+    {
+        $this->seedPublishedGroup();
+        $this->seedDraftGroup();
+
+        foreach (self::TALENTS as $talent) {
+            $this->seedPublishedTalent($talent);
+            $this->seedDraftTalent($talent);
+        }
+    }
+
+    private function seedPublishedGroup(): void
+    {
+        DB::table('wikis')->upsert([
+            [
+                'id' => self::GROUP_PUBLISHED_WIKI_ID,
+                'translation_set_identifier' => self::GROUP_TRANSLATION_SET_ID,
+                'slug' => 'twice',
+                'language' => 'ko',
+                'resource_type' => 'group',
+                'sections' => $this->groupSections('TWICE is a nine-member group sample used for the wiki editor.'),
+                'theme_color' => '#FE5F8F',
+                'version' => 1,
+                'owner_account_id' => null,
+                'editor_id' => self::EDITOR_ID,
+                'approver_id' => null,
+                'merger_id' => null,
+                'source_editor_id' => null,
+                'merged_at' => null,
+                'translated_at' => null,
+                'approved_at' => null,
+                'published_at' => '2026-04-22 00:00:00',
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['id']);
+
+        DB::table('wiki_group_basics')->upsert([
+            [
+                'wiki_id' => self::GROUP_PUBLISHED_WIKI_ID,
+                'name' => 'TWICE',
+                'normalized_name' => 'twice',
+                'agency_identifier' => null,
+                'group_type' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debut_date' => '2015-10-20',
+                'disband_date' => null,
+                'fandom_name' => 'ONCE',
+                'official_colors' => json_encode(['#FE5F8F', '#FEE500'], JSON_THROW_ON_ERROR),
+                'emoji' => '',
+                'representative_symbol' => 'Candy Bong',
+                'main_image_identifier' => null,
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['wiki_id']);
+    }
+
+    private function seedDraftGroup(): void
+    {
+        DB::table('draft_wikis')->upsert([
+            [
+                'id' => self::GROUP_DRAFT_WIKI_ID,
+                'published_wiki_id' => self::GROUP_PUBLISHED_WIKI_ID,
+                'translation_set_identifier' => self::GROUP_TRANSLATION_SET_ID,
+                'slug' => 'twice',
+                'language' => 'ko',
+                'resource_type' => 'group',
+                'sections' => $this->groupSections('Draft sample for checking the TWICE group wiki editor state.'),
+                'theme_color' => '#FE5F8F',
+                'status' => 'pending',
+                'editor_id' => self::EDITOR_ID,
+                'approver_id' => null,
+                'merger_id' => null,
+                'source_editor_id' => null,
+                'edited_at' => '2026-04-22 00:00:00',
+                'merged_at' => null,
+                'translated_at' => null,
+                'approved_at' => null,
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['id']);
+
+        DB::table('draft_wiki_group_basics')->upsert([
+            [
+                'wiki_id' => self::GROUP_DRAFT_WIKI_ID,
+                'name' => 'TWICE',
+                'normalized_name' => 'twice',
+                'agency_identifier' => null,
+                'group_type' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debut_date' => '2015-10-20',
+                'disband_date' => null,
+                'fandom_name' => 'ONCE',
+                'official_colors' => json_encode(['#FE5F8F', '#FEE500'], JSON_THROW_ON_ERROR),
+                'emoji' => '',
+                'representative_symbol' => 'Candy Bong',
+                'main_image_identifier' => null,
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['wiki_id']);
+    }
+
+    /**
+     * @param array{
+     *     published_wiki_id: string,
+     *     translation_set_identifier: string,
+     *     slug: string,
+     *     name: string,
+     *     normalized_name: string,
+     *     real_name: string,
+     *     normalized_real_name: string,
+     *     birthday: string,
+     *     representative_symbol: string,
+     *     position: string,
+     *     mbti: ?string,
+     *     zodiac_sign: string,
+     *     height: int,
+     *     blood_type: string
+     * } $talent
+     */
+    private function seedPublishedTalent(array $talent): void
+    {
+        DB::table('wikis')->upsert([
+            [
+                'id' => $talent['published_wiki_id'],
+                'translation_set_identifier' => $talent['translation_set_identifier'],
+                'slug' => $talent['slug'],
+                'language' => 'ko',
+                'resource_type' => 'talent',
+                'sections' => $this->talentSections($talent['name'], false),
+                'theme_color' => '#FE5F8F',
+                'version' => 1,
+                'owner_account_id' => null,
+                'editor_id' => self::EDITOR_ID,
+                'approver_id' => null,
+                'merger_id' => null,
+                'source_editor_id' => null,
+                'merged_at' => null,
+                'translated_at' => null,
+                'approved_at' => null,
+                'published_at' => '2026-04-22 00:00:00',
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['id']);
+
+        DB::table('wiki_talent_basics')->upsert([
+            [
+                'wiki_id' => $talent['published_wiki_id'],
+                'name' => $talent['name'],
+                'normalized_name' => $talent['normalized_name'],
+                'real_name' => $talent['real_name'],
+                'normalized_real_name' => $talent['normalized_real_name'],
+                'birthday' => $talent['birthday'],
+                'agency_identifier' => null,
+                'emoji' => '',
+                'representative_symbol' => $talent['representative_symbol'],
+                'position' => $talent['position'],
+                'mbti' => $talent['mbti'],
+                'zodiac_sign' => $talent['zodiac_sign'],
+                'english_level' => null,
+                'height' => $talent['height'],
+                'blood_type' => $talent['blood_type'],
+                'fandom_name' => 'ONCE',
+                'profile_image_identifier' => null,
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['wiki_id']);
+
+        DB::table('wiki_talent_basic_groups')->upsert([
+            [
+                'wiki_id' => $talent['published_wiki_id'],
+                'group_identifier' => self::GROUP_PUBLISHED_WIKI_ID,
+            ],
+        ], ['wiki_id', 'group_identifier']);
+    }
+
+    /**
+     * @param array{
+     *     draft_wiki_id: string,
+     *     published_wiki_id: string,
+     *     translation_set_identifier: string,
+     *     slug: string,
+     *     name: string,
+     *     normalized_name: string,
+     *     real_name: string,
+     *     normalized_real_name: string,
+     *     birthday: string,
+     *     representative_symbol: string,
+     *     position: string,
+     *     mbti: ?string,
+     *     zodiac_sign: string,
+     *     height: int,
+     *     blood_type: string
+     * } $talent
+     */
+    private function seedDraftTalent(array $talent): void
+    {
+        DB::table('draft_wikis')->upsert([
+            [
+                'id' => $talent['draft_wiki_id'],
+                'published_wiki_id' => $talent['published_wiki_id'],
+                'translation_set_identifier' => $talent['translation_set_identifier'],
+                'slug' => $talent['slug'],
+                'language' => 'ko',
+                'resource_type' => 'talent',
+                'sections' => $this->talentSections($talent['name'], true),
+                'theme_color' => '#FE5F8F',
+                'status' => 'pending',
+                'editor_id' => self::EDITOR_ID,
+                'approver_id' => null,
+                'merger_id' => null,
+                'source_editor_id' => null,
+                'edited_at' => '2026-04-22 00:00:00',
+                'merged_at' => null,
+                'translated_at' => null,
+                'approved_at' => null,
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['id']);
+
+        DB::table('draft_wiki_talent_basics')->upsert([
+            [
+                'wiki_id' => $talent['draft_wiki_id'],
+                'name' => $talent['name'],
+                'normalized_name' => $talent['normalized_name'],
+                'real_name' => $talent['real_name'],
+                'normalized_real_name' => $talent['normalized_real_name'],
+                'birthday' => $talent['birthday'],
+                'agency_identifier' => null,
+                'emoji' => '',
+                'representative_symbol' => $talent['representative_symbol'],
+                'position' => $talent['position'],
+                'mbti' => $talent['mbti'],
+                'zodiac_sign' => $talent['zodiac_sign'],
+                'english_level' => null,
+                'height' => $talent['height'],
+                'blood_type' => $talent['blood_type'],
+                'fandom_name' => 'ONCE',
+                'profile_image_identifier' => null,
+                'created_at' => '2026-04-22 00:00:00',
+                'updated_at' => '2026-04-22 00:00:00',
+            ],
+        ], ['wiki_id']);
+
+        DB::table('draft_wiki_talent_basic_groups')->upsert([
+            [
+                'wiki_id' => $talent['draft_wiki_id'],
+                'group_identifier' => self::GROUP_DRAFT_WIKI_ID,
+            ],
+        ], ['wiki_id', 'group_identifier']);
+    }
+
+    private function groupSections(string $summary): string
+    {
+        return json_encode([
+            [
+                'id' => 'overview',
+                'type' => 'plaintext',
+                'title' => 'Overview',
+                'content' => $summary,
+            ],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function talentSections(string $name, bool $isDraft): string
+    {
+        return json_encode([
+            [
+                'id' => 'overview',
+                'type' => 'plaintext',
+                'title' => 'Overview',
+                'content' => $isDraft
+                    ? "{$name} draft profile linked to the TWICE editor sample."
+                    : "{$name} published profile linked to the TWICE group sample.",
+            ],
+        ], JSON_THROW_ON_ERROR);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       APP_URL: ${APP_URL:-http://localhost:8080}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
       DB_CONNECTION: pgsql
-      DB_HOST: testing_db
+      DB_HOST: db
       DB_PORT: 5432
       DB_DATABASE: kpool
       DB_USERNAME: kpool
@@ -24,7 +24,7 @@ services:
       MAIL_FROM_NAME: Kpool
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
     depends_on:
-      - testing_db
+      - db
       - redis
     networks:
       - kpool-network
@@ -43,7 +43,7 @@ services:
     networks:
       - kpool-network
 
-  testing_db:
+  db:
     image: postgres:18-alpine
     environment:
       POSTGRES_DB: kpool
@@ -52,6 +52,20 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./database/init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - kpool-network
+
+  testing_db:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_DB: kpool
+      POSTGRES_USER: kpool
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5433:5432"
+    volumes:
       - testing_db_data:/var/lib/postgresql/data
       - ./database/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
@@ -59,8 +73,6 @@ services:
 
   redis:
     image: redis:8-alpine
-    ports:
-      - "6379:6379"
     networks:
       - kpool-network
 
@@ -81,6 +93,7 @@ services:
       - kpool-network
 
 volumes:
+  db_data:
   testing_db_data:
 
 networks:


### PR DESCRIPTION
## 📝 変更内容

- Wiki編集画面の確認に使うサンプルデータ Seeder を追加
- `DatabaseSeeder` を追加し、`WikiEditorSampleSeeder` を実行対象に設定
- Composer の autoload に `Database\\Seeders\\` を追加
- `docker-compose.yml` を調整し、通常起動用の `db` サービスを追加
- `Taskfile.yml` に `migrate` / `seed` タスクを追加し、`task up` で migrate と seed が走るように変更

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki編集画面をローカルで確認するための実データに近い投入手段が不足していたためです。  
TWICEのグループと9メンバーの公開/下書きWikiを Seeder で投入できるようにし、Docker 起動後すぐに編集画面の検証ができる状態を作っています。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `WikiEditorSampleSeeder` が投入する公開/下書きWikiの構造で、編集画面確認に必要な最低限のデータが揃っているか
- `task up` 実行時に migrate / seed を自動実行する変更が既存の開発フローに対して妥当か
- `docker-compose.yml` の `db` 追加と `php` サービスの接続先変更がローカル開発用途として問題ないか

## 📖 関連情報

### 関連Issue・タスク

Closes #320

## ⚠️ 注意事項

- `task up` で DB マイグレーションと Seeder 実行まで自動化されるため、従来より起動時の副作用が増えます
- サンプルデータは TWICE 固定です
- テスト実行有無は未確認です

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
