### PR TITLE
feat(wiki): タレント下書きWiki取得APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/GetTalentDraftWiki/GetTalentDraftWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetTalentDraftWiki/GetTalentDraftWikiAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class GetTalentDraftWikiAction
+{
+    public function __construct(
+        private GetTalentDraftWikiInterface $getTalentDraftWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GetTalentDraftWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetTalentDraftWikiInput(
+                    new Slug($request->slug()),
+                    Language::from($request->language()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $readModel = $this->getTalentDraftWiki->process($input);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Draft wiki not found.', previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetTalentDraftWiki/GetTalentDraftWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetTalentDraftWiki/GetTalentDraftWikiRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetTalentDraftWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -74,7 +74,9 @@ use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
 use Source\Wiki\Wiki\Infrastructure\Query\GetGroupDraftWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\GetTalentDraftWiki;
 
 class UseCaseServiceProvider extends ServiceProvider
 {
@@ -115,5 +117,6 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RollbackWikiInterface::class, RollbackWiki::class);
         $this->app->singleton(TranslateWikiInterface::class, TranslateWiki::class);
         $this->app->singleton(GetGroupDraftWikiInterface::class, GetGroupDraftWiki::class);
+        $this->app->singleton(GetTalentDraftWikiInterface::class, GetTalentDraftWiki::class);
     }
 }

--- a/database/seeders/WikiEditorSampleSeeder.php
+++ b/database/seeders/WikiEditorSampleSeeder.php
@@ -457,7 +457,7 @@ class WikiEditorSampleSeeder extends Seeder
         DB::table('draft_wiki_talent_basic_groups')->upsert([
             [
                 'wiki_id' => $talent['draft_wiki_id'],
-                'group_identifier' => self::GROUP_DRAFT_WIKI_ID,
+                'group_identifier' => self::GROUP_PUBLISHED_WIKI_ID,
             ],
         ], ['wiki_id', 'group_identifier']);
     }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1106,6 +1106,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /wiki/{language}/talent/{slug}/draft:
+    get:
+      operationId: WikiOperations_getTalentDraftWiki
+      description: Fetch the talent draft wiki used by the editor.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when a talent draft wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TalentDraftWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /wiki/{wikiId}/approve:
     post:
       operationId: WikiOperations_approveWiki
@@ -2164,6 +2204,191 @@ components:
             $ref: '#/components/schemas/VideoLinkInput'
           description: Video links to save.
       description: Request body for saving video links.
+    TalentDraftWikiBasic:
+      type: object
+      required:
+        - name
+        - normalizedName
+        - realName
+        - normalizedRealName
+        - emoji
+        - representativeSymbol
+        - position
+        - fandomName
+        - groups
+      properties:
+        name:
+          type: string
+          description: Display name of the talent.
+        normalizedName:
+          type: string
+          description: Normalized name of the talent.
+        realName:
+          type: string
+          description: Real name of the talent.
+        normalizedRealName:
+          type: string
+          description: Normalized real name of the talent.
+        birthday:
+          type: string
+          format: date
+          description: Birthday of the talent.
+        agencyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated agency identifier.
+        emoji:
+          type: string
+          description: Emoji representing the talent.
+        representativeSymbol:
+          type: string
+          description: Representative symbol of the talent.
+        position:
+          type: string
+          description: Position of the talent.
+        mbti:
+          type: string
+          description: MBTI of the talent.
+        zodiacSign:
+          type: string
+          description: Zodiac sign of the talent.
+        englishLevel:
+          type: string
+          description: English proficiency level of the talent.
+        height:
+          type: integer
+          format: int32
+          description: Height of the talent in centimeters.
+        bloodType:
+          type: string
+          description: Blood type of the talent.
+        fandomName:
+          type: string
+          description: Fandom name of the talent.
+        profileImageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Profile image identifier of the talent.
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/TalentDraftWikiGroupSummary'
+          description: Related published groups linked to the talent.
+      description: Basic payload for a talent draft wiki.
+    TalentDraftWikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Draft wiki identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number associated with the draft.
+        themeColor:
+          type: string
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload for the editor.
+        basic:
+          allOf:
+            - $ref: '#/components/schemas/TalentDraftWikiBasic'
+          description: Basic talent wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed talent draft wiki payload used by the editor.
+    TalentDraftWikiGroupSummary:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - name
+        - normalizedName
+        - fandomName
+        - officialColors
+        - emoji
+        - representativeSymbol
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published group wiki identifier.
+        slug:
+          type: string
+          description: Unique slug of the published group wiki.
+        language:
+          type: string
+          description: Language of the published group wiki.
+        name:
+          type: string
+          description: Display name of the group.
+        normalizedName:
+          type: string
+          description: Normalized name of the group.
+        agencyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated agency identifier.
+        groupType:
+          type: string
+          description: Group type.
+        status:
+          type: string
+          description: Current activity status of the group.
+        generation:
+          type: string
+          description: Generation label of the group.
+        debutDate:
+          type: string
+          format: date
+          description: Debut date of the group.
+        disbandDate:
+          type: string
+          format: date
+          description: Disband date of the group.
+        fandomName:
+          type: string
+          description: Fandom name of the group.
+        officialColors:
+          type: array
+          items:
+            type: string
+          description: Official color palette of the group.
+        emoji:
+          type: string
+          description: Emoji representing the group.
+        representativeSymbol:
+          type: string
+          description: Representative symbol of the group.
+        mainImageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Main image identifier of the group.
+      description: Summary of a published group linked from a talent draft wiki.
     TranslateWikiResponseBody:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -33,6 +33,7 @@ use Application\Http\Action\Wiki\Wiki\Command\RejectWiki\RejectWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RollbackWiki\RollbackWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetGroupDraftWiki\GetGroupDraftWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki\GetTalentDraftWikiAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RequestImageHide\RequestImageHideAction;
@@ -51,6 +52,7 @@ Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
 Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
 Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
 Route::get('/wiki/{language}/group/{slug}/draft', GetGroupDraftWikiAction::class);
+Route::get('/wiki/{language}/talent/{slug}/draft', GetTalentDraftWikiAction::class);
 
 // Image
 Route::post('/image/{imageId}/approve', ApproveImageAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class GetTalentDraftWikiInput implements GetTalentDraftWikiInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+    ) {
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface GetTalentDraftWikiInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki;
+
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\TalentDraftWikiReadModel;
+
+interface GetTalentDraftWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetTalentDraftWikiInputPort $input): TalentDraftWikiReadModel;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/TalentDraftWikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/TalentDraftWikiReadModel.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query;
+
+readonly class TalentDraftWikiReadModel
+{
+    /**
+     * @param array<string, mixed> $heroImage
+     * @param array<string, mixed> $basic
+     * @param list<array<string, mixed>> $sections
+     */
+    public function __construct(
+        private string $wikiIdentifier,
+        private string $slug,
+        private string $language,
+        private string $resourceType,
+        private int $version,
+        private ?string $themeColor,
+        private array $heroImage,
+        private array $basic,
+        private array $sections,
+    ) {
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return $this->wikiIdentifier;
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function language(): string
+    {
+        return $this->language;
+    }
+
+    public function resourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function version(): int
+    {
+        return $this->version;
+    }
+
+    public function themeColor(): ?string
+    {
+        return $this->themeColor;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function heroImage(): array
+    {
+        return $this->heroImage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function basic(): array
+    {
+        return $this->basic;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function sections(): array
+    {
+        return $this->sections;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'slug' => $this->slug,
+            'language' => $this->language,
+            'resourceType' => $this->resourceType,
+            'version' => $this->version,
+            'themeColor' => $this->themeColor,
+            'heroImage' => $this->heroImage,
+            'basic' => $this->basic,
+            'sections' => $this->sections,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\DraftWiki as DraftWikiModel;
+use Application\Models\Wiki\Wiki as WikiModel;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\TalentDraftWikiReadModel;
+
+readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetTalentDraftWikiInputPort $input): TalentDraftWikiReadModel
+    {
+        $model = DraftWikiModel::query()
+            ->with(['talentBasic.groups.groupBasic', 'publishedWiki'])
+            ->where('resource_type', ResourceType::TALENT->value)
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->first();
+
+        if ($model === null) {
+            throw new WikiNotFoundException("Draft wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        $basic = $model->talentBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('TalentBasic not found for DraftWiki.');
+        }
+
+        return new TalentDraftWikiReadModel(
+            wikiIdentifier: $model->id,
+            slug: $model->slug,
+            language: $model->language,
+            resourceType: ResourceType::TALENT->value,
+            version: $model->publishedWiki->version,
+            themeColor: $model->theme_color,
+            heroImage: [
+                'imageIdentifier' => $basic->profile_image_identifier,
+            ],
+            basic: [
+                'name' => $basic->name,
+                'normalizedName' => $basic->normalized_name,
+                'realName' => $basic->real_name,
+                'normalizedRealName' => $basic->normalized_real_name,
+                'birthday' => $basic->birthday,
+                'agencyIdentifier' => $basic->agency_identifier,
+                'emoji' => $basic->emoji,
+                'representativeSymbol' => $basic->representative_symbol,
+                'position' => $basic->position,
+                'mbti' => $basic->mbti,
+                'zodiacSign' => $basic->zodiac_sign,
+                'englishLevel' => $basic->english_level,
+                'height' => $basic->height,
+                'bloodType' => $basic->blood_type,
+                'fandomName' => $basic->fandom_name,
+                'profileImageIdentifier' => $basic->profile_image_identifier,
+                'groups' => $basic->groups->map(fn (WikiModel $group) => $this->groupToArray($group))->values()->all(),
+            ],
+            sections: $model->sections,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function groupToArray(WikiModel $group): array
+    {
+        $basic = $group->groupBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('GroupBasic not found for Wiki.');
+        }
+
+        return [
+            'wikiIdentifier' => $group->id,
+            'slug' => $group->slug,
+            'language' => $group->language,
+            'name' => $basic->name,
+            'normalizedName' => $basic->normalized_name,
+            'agencyIdentifier' => $basic->agency_identifier,
+            'groupType' => $basic->group_type,
+            'status' => $basic->status,
+            'generation' => $basic->generation,
+            'debutDate' => $basic->debut_date,
+            'disbandDate' => $basic->disband_date,
+            'fandomName' => $basic->fandom_name,
+            'officialColors' => $basic->official_colors,
+            'emoji' => $basic->emoji,
+            'representativeSymbol' => $basic->representative_symbol,
+            'mainImageIdentifier' => $basic->main_image_identifier,
+        ];
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/GetTalentDraftWiki/GetTalentDraftWikiInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInput;
+use Tests\TestCase;
+
+class GetTalentDraftWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $slug = new Slug('chaeyoung');
+        $language = Language::KOREAN;
+        $input = new GetTalentDraftWikiInput($slug, $language);
+
+        $this->assertSame((string) $slug, (string) $input->slug());
+        $this->assertSame($language, $input->language());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/TalentDraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/TalentDraftWikiReadModelTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\TalentDraftWikiReadModel;
+use Tests\TestCase;
+
+class TalentDraftWikiReadModelTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $readModel = new TalentDraftWikiReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            slug: 'chaeyoung',
+            language: 'ko',
+            resourceType: 'talent',
+            version: 1,
+            themeColor: '#FE5F8F',
+            heroImage: [
+                'imageIdentifier' => null,
+            ],
+            basic: [
+                'name' => '채영',
+                'normalizedName' => 'chaeyoung',
+                'realName' => '손채영',
+                'normalizedRealName' => 'sonchaeyoung',
+                'birthday' => '1999-04-23',
+                'agencyIdentifier' => null,
+                'emoji' => '',
+                'representativeSymbol' => 'Strawberry Princess',
+                'position' => 'rapper',
+                'mbti' => 'infp',
+                'zodiacSign' => 'taurus',
+                'englishLevel' => null,
+                'height' => 159,
+                'bloodType' => 'B',
+                'fandomName' => 'ONCE',
+                'profileImageIdentifier' => null,
+                'groups' => [
+                    [
+                        'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+                        'slug' => 'twice',
+                        'language' => 'ko',
+                        'name' => 'TWICE',
+                        'normalizedName' => 'twice',
+                        'agencyIdentifier' => null,
+                        'groupType' => 'girl_group',
+                        'status' => 'active',
+                        'generation' => '3',
+                        'debutDate' => '2015-10-20',
+                        'disbandDate' => null,
+                        'fandomName' => 'ONCE',
+                        'officialColors' => ['#FE5F8F', '#FEE500'],
+                        'emoji' => '',
+                        'representativeSymbol' => 'Candy Bong',
+                        'mainImageIdentifier' => null,
+                    ],
+                ],
+            ],
+            sections: [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Draft sample for checking the talent wiki editor state.',
+                ],
+            ],
+        );
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f101', $readModel->wikiIdentifier());
+        $this->assertSame('chaeyoung', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('talent', $readModel->resourceType());
+        $this->assertSame(1, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('채영', $readModel->basic()['name']);
+        $this->assertSame('TWICE', $readModel->basic()['groups'][0]['name']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'slug' => 'chaeyoung',
+            'language' => 'ko',
+            'resourceType' => 'talent',
+            'version' => 1,
+            'themeColor' => '#FE5F8F',
+            'heroImage' => [
+                'imageIdentifier' => null,
+            ],
+            'basic' => [
+                'name' => '채영',
+                'normalizedName' => 'chaeyoung',
+                'realName' => '손채영',
+                'normalizedRealName' => 'sonchaeyoung',
+                'birthday' => '1999-04-23',
+                'agencyIdentifier' => null,
+                'emoji' => '',
+                'representativeSymbol' => 'Strawberry Princess',
+                'position' => 'rapper',
+                'mbti' => 'infp',
+                'zodiacSign' => 'taurus',
+                'englishLevel' => null,
+                'height' => 159,
+                'bloodType' => 'B',
+                'fandomName' => 'ONCE',
+                'profileImageIdentifier' => null,
+                'groups' => [
+                    [
+                        'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+                        'slug' => 'twice',
+                        'language' => 'ko',
+                        'name' => 'TWICE',
+                        'normalizedName' => 'twice',
+                        'agencyIdentifier' => null,
+                        'groupType' => 'girl_group',
+                        'status' => 'active',
+                        'generation' => '3',
+                        'debutDate' => '2015-10-20',
+                        'disbandDate' => null,
+                        'fandomName' => 'ONCE',
+                        'officialColors' => ['#FE5F8F', '#FEE500'],
+                        'emoji' => '',
+                        'representativeSymbol' => 'Candy Bong',
+                        'mainImageIdentifier' => null,
+                    ],
+                ],
+            ],
+            'sections' => [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Draft sample for checking the talent wiki editor state.',
+                ],
+            ],
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use Database\Seeders\WikiEditorSampleSeeder;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
+use Tests\TestCase;
+
+class GetTalentDraftWikiTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsDraftTalentWikiForSeederData(): void
+    {
+        $this->seed(WikiEditorSampleSeeder::class);
+
+        $useCase = $this->app->make(GetTalentDraftWikiInterface::class);
+        $readModel = $useCase->process(new GetTalentDraftWikiInput(new Slug('chaeyoung'), Language::KOREAN));
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f172', $readModel->wikiIdentifier());
+        $this->assertSame('chaeyoung', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('talent', $readModel->resourceType());
+        $this->assertSame(1, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('Chaeyoung', $readModel->basic()['name']);
+        $this->assertSame('Son Chaeyoung', $readModel->basic()['realName']);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f001', $readModel->basic()['groups'][0]['wikiIdentifier']);
+        $this->assertSame('TWICE', $readModel->basic()['groups'][0]['name']);
+        $this->assertSame('girl_group', $readModel->basic()['groups'][0]['groupType']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenDraftTalentWikiDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetTalentDraftWikiInterface::class);
+
+        $this->expectException(WikiNotFoundException::class);
+
+        $useCase->process(new GetTalentDraftWikiInput(new Slug('chaeyoung'), Language::KOREAN));
+    }
+}

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -65,6 +65,102 @@ model DraftWikiDetail {
   sections: unknown[];
 }
 
+@doc("Summary of a published group linked from a talent draft wiki.")
+model TalentDraftWikiGroupSummary {
+  @doc("Published group wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug of the published group wiki.")
+  slug: string;
+  @doc("Language of the published group wiki.")
+  language: string;
+  @doc("Display name of the group.")
+  name: string;
+  @doc("Normalized name of the group.")
+  normalizedName: string;
+  @doc("Associated agency identifier.")
+  agencyIdentifier?: Uuid;
+  @doc("Group type.")
+  groupType?: string;
+  @doc("Current activity status of the group.")
+  status?: string;
+  @doc("Generation label of the group.")
+  generation?: string;
+  @doc("Debut date of the group.")
+  debutDate?: plainDate;
+  @doc("Disband date of the group.")
+  disbandDate?: plainDate;
+  @doc("Fandom name of the group.")
+  fandomName: string;
+  @doc("Official color palette of the group.")
+  officialColors: string[];
+  @doc("Emoji representing the group.")
+  emoji: string;
+  @doc("Representative symbol of the group.")
+  representativeSymbol: string;
+  @doc("Main image identifier of the group.")
+  mainImageIdentifier?: Uuid;
+}
+
+@doc("Basic payload for a talent draft wiki.")
+model TalentDraftWikiBasic {
+  @doc("Display name of the talent.")
+  name: string;
+  @doc("Normalized name of the talent.")
+  normalizedName: string;
+  @doc("Real name of the talent.")
+  realName: string;
+  @doc("Normalized real name of the talent.")
+  normalizedRealName: string;
+  @doc("Birthday of the talent.")
+  birthday?: plainDate;
+  @doc("Associated agency identifier.")
+  agencyIdentifier?: Uuid;
+  @doc("Emoji representing the talent.")
+  emoji: string;
+  @doc("Representative symbol of the talent.")
+  representativeSymbol: string;
+  @doc("Position of the talent.")
+  position: string;
+  @doc("MBTI of the talent.")
+  mbti?: string;
+  @doc("Zodiac sign of the talent.")
+  zodiacSign?: string;
+  @doc("English proficiency level of the talent.")
+  englishLevel?: string;
+  @doc("Height of the talent in centimeters.")
+  height?: int32;
+  @doc("Blood type of the talent.")
+  bloodType?: string;
+  @doc("Fandom name of the talent.")
+  fandomName: string;
+  @doc("Profile image identifier of the talent.")
+  profileImageIdentifier?: Uuid;
+  @doc("Related published groups linked to the talent.")
+  groups: TalentDraftWikiGroupSummary[];
+}
+
+@doc("Detailed talent draft wiki payload used by the editor.")
+model TalentDraftWikiDetail {
+  @doc("Draft wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number associated with the draft.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor?: string;
+  @doc("Hero image payload for the editor.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic talent wiki content payload.")
+  basic: TalentDraftWikiBasic;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
 @doc("Summary of a draft image.")
 model ImageDraftSummary {
   @doc("Image identifier.")

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -77,6 +77,12 @@ model GetGroupDraftWikiResponse {
   @body body: DraftWikiDetail;
 }
 
+@doc("Response returned when a talent draft wiki is fetched.")
+model GetTalentDraftWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: TalentDraftWikiDetail;
+}
+
 @doc("Response returned when a wiki is published.")
 model CreatePublishedWikiResponse {
   @statusCode statusCode: 201;
@@ -194,4 +200,12 @@ interface WikiOperations {
     @path language: string,
     @path slug: string,
   ): GetGroupDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/{language}/talent/{slug}/draft")
+  @doc("Fetch the talent draft wiki used by the editor.")
+  getTalentDraftWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetTalentDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- タレント下書きWikiを取得する `/wiki/{language}/talent/{slug}/draft` API を追加
- Action / Request / UseCase Interface / Query 実装を追加し、タレント基本情報・所属グループ・sections を返却
- TypeSpec と OpenAPI 定義を追加して API スキーマを同期
- `WikiEditorSampleSeeder` を更新し、タレント下書きから参照するグループ識別子を公開Wiki側に揃えた
- 入力値・ReadModel・Query のテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki編集画面で、タレント用の下書きデータを取得するAPIが必要だったためです。
既存のグループ下書き取得APIと同じ流れで、タレントの基本情報、関連グループ、セクション情報を返せるようにしています。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- タレント下書き取得APIのレスポンス構造がフロントエンド想定と一致しているか
- `groups` に公開Wikiの情報を返す実装と Seeder の整合が取れているか
- TypeSpec / OpenAPI の定義が実装レスポンスとずれていないか

## 📖 関連情報

### 関連Issue・タスク

Closes #324

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
