### PR TITLE
fix: フロントエンド Zod スキーマ更新 workflow を pnpm に統一

### DIFF
--- a/.github/workflows/update-frontend-zod-schemas.yml
+++ b/.github/workflows/update-frontend-zod-schemas.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install frontend runtime dependencies for generated schemas
         working-directory: ${{ env.FRONTEND_CHECKOUT_PATH }}
-        run: npm install --save-exact zod@${FRONTEND_ZOD_VERSION} @zodios/core@${FRONTEND_ZODIOS_CORE_VERSION}
+        run: pnpm add --save-exact -w zod@${FRONTEND_ZOD_VERSION} @zodios/core@${FRONTEND_ZODIOS_CORE_VERSION}
 
       - name: Generate frontend Zod schemas
         run: ./scripts/generate_frontend_zod_schemas.sh "${GITHUB_WORKSPACE}/${FRONTEND_CHECKOUT_PATH}"
@@ -66,8 +66,8 @@ jobs:
       - name: Verify frontend lint and build
         working-directory: ${{ env.FRONTEND_CHECKOUT_PATH }}
         run: |
-          npm run lint
-          npm run build
+          pnpm run lint
+          pnpm run build
 
       - name: Detect frontend changes
         id: changes
@@ -88,7 +88,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "${{ steps.changes.outputs.branch_name }}"
-          git add package.json package-lock.json packages/types/src
+          git add package.json pnpm-lock.yaml packages/types/src
           git commit -m "chore: update generated zod schemas"
           git push --set-upstream origin "${{ steps.changes.outputs.branch_name }}"
 

--- a/scripts/render_frontend_zod_pr_body.sh
+++ b/scripts/render_frontend_zod_pr_body.sh
@@ -40,8 +40,8 @@ cat > "${OUTPUT_FILE}" <<'EOF'
 
 ### 動作確認
 
-- `npm run lint`
-- `npm run build`
+- `pnpm run lint`
+- `pnpm run build`
 
 ## 🔍 レビューのポイント
 


### PR DESCRIPTION
## 📝 変更内容

フロントエンド Zod スキーマ更新 workflow のパッケージマネージャーを `npm` から `pnpm` に統一しました。
あわせて、依存追加後の検証コマンドと commit 対象 lockfile も `pnpm` 前提に揃えています。

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🚀 新機能 (Feature)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

フロントエンドリポジトリが `workspace:*` 依存を含む `pnpm` ワークスペース構成であるのに対し、workflow 内で `npm install` を実行していたため、CI が `EUNSUPPORTEDPROTOCOL` で失敗していました。
依存追加、lint/build、lockfile 更新をすべて `pnpm` に統一して、workflow がフロントエンド側の構成と整合するようにしています。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- frontend checkout 上の依存追加コマンドを `pnpm add --save-exact -w` に変更した内容が妥当か
- 検証コマンドを `pnpm run lint` / `pnpm run build` に変更して問題ないか
- commit 対象を `package-lock.json` から `pnpm-lock.yaml` に変更した内容がフロントエンド構成に合っているか

## ⚠️ 注意事項

`task check` や GitHub Actions 上での workflow 実行は、この変更では未確認です。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した