### PR TITLE
fix(wiki): 下書き歌Wiki・事務所Wiki取得APIのTypeSpecを追加

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1066,6 +1066,46 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateWikiRequestBody'
+  /wiki/{language}/agency/{slug}/draft:
+    get:
+      operationId: WikiOperations_getAgencyDraftWiki
+      description: Fetch the agency draft wiki used by the editor.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when an agency draft wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgencyDraftWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /wiki/{language}/group/{slug}/draft:
     get:
       operationId: WikiOperations_getGroupDraftWiki
@@ -1088,6 +1128,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DraftWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /wiki/{language}/song/{slug}/draft:
+    get:
+      operationId: WikiOperations_getSongDraftWiki
+      description: Fetch the song draft wiki used by the editor.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when a song draft wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SongDraftWikiDetail'
         '404':
           description: The server cannot find the requested resource.
           content:
@@ -1566,6 +1646,97 @@ paths:
               $ref: '#/components/schemas/WikiWorkflowRequestBody'
 components:
   schemas:
+    AgencyDraftWikiBasic:
+      type: object
+      required:
+        - name
+        - normalizedName
+        - ceo
+        - normalizedCeo
+        - officialWebsite
+        - socialLinks
+      properties:
+        name:
+          type: string
+          description: Display name of the agency.
+        normalizedName:
+          type: string
+          description: Normalized name of the agency.
+        ceo:
+          type: string
+          description: Chief executive officer of the agency.
+        normalizedCeo:
+          type: string
+          description: Normalized chief executive officer name.
+        foundedIn:
+          type: string
+          format: date
+          description: Date when the agency was founded.
+        parentAgencyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Parent agency identifier.
+        status:
+          type: string
+          description: Current activity status of the agency.
+        logoImageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Logo image identifier of the agency.
+        officialWebsite:
+          type: string
+          description: Official website of the agency.
+        socialLinks:
+          type: array
+          items:
+            type: string
+          description: Social links of the agency.
+      description: Basic payload for an agency draft wiki.
+    AgencyDraftWikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Draft wiki identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number associated with the draft.
+        themeColor:
+          type: string
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload for the editor.
+        basic:
+          allOf:
+            - $ref: '#/components/schemas/AgencyDraftWikiBasic'
+          description: Basic agency wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed agency draft wiki payload used by the editor.
     AttachPolicyToRoleRequestBody:
       type: object
       required:
@@ -2204,6 +2375,273 @@ components:
             $ref: '#/components/schemas/VideoLinkInput'
           description: Video links to save.
       description: Request body for saving video links.
+    SongDraftWikiBasic:
+      type: object
+      required:
+        - name
+        - normalizedName
+        - songType
+        - genres
+        - albumName
+        - lyricist
+        - normalizedLyricist
+        - composer
+        - normalizedComposer
+        - arranger
+        - normalizedArranger
+        - groups
+        - talents
+      properties:
+        name:
+          type: string
+          description: Display name of the song.
+        normalizedName:
+          type: string
+          description: Normalized name of the song.
+        songType:
+          type: string
+          description: Song type.
+        genres:
+          type: array
+          items:
+            type: string
+          description: Genres associated with the song.
+        agencyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated agency identifier.
+        releaseDate:
+          type: string
+          format: date
+          description: Release date of the song.
+        albumName:
+          type: string
+          description: Album name.
+        coverImageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Cover image identifier of the song.
+        lyricist:
+          type: string
+          description: Lyricist name.
+        normalizedLyricist:
+          type: string
+          description: Normalized lyricist name.
+        composer:
+          type: string
+          description: Composer name.
+        normalizedComposer:
+          type: string
+          description: Normalized composer name.
+        arranger:
+          type: string
+          description: Arranger name.
+        normalizedArranger:
+          type: string
+          description: Normalized arranger name.
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/SongDraftWikiGroupSummary'
+          description: Related published groups linked to the song.
+        talents:
+          type: array
+          items:
+            $ref: '#/components/schemas/SongDraftWikiTalentSummary'
+          description: Related published talents linked to the song.
+      description: Basic payload for a song draft wiki.
+    SongDraftWikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Draft wiki identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number associated with the draft.
+        themeColor:
+          type: string
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload for the editor.
+        basic:
+          allOf:
+            - $ref: '#/components/schemas/SongDraftWikiBasic'
+          description: Basic song wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed song draft wiki payload used by the editor.
+    SongDraftWikiGroupSummary:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - name
+        - normalizedName
+        - fandomName
+        - officialColors
+        - emoji
+        - representativeSymbol
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published group wiki identifier.
+        slug:
+          type: string
+          description: Unique slug of the published group wiki.
+        language:
+          type: string
+          description: Language of the published group wiki.
+        name:
+          type: string
+          description: Display name of the group.
+        normalizedName:
+          type: string
+          description: Normalized name of the group.
+        agencyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated agency identifier.
+        groupType:
+          type: string
+          description: Group type.
+        status:
+          type: string
+          description: Current activity status of the group.
+        generation:
+          type: string
+          description: Generation label of the group.
+        debutDate:
+          type: string
+          format: date
+          description: Debut date of the group.
+        disbandDate:
+          type: string
+          format: date
+          description: Disband date of the group.
+        fandomName:
+          type: string
+          description: Fandom name of the group.
+        officialColors:
+          type: array
+          items:
+            type: string
+          description: Official color palette of the group.
+        emoji:
+          type: string
+          description: Emoji representing the group.
+        representativeSymbol:
+          type: string
+          description: Representative symbol of the group.
+        mainImageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Main image identifier of the group.
+      description: Summary of a published group linked from a song draft wiki.
+    SongDraftWikiTalentSummary:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - name
+        - normalizedName
+        - realName
+        - normalizedRealName
+        - emoji
+        - representativeSymbol
+        - position
+        - fandomName
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published talent wiki identifier.
+        slug:
+          type: string
+          description: Unique slug of the published talent wiki.
+        language:
+          type: string
+          description: Language of the published talent wiki.
+        name:
+          type: string
+          description: Display name of the talent.
+        normalizedName:
+          type: string
+          description: Normalized name of the talent.
+        realName:
+          type: string
+          description: Real name of the talent.
+        normalizedRealName:
+          type: string
+          description: Normalized real name of the talent.
+        birthday:
+          type: string
+          format: date
+          description: Birthday of the talent.
+        agencyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated agency identifier.
+        emoji:
+          type: string
+          description: Emoji representing the talent.
+        representativeSymbol:
+          type: string
+          description: Representative symbol of the talent.
+        position:
+          type: string
+          description: Position of the talent.
+        mbti:
+          type: string
+          description: MBTI of the talent.
+        zodiacSign:
+          type: string
+          description: Zodiac sign of the talent.
+        englishLevel:
+          type: string
+          description: English proficiency level of the talent.
+        height:
+          type: integer
+          format: int32
+          description: Height of the talent in centimeters.
+        bloodType:
+          type: string
+          description: Blood type of the talent.
+        fandomName:
+          type: string
+          description: Fandom name of the talent.
+        profileImageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Profile image identifier of the talent.
+      description: Summary of a published talent linked from a song draft wiki.
     TalentDraftWikiBasic:
       type: object
       required:

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -161,6 +161,188 @@ model TalentDraftWikiDetail {
   sections: unknown[];
 }
 
+@doc("Summary of a published group linked from a song draft wiki.")
+model SongDraftWikiGroupSummary {
+  @doc("Published group wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug of the published group wiki.")
+  slug: string;
+  @doc("Language of the published group wiki.")
+  language: string;
+  @doc("Display name of the group.")
+  name: string;
+  @doc("Normalized name of the group.")
+  normalizedName: string;
+  @doc("Associated agency identifier.")
+  agencyIdentifier?: Uuid;
+  @doc("Group type.")
+  groupType?: string;
+  @doc("Current activity status of the group.")
+  status?: string;
+  @doc("Generation label of the group.")
+  generation?: string;
+  @doc("Debut date of the group.")
+  debutDate?: plainDate;
+  @doc("Disband date of the group.")
+  disbandDate?: plainDate;
+  @doc("Fandom name of the group.")
+  fandomName: string;
+  @doc("Official color palette of the group.")
+  officialColors: string[];
+  @doc("Emoji representing the group.")
+  emoji: string;
+  @doc("Representative symbol of the group.")
+  representativeSymbol: string;
+  @doc("Main image identifier of the group.")
+  mainImageIdentifier?: Uuid;
+}
+
+@doc("Summary of a published talent linked from a song draft wiki.")
+model SongDraftWikiTalentSummary {
+  @doc("Published talent wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug of the published talent wiki.")
+  slug: string;
+  @doc("Language of the published talent wiki.")
+  language: string;
+  @doc("Display name of the talent.")
+  name: string;
+  @doc("Normalized name of the talent.")
+  normalizedName: string;
+  @doc("Real name of the talent.")
+  realName: string;
+  @doc("Normalized real name of the talent.")
+  normalizedRealName: string;
+  @doc("Birthday of the talent.")
+  birthday?: plainDate;
+  @doc("Associated agency identifier.")
+  agencyIdentifier?: Uuid;
+  @doc("Emoji representing the talent.")
+  emoji: string;
+  @doc("Representative symbol of the talent.")
+  representativeSymbol: string;
+  @doc("Position of the talent.")
+  position: string;
+  @doc("MBTI of the talent.")
+  mbti?: string;
+  @doc("Zodiac sign of the talent.")
+  zodiacSign?: string;
+  @doc("English proficiency level of the talent.")
+  englishLevel?: string;
+  @doc("Height of the talent in centimeters.")
+  height?: int32;
+  @doc("Blood type of the talent.")
+  bloodType?: string;
+  @doc("Fandom name of the talent.")
+  fandomName: string;
+  @doc("Profile image identifier of the talent.")
+  profileImageIdentifier?: Uuid;
+}
+
+@doc("Basic payload for a song draft wiki.")
+model SongDraftWikiBasic {
+  @doc("Display name of the song.")
+  name: string;
+  @doc("Normalized name of the song.")
+  normalizedName: string;
+  @doc("Song type.")
+  songType: string;
+  @doc("Genres associated with the song.")
+  genres: string[];
+  @doc("Associated agency identifier.")
+  agencyIdentifier?: Uuid;
+  @doc("Release date of the song.")
+  releaseDate?: plainDate;
+  @doc("Album name.")
+  albumName: string;
+  @doc("Cover image identifier of the song.")
+  coverImageIdentifier?: Uuid;
+  @doc("Lyricist name.")
+  lyricist: string;
+  @doc("Normalized lyricist name.")
+  normalizedLyricist: string;
+  @doc("Composer name.")
+  composer: string;
+  @doc("Normalized composer name.")
+  normalizedComposer: string;
+  @doc("Arranger name.")
+  arranger: string;
+  @doc("Normalized arranger name.")
+  normalizedArranger: string;
+  @doc("Related published groups linked to the song.")
+  groups: SongDraftWikiGroupSummary[];
+  @doc("Related published talents linked to the song.")
+  talents: SongDraftWikiTalentSummary[];
+}
+
+@doc("Detailed song draft wiki payload used by the editor.")
+model SongDraftWikiDetail {
+  @doc("Draft wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number associated with the draft.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor?: string;
+  @doc("Hero image payload for the editor.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic song wiki content payload.")
+  basic: SongDraftWikiBasic;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
+@doc("Basic payload for an agency draft wiki.")
+model AgencyDraftWikiBasic {
+  @doc("Display name of the agency.")
+  name: string;
+  @doc("Normalized name of the agency.")
+  normalizedName: string;
+  @doc("Chief executive officer of the agency.")
+  ceo: string;
+  @doc("Normalized chief executive officer name.")
+  normalizedCeo: string;
+  @doc("Date when the agency was founded.")
+  foundedIn?: plainDate;
+  @doc("Parent agency identifier.")
+  parentAgencyIdentifier?: Uuid;
+  @doc("Current activity status of the agency.")
+  status?: string;
+  @doc("Logo image identifier of the agency.")
+  logoImageIdentifier?: Uuid;
+  @doc("Official website of the agency.")
+  officialWebsite: string;
+  @doc("Social links of the agency.")
+  socialLinks: string[];
+}
+
+@doc("Detailed agency draft wiki payload used by the editor.")
+model AgencyDraftWikiDetail {
+  @doc("Draft wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number associated with the draft.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor?: string;
+  @doc("Hero image payload for the editor.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic agency wiki content payload.")
+  basic: AgencyDraftWikiBasic;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
 @doc("Summary of a draft image.")
 model ImageDraftSummary {
   @doc("Image identifier.")

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -83,6 +83,18 @@ model GetTalentDraftWikiResponse {
   @body body: TalentDraftWikiDetail;
 }
 
+@doc("Response returned when a song draft wiki is fetched.")
+model GetSongDraftWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: SongDraftWikiDetail;
+}
+
+@doc("Response returned when an agency draft wiki is fetched.")
+model GetAgencyDraftWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: AgencyDraftWikiDetail;
+}
+
 @doc("Response returned when a wiki is published.")
 model CreatePublishedWikiResponse {
   @statusCode statusCode: 201;
@@ -208,4 +220,20 @@ interface WikiOperations {
     @path language: string,
     @path slug: string,
   ): GetTalentDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/{language}/song/{slug}/draft")
+  @doc("Fetch the song draft wiki used by the editor.")
+  getSongDraftWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetSongDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/{language}/agency/{slug}/draft")
+  @doc("Fetch the agency draft wiki used by the editor.")
+  getAgencyDraftWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetAgencyDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

下書き歌Wiki取得APIと下書き事務所Wiki取得APIについて、実装済みだったレスポンス形状を TypeSpec に反映しました。
あわせて `/wiki/{language}/song/{slug}/draft` と `/wiki/{language}/agency/{slug}/draft` の OpenAPI 定義を再生成し、API 仕様と実装の差分を解消しています。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

`61aadc64` と `ebcc2867` では TypeSpec 更新と OpenAPI 生成が行われていましたが、`1b2c60c3` と `a679fcfd` では同様の更新が不足していました。
そのため、下書き歌Wiki取得APIと下書き事務所Wiki取得APIの実装内容が API 仕様に反映されていない状態になっていました。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `SongDraftWikiDetail` と `AgencyDraftWikiDetail` の TypeSpec 定義が実装のレスポンス形状と一致しているか
- `song` と `agency` の draft 取得 API が OpenAPI に正しく出力されているか
- 既存の `group` / `talent` 向け定義との粒度や命名が揃っているか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

`task check` は未実行です。TypeSpec のコンパイルによる OpenAPI 再生成のみ確認しています。

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [ ] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
