### PR TITLE
feat(wiki): グループ下書きWiki取得APIを追加

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,7 @@ vars:
   API_SERVICES: php nginx db redis mail
   TEST_SERVICES: testing_db redis
   PHP_RUN: docker-compose run --rm --no-deps php
+  PHP_RUN_TEST: docker-compose run --rm --no-deps -e DB_HOST=testing_db php
   PHP_EXEC: docker-compose exec php
 
 tasks:
@@ -22,7 +23,7 @@ tasks:
       - docker-compose up -d {{.TEST_SERVICES}}
       - task: wait-for-db
       - defer: '{{if not .keepdb}}docker-compose stop testing_db redis && docker-compose rm -v -f testing_db redis{{end}}'
-      - '{{.PHP_RUN}} bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --coverage-html coverage-html"'
+      - '{{.PHP_RUN_TEST}} bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --coverage-html coverage-html"'
 
   test-no-db:
     desc: "Run PHPUnit tests excluding 'useDb' group. Usage: task test-no-db [filter=TestClassName]"

--- a/application/Http/Action/Wiki/Wiki/Query/GetGroupDraftWiki/GetGroupDraftWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetGroupDraftWiki/GetGroupDraftWikiAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetGroupDraftWiki;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class GetGroupDraftWikiAction
+{
+    public function __construct(
+        private GetGroupDraftWikiInterface $getGroupDraftWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GetGroupDraftWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetGroupDraftWikiInput(
+                    new Slug($request->slug()),
+                    Language::from($request->language()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $readModel = $this->getGroupDraftWiki->process($input);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Draft wiki not found.', previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetGroupDraftWiki/GetGroupDraftWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetGroupDraftWiki/GetGroupDraftWikiRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetGroupDraftWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetGroupDraftWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+}

--- a/application/Models/Wiki/DraftWiki.php
+++ b/application/Models/Wiki/DraftWiki.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Models\Wiki;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 
@@ -31,6 +32,7 @@ use Illuminate\Support\Carbon;
  * @property-read ?DraftWikiGroupBasic $groupBasic
  * @property-read ?DraftWikiAgencyBasic $agencyBasic
  * @property-read ?DraftWikiSongBasic $songBasic
+ * @property-read ?Wiki $publishedWiki
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',
@@ -96,5 +98,13 @@ class DraftWiki extends Model
     public function songBasic(): HasOne
     {
         return $this->hasOne(DraftWikiSongBasic::class, 'wiki_id', 'id');
+    }
+
+    /**
+     * @return BelongsTo<Wiki, DraftWiki>
+     */
+    public function publishedWiki(): BelongsTo
+    {
+        return $this->belongsTo(Wiki::class, 'published_wiki_id', 'id');
     }
 }

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -73,6 +73,8 @@ use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
+use Source\Wiki\Wiki\Infrastructure\Query\GetGroupDraftWiki;
 
 class UseCaseServiceProvider extends ServiceProvider
 {
@@ -112,5 +114,6 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(PublishWikiInterface::class, PublishWiki::class);
         $this->app->singleton(RollbackWikiInterface::class, RollbackWiki::class);
         $this->app->singleton(TranslateWikiInterface::class, TranslateWiki::class);
+        $this->app->singleton(GetGroupDraftWikiInterface::class, GetGroupDraftWiki::class);
     }
 }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1066,6 +1066,46 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateWikiRequestBody'
+  /wiki/{language}/group/{slug}/draft:
+    get:
+      operationId: WikiOperations_getGroupDraftWiki
+      description: Fetch the group draft wiki used by the editor.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when a group draft wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DraftWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /wiki/{wikiId}/approve:
     post:
       operationId: WikiOperations_approveWiki
@@ -1624,6 +1664,57 @@ components:
       allOf:
         - $ref: '#/components/schemas/WikiAssociationTargets'
       description: Request body for creating a wiki draft.
+    DraftWikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Draft wiki identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number associated with the draft.
+        themeColor:
+          type: string
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload for the editor.
+        basic:
+          description: Basic wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed draft wiki payload used by the editor.
+    DraftWikiHeroImage:
+      type: object
+      properties:
+        imageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Image identifier shown as the hero image.
+      description: Hero image payload for a draft wiki.
     DraftWikiSummary:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -32,6 +32,7 @@ use Application\Http\Action\Wiki\Wiki\Command\PublishWiki\PublishWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RejectWiki\RejectWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RollbackWiki\RollbackWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\GetGroupDraftWiki\GetGroupDraftWikiAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RequestImageHide\RequestImageHideAction;
@@ -49,6 +50,7 @@ Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
 Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
 Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
 Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+Route::get('/wiki/{language}/group/{slug}/draft', GetGroupDraftWikiAction::class);
 
 // Image
 Route::post('/image/{imageId}/approve', ApproveImageAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query;
+
+readonly class DraftWikiReadModel
+{
+    /**
+     * @param array<string, mixed> $heroImage
+     * @param array<string, mixed> $basic
+     * @param list<array<string, mixed>> $sections
+     */
+    public function __construct(
+        private string $wikiIdentifier,
+        private string $slug,
+        private string $language,
+        private string $resourceType,
+        private int $version,
+        private ?string $themeColor,
+        private array $heroImage,
+        private array $basic,
+        private array $sections,
+    ) {
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return $this->wikiIdentifier;
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function language(): string
+    {
+        return $this->language;
+    }
+
+    public function resourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function version(): int
+    {
+        return $this->version;
+    }
+
+    public function themeColor(): ?string
+    {
+        return $this->themeColor;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function heroImage(): array
+    {
+        return $this->heroImage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function basic(): array
+    {
+        return $this->basic;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function sections(): array
+    {
+        return $this->sections;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'slug' => $this->slug,
+            'language' => $this->language,
+            'resourceType' => $this->resourceType,
+            'version' => $this->version,
+            'themeColor' => $this->themeColor,
+            'heroImage' => $this->heroImage,
+            'basic' => $this->basic,
+            'sections' => $this->sections,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class GetGroupDraftWikiInput implements GetGroupDraftWikiInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+    ) {
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface GetGroupDraftWikiInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki;
+
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiReadModel;
+
+interface GetGroupDraftWikiInterface
+{
+    /**
+     * @param GetGroupDraftWikiInputPort $input
+     * @return DraftWikiReadModel
+     * @throws WikiNotFoundException
+     */
+    public function process(GetGroupDraftWikiInputPort $input): DraftWikiReadModel;
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\DraftWiki as DraftWikiModel;
+use Application\Models\Wiki\DraftWikiGroupBasic as DraftWikiGroupBasicModel;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiReadModel;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
+
+readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
+{
+    /**
+     * @param GetGroupDraftWikiInputPort $input
+     * @return DraftWikiReadModel
+     * @throws WikiNotFoundException
+     */
+    public function process(GetGroupDraftWikiInputPort $input): DraftWikiReadModel
+    {
+        $model = DraftWikiModel::query()
+            ->with(['groupBasic', 'publishedWiki'])
+            ->where('resource_type', ResourceType::GROUP->value)
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->first();
+
+        if ($model === null) {
+            throw new WikiNotFoundException("Draft wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        $basic = $this->groupBasic($model->groupBasic);
+
+        return new DraftWikiReadModel(
+            wikiIdentifier: $model->id,
+            slug: $model->slug,
+            language: $model->language,
+            resourceType: ResourceType::GROUP->value,
+            version: $model->publishedWiki->version,
+            themeColor: $model->theme_color,
+            heroImage: [
+                'imageIdentifier' => $basic->main_image_identifier,
+            ],
+            basic: [
+                'name' => $basic->name,
+                'normalizedName' => $basic->normalized_name,
+                'agencyIdentifier' => $basic->agency_identifier,
+                'groupType' => $basic->group_type,
+                'status' => $basic->status,
+                'generation' => $basic->generation,
+                'debutDate' => $basic->debut_date,
+                'disbandDate' => $basic->disband_date,
+                'fandomName' => $basic->fandom_name,
+                'officialColors' => $basic->official_colors,
+                'emoji' => $basic->emoji,
+                'representativeSymbol' => $basic->representative_symbol,
+                'mainImageIdentifier' => $basic->main_image_identifier,
+            ],
+            sections: $model->sections,
+        );
+    }
+
+    private function groupBasic(?DraftWikiGroupBasicModel $basic): DraftWikiGroupBasicModel
+    {
+        if ($basic === null) {
+            throw new InvalidArgumentException('GroupBasic not found for DraftWiki.');
+        }
+
+        return $basic;
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiReadModel;
+use Tests\TestCase;
+
+class DraftWikiReadModelTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $readModel = new DraftWikiReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            slug: 'twice',
+            language: 'ko',
+            resourceType: 'group',
+            version: 1,
+            themeColor: '#FE5F8F',
+            heroImage: [
+                'imageIdentifier' => null,
+            ],
+            basic: [
+                'name' => 'TWICE',
+                'normalizedName' => 'twice',
+                'agencyIdentifier' => null,
+                'groupType' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debutDate' => '2015-10-20',
+                'disbandDate' => null,
+                'fandomName' => 'ONCE',
+                'officialColors' => ['#FE5F8F', '#FEE500'],
+                'emoji' => '',
+                'representativeSymbol' => 'Candy Bong',
+                'mainImageIdentifier' => null,
+            ],
+            sections: [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Draft sample for checking the TWICE group wiki editor state.',
+                ],
+            ],
+        );
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('twice', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('group', $readModel->resourceType());
+        $this->assertSame(1, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('TWICE', $readModel->basic()['name']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'slug' => 'twice',
+            'language' => 'ko',
+            'resourceType' => 'group',
+            'version' => 1,
+            'themeColor' => '#FE5F8F',
+            'heroImage' => [
+                'imageIdentifier' => null,
+            ],
+            'basic' => [
+                'name' => 'TWICE',
+                'normalizedName' => 'twice',
+                'agencyIdentifier' => null,
+                'groupType' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debutDate' => '2015-10-20',
+                'disbandDate' => null,
+                'fandomName' => 'ONCE',
+                'officialColors' => ['#FE5F8F', '#FEE500'],
+                'emoji' => '',
+                'representativeSymbol' => 'Candy Bong',
+                'mainImageIdentifier' => null,
+            ],
+            'sections' => [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Draft sample for checking the TWICE group wiki editor state.',
+                ],
+            ],
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/GetGroupDraftWiki/GetGroupDraftWikiInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInput;
+use Tests\TestCase;
+
+class GetGroupDraftWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $slug = new Slug('twice');
+        $language = Language::KOREAN;
+        $input = new GetGroupDraftWikiInput($slug, $language);
+
+        $this->assertSame((string) $slug, (string) $input->slug());
+        $this->assertSame($language, $input->language());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use Database\Seeders\WikiEditorSampleSeeder;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
+use Tests\TestCase;
+
+class GetGroupDraftWikiTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsDraftGroupWikiForSeederData(): void
+    {
+        $this->seed(WikiEditorSampleSeeder::class);
+
+        $useCase = $this->app->make(GetGroupDraftWikiInterface::class);
+        $readModel = $useCase->process(new GetGroupDraftWikiInput(new Slug('twice'), Language::KOREAN));
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('twice', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('group', $readModel->resourceType());
+        $this->assertSame(1, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('TWICE', $readModel->basic()['name']);
+        $this->assertSame('girl_group', $readModel->basic()['groupType']);
+        $this->assertSame(['#FE5F8F', '#FEE500'], $readModel->basic()['officialColors']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenDraftGroupWikiDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetGroupDraftWikiInterface::class);
+
+        $this->expectException(WikiNotFoundException::class);
+
+        $useCase->process(new GetGroupDraftWikiInput(new Slug('twice'), Language::KOREAN));
+    }
+}

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -37,6 +37,34 @@ model PublishedWikiSummary {
   version: int32;
 }
 
+@doc("Hero image payload for a draft wiki.")
+model DraftWikiHeroImage {
+  @doc("Image identifier shown as the hero image.")
+  imageIdentifier?: Uuid;
+}
+
+@doc("Detailed draft wiki payload used by the editor.")
+model DraftWikiDetail {
+  @doc("Draft wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number associated with the draft.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor?: string;
+  @doc("Hero image payload for the editor.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic wiki content payload.")
+  basic: unknown;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
 @doc("Summary of a draft image.")
 model ImageDraftSummary {
   @doc("Image identifier.")

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -71,6 +71,12 @@ model CreateDraftWikiResponse {
   @body body: DraftWikiSummary;
 }
 
+@doc("Response returned when a group draft wiki is fetched.")
+model GetGroupDraftWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: DraftWikiDetail;
+}
+
 @doc("Response returned when a wiki is published.")
 model CreatePublishedWikiResponse {
   @statusCode statusCode: 201;
@@ -180,4 +186,12 @@ interface WikiOperations {
     @path wikiId: Uuid,
     @body body: WikiWorkflowRequestBody,
   ): TranslateWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/{language}/group/{slug}/draft")
+  @doc("Fetch the group draft wiki used by the editor.")
+  getGroupDraftWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetGroupDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- グループ編集画面向けに、`language` と `slug` から下書き Wiki を取得する API を追加
- 下書き Wiki の詳細 payload を返す `DraftWikiReadModel` と query 実装を追加
- ルーティング、リクエストバリデーション、DI 登録を追加
- OpenAPI / TypeSpec を更新
- read model / input / infrastructure query のテストを追加
- `task test` が `testing_db` を利用するよう `Taskfile.yml` を調整

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

グループ Wiki 編集画面で、対象グループの下書き状態を初期表示できる API が必要だったためです。
既存の下書きデータ、基本情報、セクション情報をまとめて返し、編集画面が 1 リクエストで初期化できるようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `GET /wiki/{language}/group/{slug}/draft` の責務と、編集画面が必要とする response shape が妥当か
- `GetGroupDraftWiki` が `groupBasic` / `publishedWiki` から組み立てる payload の項目が不足なく返っているか
- `Taskfile.yml` の `DB_HOST=testing_db` 変更が既存のテスト実行導線に悪影響を与えないか

## 📖 関連情報

### 関連Issue・タスク

Closes #323

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
