### PR TITLE
feat(wiki): 歌Wikiの下書き取得APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/GetSongDraftWiki/GetSongDraftWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetSongDraftWiki/GetSongDraftWikiAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetSongDraftWiki;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class GetSongDraftWikiAction
+{
+    public function __construct(
+        private GetSongDraftWikiInterface $getSongDraftWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GetSongDraftWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetSongDraftWikiInput(
+                    new Slug($request->slug()),
+                    Language::from($request->language()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $readModel = $this->getSongDraftWiki->process($input);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Draft wiki not found.', previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetSongDraftWiki/GetSongDraftWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetSongDraftWiki/GetSongDraftWikiRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetSongDraftWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetSongDraftWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -74,8 +74,10 @@ use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
 use Source\Wiki\Wiki\Infrastructure\Query\GetGroupDraftWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\GetSongDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentDraftWiki;
 
 class UseCaseServiceProvider extends ServiceProvider
@@ -117,6 +119,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RollbackWikiInterface::class, RollbackWiki::class);
         $this->app->singleton(TranslateWikiInterface::class, TranslateWiki::class);
         $this->app->singleton(GetGroupDraftWikiInterface::class, GetGroupDraftWiki::class);
+        $this->app->singleton(GetSongDraftWikiInterface::class, GetSongDraftWiki::class);
         $this->app->singleton(GetTalentDraftWikiInterface::class, GetTalentDraftWiki::class);
     }
 }

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -33,6 +33,7 @@ use Application\Http\Action\Wiki\Wiki\Command\RejectWiki\RejectWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RollbackWiki\RollbackWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetGroupDraftWiki\GetGroupDraftWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\GetSongDraftWiki\GetSongDraftWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki\GetTalentDraftWikiAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
@@ -52,6 +53,7 @@ Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
 Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
 Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
 Route::get('/wiki/{language}/group/{slug}/draft', GetGroupDraftWikiAction::class);
+Route::get('/wiki/{language}/song/{slug}/draft', GetSongDraftWikiAction::class);
 Route::get('/wiki/{language}/talent/{slug}/draft', GetTalentDraftWikiAction::class);
 
 // Image

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class GetSongDraftWikiInput implements GetSongDraftWikiInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+    ) {
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface GetSongDraftWikiInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki;
+
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\SongDraftWikiReadModel;
+
+interface GetSongDraftWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetSongDraftWikiInputPort $input): SongDraftWikiReadModel;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/SongDraftWikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/SongDraftWikiReadModel.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query;
+
+readonly class SongDraftWikiReadModel
+{
+    /**
+     * @param array<string, mixed> $heroImage
+     * @param array<string, mixed> $basic
+     * @param list<array<string, mixed>> $sections
+     */
+    public function __construct(
+        private string $wikiIdentifier,
+        private string $slug,
+        private string $language,
+        private string $resourceType,
+        private int $version,
+        private ?string $themeColor,
+        private array $heroImage,
+        private array $basic,
+        private array $sections,
+    ) {
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return $this->wikiIdentifier;
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function language(): string
+    {
+        return $this->language;
+    }
+
+    public function resourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function version(): int
+    {
+        return $this->version;
+    }
+
+    public function themeColor(): ?string
+    {
+        return $this->themeColor;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function heroImage(): array
+    {
+        return $this->heroImage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function basic(): array
+    {
+        return $this->basic;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function sections(): array
+    {
+        return $this->sections;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'slug' => $this->slug,
+            'language' => $this->language,
+            'resourceType' => $this->resourceType,
+            'version' => $this->version,
+            'themeColor' => $this->themeColor,
+            'heroImage' => $this->heroImage,
+            'basic' => $this->basic,
+            'sections' => $this->sections,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\DraftWiki as DraftWikiModel;
+use Application\Models\Wiki\DraftWikiSongBasic as DraftWikiSongBasicModel;
+use Application\Models\Wiki\Wiki as WikiModel;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\SongDraftWikiReadModel;
+
+readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetSongDraftWikiInputPort $input): SongDraftWikiReadModel
+    {
+        $model = DraftWikiModel::query()
+            ->with(['songBasic.groups.groupBasic', 'songBasic.talents.talentBasic', 'publishedWiki'])
+            ->where('resource_type', ResourceType::SONG->value)
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->first();
+
+        if ($model === null) {
+            throw new WikiNotFoundException("Draft wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        $basic = $this->songBasic($model->songBasic);
+
+        return new SongDraftWikiReadModel(
+            wikiIdentifier: $model->id,
+            slug: $model->slug,
+            language: $model->language,
+            resourceType: ResourceType::SONG->value,
+            version: $model->publishedWiki->version,
+            themeColor: $model->theme_color,
+            heroImage: [
+                'imageIdentifier' => $basic->cover_image_identifier,
+            ],
+            basic: [
+                'name' => $basic->name,
+                'normalizedName' => $basic->normalized_name,
+                'songType' => $basic->song_type,
+                'genres' => $basic->genres,
+                'agencyIdentifier' => $basic->agency_identifier,
+                'releaseDate' => $basic->release_date,
+                'albumName' => $basic->album_name,
+                'coverImageIdentifier' => $basic->cover_image_identifier,
+                'lyricist' => $basic->lyricist,
+                'normalizedLyricist' => $basic->normalized_lyricist,
+                'composer' => $basic->composer,
+                'normalizedComposer' => $basic->normalized_composer,
+                'arranger' => $basic->arranger,
+                'normalizedArranger' => $basic->normalized_arranger,
+                'groups' => $basic->groups->map(fn (WikiModel $group) => $this->groupToArray($group))->values()->all(),
+                'talents' => $basic->talents->map(fn (WikiModel $talent) => $this->talentToArray($talent))->values()->all(),
+            ],
+            sections: $model->sections,
+        );
+    }
+
+    private function songBasic(?DraftWikiSongBasicModel $basic): DraftWikiSongBasicModel
+    {
+        if ($basic === null) {
+            throw new InvalidArgumentException('SongBasic not found for DraftWiki.');
+        }
+
+        return $basic;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function groupToArray(WikiModel $group): array
+    {
+        $basic = $group->groupBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('GroupBasic not found for Wiki.');
+        }
+
+        return [
+            'wikiIdentifier' => $group->id,
+            'slug' => $group->slug,
+            'language' => $group->language,
+            'name' => $basic->name,
+            'normalizedName' => $basic->normalized_name,
+            'agencyIdentifier' => $basic->agency_identifier,
+            'groupType' => $basic->group_type,
+            'status' => $basic->status,
+            'generation' => $basic->generation,
+            'debutDate' => $basic->debut_date,
+            'disbandDate' => $basic->disband_date,
+            'fandomName' => $basic->fandom_name,
+            'officialColors' => $basic->official_colors,
+            'emoji' => $basic->emoji,
+            'representativeSymbol' => $basic->representative_symbol,
+            'mainImageIdentifier' => $basic->main_image_identifier,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function talentToArray(WikiModel $talent): array
+    {
+        $basic = $talent->talentBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('TalentBasic not found for Wiki.');
+        }
+
+        return [
+            'wikiIdentifier' => $talent->id,
+            'slug' => $talent->slug,
+            'language' => $talent->language,
+            'name' => $basic->name,
+            'normalizedName' => $basic->normalized_name,
+            'realName' => $basic->real_name,
+            'normalizedRealName' => $basic->normalized_real_name,
+            'birthday' => $basic->birthday,
+            'agencyIdentifier' => $basic->agency_identifier,
+            'emoji' => $basic->emoji,
+            'representativeSymbol' => $basic->representative_symbol,
+            'position' => $basic->position,
+            'mbti' => $basic->mbti,
+            'zodiacSign' => $basic->zodiac_sign,
+            'englishLevel' => $basic->english_level,
+            'height' => $basic->height,
+            'bloodType' => $basic->blood_type,
+            'fandomName' => $basic->fandom_name,
+            'profileImageIdentifier' => $basic->profile_image_identifier,
+        ];
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/GetSongDraftWiki/GetSongDraftWikiInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInput;
+use Tests\TestCase;
+
+class GetSongDraftWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $slug = new Slug('signal');
+        $language = Language::KOREAN;
+        $input = new GetSongDraftWikiInput($slug, $language);
+
+        $this->assertSame((string) $slug, (string) $input->slug());
+        $this->assertSame($language, $input->language());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/SongDraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/SongDraftWikiReadModelTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\SongDraftWikiReadModel;
+use Tests\TestCase;
+
+class SongDraftWikiReadModelTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $readModel = new SongDraftWikiReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+            slug: 'tt',
+            language: 'ko',
+            resourceType: 'song',
+            version: 1,
+            themeColor: '#FE5F8F',
+            heroImage: [
+                'imageIdentifier' => null,
+            ],
+            basic: [
+                'name' => 'TT',
+                'normalizedName' => 'tt',
+                'songType' => 'title_track',
+                'genres' => ['dance_pop'],
+                'agencyIdentifier' => null,
+                'releaseDate' => '2016-10-24',
+                'albumName' => 'TWICEcoaster: Lane 1',
+                'coverImageIdentifier' => null,
+                'lyricist' => 'Black Eyed Pilseung',
+                'normalizedLyricist' => 'black eyed pilseung',
+                'composer' => 'Black Eyed Pilseung',
+                'normalizedComposer' => 'black eyed pilseung',
+                'arranger' => 'Rado',
+                'normalizedArranger' => 'rado',
+                'groups' => [
+                    [
+                        'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+                        'slug' => 'twice',
+                        'language' => 'ko',
+                        'name' => 'TWICE',
+                        'normalizedName' => 'twice',
+                        'agencyIdentifier' => null,
+                        'groupType' => 'girl_group',
+                        'status' => 'active',
+                        'generation' => '3',
+                        'debutDate' => '2015-10-20',
+                        'disbandDate' => null,
+                        'fandomName' => 'ONCE',
+                        'officialColors' => ['#FE5F8F', '#FEE500'],
+                        'emoji' => '',
+                        'representativeSymbol' => 'Candy Bong',
+                        'mainImageIdentifier' => null,
+                    ],
+                ],
+                'talents' => [
+                    [
+                        'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+                        'slug' => 'chaeyoung',
+                        'language' => 'ko',
+                        'name' => '채영',
+                        'normalizedName' => 'chaeyoung',
+                        'realName' => '손채영',
+                        'normalizedRealName' => 'sonchaeyoung',
+                        'birthday' => '1999-04-23',
+                        'agencyIdentifier' => null,
+                        'emoji' => '',
+                        'representativeSymbol' => 'Strawberry Princess',
+                        'position' => 'rapper',
+                        'mbti' => 'infp',
+                        'zodiacSign' => 'taurus',
+                        'englishLevel' => null,
+                        'height' => 159,
+                        'bloodType' => 'B',
+                        'fandomName' => 'ONCE',
+                        'profileImageIdentifier' => null,
+                    ],
+                ],
+            ],
+            sections: [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Draft sample for checking the song wiki editor state.',
+                ],
+            ],
+        );
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f301', $readModel->wikiIdentifier());
+        $this->assertSame('tt', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('song', $readModel->resourceType());
+        $this->assertSame(1, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('TT', $readModel->basic()['name']);
+        $this->assertSame('TWICE', $readModel->basic()['groups'][0]['name']);
+        $this->assertSame('채영', $readModel->basic()['talents'][0]['name']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+            'slug' => 'tt',
+            'language' => 'ko',
+            'resourceType' => 'song',
+            'version' => 1,
+            'themeColor' => '#FE5F8F',
+            'heroImage' => [
+                'imageIdentifier' => null,
+            ],
+            'basic' => [
+                'name' => 'TT',
+                'normalizedName' => 'tt',
+                'songType' => 'title_track',
+                'genres' => ['dance_pop'],
+                'agencyIdentifier' => null,
+                'releaseDate' => '2016-10-24',
+                'albumName' => 'TWICEcoaster: Lane 1',
+                'coverImageIdentifier' => null,
+                'lyricist' => 'Black Eyed Pilseung',
+                'normalizedLyricist' => 'black eyed pilseung',
+                'composer' => 'Black Eyed Pilseung',
+                'normalizedComposer' => 'black eyed pilseung',
+                'arranger' => 'Rado',
+                'normalizedArranger' => 'rado',
+                'groups' => [
+                    [
+                        'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+                        'slug' => 'twice',
+                        'language' => 'ko',
+                        'name' => 'TWICE',
+                        'normalizedName' => 'twice',
+                        'agencyIdentifier' => null,
+                        'groupType' => 'girl_group',
+                        'status' => 'active',
+                        'generation' => '3',
+                        'debutDate' => '2015-10-20',
+                        'disbandDate' => null,
+                        'fandomName' => 'ONCE',
+                        'officialColors' => ['#FE5F8F', '#FEE500'],
+                        'emoji' => '',
+                        'representativeSymbol' => 'Candy Bong',
+                        'mainImageIdentifier' => null,
+                    ],
+                ],
+                'talents' => [
+                    [
+                        'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+                        'slug' => 'chaeyoung',
+                        'language' => 'ko',
+                        'name' => '채영',
+                        'normalizedName' => 'chaeyoung',
+                        'realName' => '손채영',
+                        'normalizedRealName' => 'sonchaeyoung',
+                        'birthday' => '1999-04-23',
+                        'agencyIdentifier' => null,
+                        'emoji' => '',
+                        'representativeSymbol' => 'Strawberry Princess',
+                        'position' => 'rapper',
+                        'mbti' => 'infp',
+                        'zodiacSign' => 'taurus',
+                        'englishLevel' => null,
+                        'height' => 159,
+                        'bloodType' => 'B',
+                        'fandomName' => 'ONCE',
+                        'profileImageIdentifier' => null,
+                    ],
+                ],
+            ],
+            'sections' => [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Draft sample for checking the song wiki editor state.',
+                ],
+            ],
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInterface;
+use Tests\Helper\CreateDraftWiki;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class GetSongDraftWikiTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsDraftSongWiki(): void
+    {
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'group',
+            [
+                'slug' => 'twice',
+                'language' => 'ko',
+                'version' => 1,
+            ],
+            [
+                'name' => 'TWICE',
+                'normalized_name' => 'twice',
+                'group_type' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debut_date' => '2015-10-20',
+                'fandom_name' => 'ONCE',
+                'official_colors' => json_encode(['#FE5F8F', '#FEE500']),
+                'representative_symbol' => 'Candy Bong',
+            ],
+        );
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'talent',
+            [
+                'slug' => 'chaeyoung',
+                'language' => 'ko',
+                'version' => 1,
+            ],
+            [
+                'name' => '채영',
+                'normalized_name' => 'chaeyoung',
+                'real_name' => '손채영',
+                'normalized_real_name' => 'sonchaeyoung',
+                'birthday' => '1999-04-23',
+                'representative_symbol' => 'Strawberry Princess',
+                'position' => 'rapper',
+                'mbti' => 'infp',
+                'zodiac_sign' => 'taurus',
+                'height' => 159,
+                'blood_type' => 'B',
+                'fandom_name' => 'ONCE',
+            ],
+        );
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'song',
+            [
+                'slug' => 'signal',
+                'language' => 'ko',
+                'version' => 1,
+            ],
+            [
+                'name' => 'TT',
+                'normalized_name' => 'tt',
+                'song_type' => 'title_track',
+                'genres' => json_encode(['dance_pop']),
+                'group_identifiers' => json_encode(['01965bb2-bcc9-7c6f-8b90-89f7f217f002']),
+                'talent_identifiers' => json_encode(['01965bb2-bcc9-7c6f-8b90-89f7f217f101']),
+                'release_date' => '2016-10-24',
+                'album_name' => 'TWICEcoaster: Lane 1',
+                'lyricist' => 'Black Eyed Pilseung',
+                'normalized_lyricist' => 'black eyed pilseung',
+                'composer' => 'Black Eyed Pilseung',
+                'normalized_composer' => 'black eyed pilseung',
+                'arranger' => 'Rado',
+                'normalized_arranger' => 'rado',
+            ],
+        );
+        CreateDraftWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+            'song',
+            [
+                'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+                'slug' => 'signal',
+                'language' => 'ko',
+                'theme_color' => '#FE5F8F',
+                'sections' => json_encode([
+                    [
+                        'id' => 'overview',
+                        'type' => 'plaintext',
+                        'title' => 'Overview',
+                        'content' => 'Draft sample for checking the song wiki editor state.',
+                    ],
+                ]),
+            ],
+            [
+                'name' => 'TT',
+                'normalized_name' => 'tt',
+                'song_type' => 'title_track',
+                'genres' => json_encode(['dance_pop']),
+                'group_identifiers' => json_encode(['01965bb2-bcc9-7c6f-8b90-89f7f217f002']),
+                'talent_identifiers' => json_encode(['01965bb2-bcc9-7c6f-8b90-89f7f217f101']),
+                'release_date' => '2016-10-24',
+                'album_name' => 'TWICEcoaster: Lane 1',
+                'lyricist' => 'Black Eyed Pilseung',
+                'normalized_lyricist' => 'black eyed pilseung',
+                'composer' => 'Black Eyed Pilseung',
+                'normalized_composer' => 'black eyed pilseung',
+                'arranger' => 'Rado',
+                'normalized_arranger' => 'rado',
+            ],
+        );
+
+        $useCase = $this->app->make(GetSongDraftWikiInterface::class);
+        $readModel = $useCase->process(new GetSongDraftWikiInput(new Slug('signal'), Language::KOREAN));
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f301', $readModel->wikiIdentifier());
+        $this->assertSame('signal', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('song', $readModel->resourceType());
+        $this->assertSame(1, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('TT', $readModel->basic()['name']);
+        $this->assertSame('title_track', $readModel->basic()['songType']);
+        $this->assertSame(['dance_pop'], $readModel->basic()['genres']);
+        $this->assertSame('TWICE', $readModel->basic()['groups'][0]['name']);
+        $this->assertSame('girl_group', $readModel->basic()['groups'][0]['groupType']);
+        $this->assertSame('채영', $readModel->basic()['talents'][0]['name']);
+        $this->assertSame('rapper', $readModel->basic()['talents'][0]['position']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenDraftSongWikiDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetSongDraftWikiInterface::class);
+
+        $this->expectException(WikiNotFoundException::class);
+
+        $useCase->process(new GetSongDraftWikiInput(new Slug('signal'), Language::KOREAN));
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

- 歌Wikiの下書きを取得する private API を追加
- アクション、リクエスト、ユースケース入力、インターフェース、ReadModel、インフラ実装を追加
- ルート登録と DI バインディングを追加
- ReadModel とクエリ実装のユニットテスト・DBテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

歌Wiki編集画面から下書き状態のデータを取得できるようにするためです。
既存の group / talent 向け draft 取得APIと同じ構成で song 向けの取得経路を追加し、編集対象の基本情報・関連 group / talent・sections をまとめて返せるようにしました。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `GET /wiki/{language}/song/{slug}/draft` のレスポンス構造がフロントの期待値と一致しているか
- `songBasic` と関連する group / talent の展開内容が既存の draft API の設計方針と揃っているか
- 下書き未存在時の 404、入力不正時の 422 の扱いが妥当か

## 📖 関連情報

### 関連Issue・タスク

Closes #326

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
