### PR TITLE
fix: ソーシャルログイン修正と認証済みユーザー取得API追加

### DIFF
--- a/application/Http/Action/Identity/Command/SocialLogin/Callback/SocialLoginCallbackAction.php
+++ b/application/Http/Action/Identity/Command/SocialLogin/Callback/SocialLoginCallbackAction.php
@@ -6,7 +6,9 @@ namespace Application\Http\Action\Identity\Command\SocialLogin\Callback;
 
 use Application\Http\Exceptions\InternalServerErrorHttpException;
 use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use DateTimeImmutable;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
@@ -18,7 +20,6 @@ use Source\Identity\Domain\Exception\SocialOAuthException;
 use Source\Identity\Domain\ValueObject\OAuthCode;
 use Source\Identity\Domain\ValueObject\OAuthState;
 use Source\Identity\Domain\ValueObject\SocialProvider;
-use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
 readonly class SocialLoginCallbackAction
@@ -31,17 +32,17 @@ readonly class SocialLoginCallbackAction
 
     /**
      * @param SocialLoginCallbackRequest $request
-     * @return JsonResponse
+     * @return JsonResponse|RedirectResponse
      * @throws InternalServerErrorHttpException
      */
-    public function __invoke(SocialLoginCallbackRequest $request): JsonResponse
+    public function __invoke(SocialLoginCallbackRequest $request): JsonResponse|RedirectResponse
     {
         try {
             try {
                 $input = new SocialLoginCallbackInput(
                     provider: SocialProvider::fromString($request->provider()),
                     code: new OAuthCode($request->code()),
-                    state: new OAuthState($request->state()),
+                    state: new OAuthState($request->state(), new DateTimeImmutable('+10 minutes')),
                 );
                 $output = new SocialLoginCallbackOutput();
             } catch (InvalidArgumentException $e) {
@@ -78,6 +79,6 @@ readonly class SocialLoginCallbackAction
             throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
         }
 
-        return response()->json(['redirectUrl' => $output->redirectUrl()], Response::HTTP_OK);
+        return redirect()->away(rtrim((string) config('app.frontend_url', 'http://localhost:3000'), '/'));
     }
 }

--- a/application/Http/Action/Identity/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityAction.php
+++ b/application/Http/Action/Identity/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityAction.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Identity\Query\GetAuthenticatedIdentity;
+
+use Application\Http\Context\ActorContext;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Illuminate\Http\JsonResponse;
+use Psr\Log\LoggerInterface;
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInput;
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class GetAuthenticatedIdentityAction
+{
+    public function __construct(
+        private GetAuthenticatedIdentityInterface $getAuthenticatedIdentity,
+        private ActorContext $actorContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(): JsonResponse
+    {
+        try {
+            try {
+                $readModel = $this->getAuthenticatedIdentity->process(
+                    new GetAuthenticatedIdentityInput($this->actorContext->identityIdentifier),
+                );
+            } catch (IdentityNotFoundException $e) {
+                throw new NotFoundHttpException(detail: error_message('identity_not_found', $this->actorContext->language->value), previous: $e);
+            }
+        } catch (NotFoundHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Providers/Identity/UseCaseServiceProvider.php
+++ b/application/Providers/Identity/UseCaseServiceProvider.php
@@ -21,6 +21,8 @@ use Source\Identity\Application\UseCase\Command\SwitchIdentity\SwitchIdentity;
 use Source\Identity\Application\UseCase\Command\SwitchIdentity\SwitchIdentityInterface;
 use Source\Identity\Application\UseCase\Command\VerifyEmail\VerifyEmail;
 use Source\Identity\Application\UseCase\Command\VerifyEmail\VerifyEmailInterface;
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
+use Source\Identity\Infrastructure\Query\GetAuthenticatedIdentity;
 
 class UseCaseServiceProvider extends ServiceProvider
 {
@@ -34,5 +36,6 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(SocialLoginRedirectInterface::class, SocialLoginRedirect::class);
         $this->app->singleton(SocialLoginCallbackInterface::class, SocialLoginCallback::class);
         $this->app->singleton(SwitchIdentityInterface::class, SwitchIdentity::class);
+        $this->app->singleton(GetAuthenticatedIdentityInterface::class, GetAuthenticatedIdentity::class);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
 use Sentry\Laravel\Integration as SentryIntegration;
 use Source\Wiki\Grading\Domain\ValueObject\YearMonth;
@@ -14,17 +15,17 @@ use Source\Wiki\Grading\Domain\ValueObject\YearMonth;
 $app = Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         then: function () {
-            Route::middleware('api')
+            Route::middleware(['api', 'session'])
                 ->prefix('api/identity')
                 ->group(base_path('routes/identity_api.php'));
-            Route::middleware(['api', 'auth.api', 'resolve.actor'])
+            Route::middleware(['api', 'session', 'auth.api', 'resolve.actor'])
                 ->prefix('api/monetization')
                 ->group(base_path('routes/monetization_api.php'));
-            Route::middleware(['api', 'auth.api', 'resolve.actor'])
+            Route::middleware(['api', 'session', 'auth.api', 'resolve.actor'])
                 ->prefix('api/account')
                 ->group(base_path('routes/account_api.php'));
 //            Route::middleware(['api', 'auth.api', 'resolve.actor', 'resolve.wiki'])
-            Route::middleware(['api'])
+            Route::middleware(['api', 'session'])
                 ->prefix('api/wiki')
                 ->group(base_path('routes/wiki_private_api.php'));
             Route::prefix('webhook')
@@ -73,6 +74,7 @@ $app = Application::configure(basePath: dirname(__DIR__))
             'auth.api' => \Application\Http\Middleware\EnsureAuthenticated::class,
             'resolve.actor' => \Application\Http\Middleware\ResolveActorContext::class,
             'resolve.wiki' => \Application\Http\Middleware\ResolveWikiContext::class,
+            'session' => StartSession::class,
         ]);
         $middleware->preventRequestForgery(except: [
             'webhook/*',

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\ServiceProvider;
+
+return [
+    'name' => env('APP_NAME', 'Laravel'),
+    'env' => env('APP_ENV', 'production'),
+    'debug' => (bool) env('APP_DEBUG', false),
+    'url' => env('APP_URL', 'http://localhost'),
+    'frontend_url' => env('FRONTEND_URL', 'http://localhost:3000'),
+    'asset_url' => env('ASSET_URL'),
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
+    'locale' => env('APP_LOCALE', 'en'),
+    'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
+    'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
+    'cipher' => 'AES-256-CBC',
+    'key' => env('APP_KEY'),
+    'previous_keys' => [
+        ...array_filter(explode(',', (string) env('APP_PREVIOUS_KEYS', ''))),
+    ],
+    'maintenance' => [
+        'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
+        'store' => env('APP_MAINTENANCE_STORE', 'database'),
+    ],
+    'providers' => ServiceProvider::defaultProviders()->merge([
+        //
+    ])->toArray(),
+    'aliases' => Facade::defaultAliases()->merge([
+        //
+    ])->toArray(),
+];

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+    'default' => env('CACHE_STORE', 'redis'),
+
+    'stores' => [
+        'array' => [
+            'driver' => 'array',
+            'serialize' => false,
+        ],
+
+        'file' => [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/data'),
+        ],
+
+        'redis' => [
+            'driver' => 'redis',
+            'connection' => env('REDIS_CACHE_CONNECTION', 'cache'),
+            'lock_connection' => env('REDIS_CACHE_LOCK_CONNECTION', 'default'),
+        ],
+    ],
+
+    'prefix' => env('CACHE_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')) . '-cache-'),
+];

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -51,5 +53,39 @@ return [
     |--------------------------------------------------------------------------
     */
     'migrations' => 'migrations',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redis Databases
+    |--------------------------------------------------------------------------
+    */
+
+    'redis' => [
+        'client' => env('REDIS_CLIENT', 'phpredis'),
+
+        'options' => [
+            'cluster' => env('REDIS_CLUSTER', 'redis'),
+            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')) . '-database-'),
+            'persistent' => env('REDIS_PERSISTENT', false),
+        ],
+
+        'default' => [
+            'url' => env('REDIS_URL'),
+            'host' => env('REDIS_HOST', '127.0.0.1'),
+            'username' => env('REDIS_USERNAME'),
+            'password' => env('REDIS_PASSWORD'),
+            'port' => env('REDIS_PORT', '6379'),
+            'database' => env('REDIS_DB', '0'),
+        ],
+
+        'cache' => [
+            'url' => env('REDIS_URL'),
+            'host' => env('REDIS_HOST', '127.0.0.1'),
+            'username' => env('REDIS_USERNAME'),
+            'password' => env('REDIS_PASSWORD'),
+            'port' => env('REDIS_PORT', '6379'),
+            'database' => env('REDIS_CACHE_DB', '1'),
+        ],
+    ],
 
 ]; 

--- a/config/session.php
+++ b/config/session.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Str;
+
+return [
+    'driver' => env('SESSION_DRIVER', 'redis'),
+    'lifetime' => (int) env('SESSION_LIFETIME', 120),
+    'expire_on_close' => env('SESSION_EXPIRE_ON_CLOSE', false),
+    'encrypt' => env('SESSION_ENCRYPT', false),
+    'files' => storage_path('framework/sessions'),
+    'connection' => env('SESSION_CONNECTION', 'default'),
+    'table' => env('SESSION_TABLE', 'sessions'),
+    'store' => env('SESSION_STORE', 'redis'),
+    'lottery' => [2, 100],
+    'cookie' => env(
+        'SESSION_COOKIE',
+        Str::snake((string) env('APP_NAME', 'laravel')) . '_session',
+    ),
+    'path' => env('SESSION_PATH', '/'),
+    'domain' => env('SESSION_DOMAIN'),
+    'secure' => env('SESSION_SECURE_COOKIE'),
+    'http_only' => env('SESSION_HTTP_ONLY', true),
+    'same_site' => env('SESSION_SAME_SITE', 'lax'),
+    'partitioned' => env('SESSION_PARTITIONED_COOKIE', false),
+];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       DB_PASSWORD: secret
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      SESSION_DRIVER: redis
+      SESSION_CONNECTION: default
+      SESSION_STORE: redis
       MAIL_MAILER: smtp
       MAIL_HOST: mail
       MAIL_PORT: 1025

--- a/routes/identity_api.php
+++ b/routes/identity_api.php
@@ -10,6 +10,7 @@ use Application\Http\Action\Identity\Command\SocialLogin\Callback\SocialLoginCal
 use Application\Http\Action\Identity\Command\SocialLogin\Redirect\SocialLoginRedirectAction;
 use Application\Http\Action\Identity\Command\SwitchIdentity\SwitchIdentityAction;
 use Application\Http\Action\Identity\Command\VerifyEmail\VerifyEmailAction;
+use Application\Http\Action\Identity\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityAction;
 use Illuminate\Support\Facades\Route;
 
 // Public Auth
@@ -24,6 +25,7 @@ Route::get('/auth/social/{provider}/callback', SocialLoginCallbackAction::class)
 
 // Authenticated
 Route::middleware(['auth.api', 'resolve.actor'])->group(function () {
+    Route::get('/auth/me', GetAuthenticatedIdentityAction::class);
     Route::post('/auth/logout', LogoutAction::class);
     Route::post('/auth/switch-identity', SwitchIdentityAction::class);
 });

--- a/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
+++ b/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Query;
+
+readonly class AuthenticatedIdentityReadModel
+{
+    public function __construct(
+        private string $identityIdentifier,
+        private string $username,
+        private string $email,
+        private string $language,
+        private ?string $profileImage,
+    ) {
+    }
+
+    public function identityIdentifier(): string
+    {
+        return $this->identityIdentifier;
+    }
+
+    public function username(): string
+    {
+        return $this->username;
+    }
+
+    public function email(): string
+    {
+        return $this->email;
+    }
+
+    public function language(): string
+    {
+        return $this->language;
+    }
+
+    public function profileImage(): ?string
+    {
+        return $this->profileImage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'identityIdentifier' => $this->identityIdentifier,
+            'username' => $this->username,
+            'email' => $this->email,
+            'language' => $this->language,
+            'profileImage' => $this->profileImage,
+        ];
+    }
+}

--- a/src/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInput.php
+++ b/src/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInput.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity;
+
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+readonly class GetAuthenticatedIdentityInput implements GetAuthenticatedIdentityInputPort
+{
+    public function __construct(
+        private IdentityIdentifier $identityIdentifier,
+    ) {
+    }
+
+    public function identityIdentifier(): IdentityIdentifier
+    {
+        return $this->identityIdentifier;
+    }
+}

--- a/src/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInputPort.php
+++ b/src/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity;
+
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+interface GetAuthenticatedIdentityInputPort
+{
+    public function identityIdentifier(): IdentityIdentifier;
+}

--- a/src/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInterface.php
+++ b/src/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity;
+
+use Source\Identity\Application\UseCase\Query\AuthenticatedIdentityReadModel;
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+
+interface GetAuthenticatedIdentityInterface
+{
+    /**
+     * @throws IdentityNotFoundException
+     */
+    public function process(GetAuthenticatedIdentityInputPort $input): AuthenticatedIdentityReadModel;
+}

--- a/src/Identity/Infrastructure/Factory/IdentityFactory.php
+++ b/src/Identity/Infrastructure/Factory/IdentityFactory.php
@@ -15,7 +15,6 @@ use Source\Shared\Application\Service\Uuid\UuidGeneratorInterface;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
-use Source\Shared\Domain\ValueObject\ImagePath;
 use Source\Shared\Domain\ValueObject\Language;
 
 readonly class IdentityFactory implements IdentityFactoryInterface
@@ -46,14 +45,13 @@ readonly class IdentityFactory implements IdentityFactoryInterface
     {
         $username = $this->buildUserName($profile);
         $password = $this->generateRandomPassword();
-        $profileImage = $profile->avatarUrl() ? new ImagePath($profile->avatarUrl()) : null;
 
         return new Identity(
             new IdentityIdentifier($this->ulidGenerator->generate()),
             $username,
             $profile->email(),
             Language::ENGLISH,
-            $profileImage,
+            null,
             HashedPassword::fromPlain($password),
             null,
             [new SocialConnection($profile->provider(), $profile->providerUserId())],

--- a/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
+++ b/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Infrastructure\Query;
+
+use Application\Models\Identity\Identity as IdentityModel;
+use Source\Identity\Application\UseCase\Query\AuthenticatedIdentityReadModel;
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInputPort;
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+
+readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInterface
+{
+    /**
+     * @throws IdentityNotFoundException
+     */
+    public function process(GetAuthenticatedIdentityInputPort $input): AuthenticatedIdentityReadModel
+    {
+        $model = IdentityModel::query()
+            ->where('id', (string) $input->identityIdentifier())
+            ->first();
+
+        if ($model === null) {
+            throw new IdentityNotFoundException();
+        }
+
+        return new AuthenticatedIdentityReadModel(
+            identityIdentifier: $model->id,
+            username: $model->username,
+            email: $model->email,
+            language: $model->language,
+            profileImage: $model->profile_image,
+        );
+    }
+}

--- a/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
+++ b/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Application\UseCase\Query;
+
+use Source\Identity\Application\UseCase\Query\AuthenticatedIdentityReadModel;
+use Tests\TestCase;
+
+class AuthenticatedIdentityReadModelTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $readModel = new AuthenticatedIdentityReadModel(
+            identityIdentifier: '019de7f3-78f3-7b55-9ed5-17f63e14d5fe',
+            username: 'test-user',
+            email: 'test@example.com',
+            language: 'ja',
+            profileImage: '/storage/profile/test.png',
+        );
+
+        $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5fe', $readModel->identityIdentifier());
+        $this->assertSame('test-user', $readModel->username());
+        $this->assertSame('test@example.com', $readModel->email());
+        $this->assertSame('ja', $readModel->language());
+        $this->assertSame('/storage/profile/test.png', $readModel->profileImage());
+        $this->assertSame([
+            'identityIdentifier' => '019de7f3-78f3-7b55-9ed5-17f63e14d5fe',
+            'username' => 'test-user',
+            'email' => 'test@example.com',
+            'language' => 'ja',
+            'profileImage' => '/storage/profile/test.png',
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInputTest.php
+++ b/tests/Identity/Application/UseCase/Query/GetAuthenticatedIdentity/GetAuthenticatedIdentityInputTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Application\UseCase\Query\GetAuthenticatedIdentity;
+
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInput;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\TestCase;
+
+class GetAuthenticatedIdentityInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $identityIdentifier = new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5fe');
+        $input = new GetAuthenticatedIdentityInput($identityIdentifier);
+
+        $this->assertSame((string) $identityIdentifier, (string) $input->identityIdentifier());
+    }
+}

--- a/tests/Identity/Http/Action/Command/SocialLogin/Callback/SocialLoginCallbackActionTest.php
+++ b/tests/Identity/Http/Action/Command/SocialLogin/Callback/SocialLoginCallbackActionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Http\Action\Command\SocialLogin\Callback;
+
+use Application\Http\Action\Identity\Command\SocialLogin\Callback\SocialLoginCallbackAction;
+use Application\Http\Action\Identity\Command\SocialLogin\Callback\SocialLoginCallbackRequest;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Identity\Application\UseCase\Command\SocialLogin\Callback\SocialLoginCallbackInput;
+use Source\Identity\Application\UseCase\Command\SocialLogin\Callback\SocialLoginCallbackInterface;
+use Source\Identity\Application\UseCase\Command\SocialLogin\Callback\SocialLoginCallbackOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class SocialLoginCallbackActionTest extends TestCase
+{
+    public function testInvokeReturnsRedirectUrlResponse(): void
+    {
+        $this->app['config']->set('app.frontend_url', 'http://localhost:3000');
+
+        /** @var SocialLoginCallbackRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(SocialLoginCallbackRequest::class);
+        $request->shouldReceive('provider')->andReturn('google');
+        $request->shouldReceive('code')->andReturn('oauth-code');
+        $request->shouldReceive('state')->andReturn('state-token');
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var SocialLoginCallbackInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(SocialLoginCallbackInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::on(function ($input): bool {
+                    return $input instanceof SocialLoginCallbackInput
+                        && (string) $input->state() === 'state-token';
+                }),
+                Mockery::on(function ($output): bool {
+                    if (! $output instanceof SocialLoginCallbackOutput) {
+                        return false;
+                    }
+
+                    $output->setRedirectUrl('/auth/callback');
+
+                    return true;
+                }),
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $action = new SocialLoginCallbackAction($useCase, $logger);
+
+        $response = $action($request);
+
+        $this->assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        $this->assertSame('http://localhost:3000', $response->headers->get('Location'));
+    }
+}

--- a/tests/Identity/Infrastructure/Factory/IdentityFactoryTest.php
+++ b/tests/Identity/Infrastructure/Factory/IdentityFactoryTest.php
@@ -70,8 +70,8 @@ class IdentityFactoryTest extends TestCase
         $providerUserId = 'google-user-1';
         $email = new Email('user@example.com');
         $name = 'Google User';
-        $avatarPath = 'images/avatars/google-user.png';
-        $profile = new SocialProfile($provider, $providerUserId, $email, $name, $avatarPath);
+        $avatarUrl = 'https://lh3.googleusercontent.com/avatar.jpg';
+        $profile = new SocialProfile($provider, $providerUserId, $email, $name, $avatarUrl);
 
         $identityFactory = $this->app->make(IdentityFactoryInterface::class);
 
@@ -81,7 +81,7 @@ class IdentityFactoryTest extends TestCase
         $this->assertSame((string)$email, (string)$identity->email());
         $this->assertSame(Language::ENGLISH, $identity->language());
         $this->assertSame($name, (string)$identity->username());
-        $this->assertSame($avatarPath, (string)$identity->profileImage());
+        $this->assertNull($identity->profileImage());
         $this->assertNull($identity->emailVerifiedAt());
         $this->assertTrue($identity->hasSocialConnection(new SocialConnection($provider, $providerUserId)));
         $this->assertNotEmpty((string)$identity->hashedPassword());

--- a/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
+++ b/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInput;
+use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\CreateIdentity;
+use Tests\TestCase;
+
+class GetAuthenticatedIdentityTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsAuthenticatedIdentity(): void
+    {
+        $identityIdentifier = new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5fe');
+        CreateIdentity::create($identityIdentifier, [
+            'username' => 'test-user',
+            'email' => 'test@example.com',
+            'language' => 'ja',
+            'profile_image' => '/storage/profile/test.png',
+        ]);
+
+        $useCase = $this->app->make(GetAuthenticatedIdentityInterface::class);
+        $readModel = $useCase->process(new GetAuthenticatedIdentityInput($identityIdentifier));
+
+        $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5fe', $readModel->identityIdentifier());
+        $this->assertSame('test-user', $readModel->username());
+        $this->assertSame('test@example.com', $readModel->email());
+        $this->assertSame('ja', $readModel->language());
+        $this->assertSame('/storage/profile/test.png', $readModel->profileImage());
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenIdentityDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetAuthenticatedIdentityInterface::class);
+
+        $this->expectException(IdentityNotFoundException::class);
+
+        $useCase->process(new GetAuthenticatedIdentityInput(
+            new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5ff'),
+        ));
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

- ソーシャルログイン callback で `OAuthState` の生成に有効期限を渡すよう修正
- ソーシャルログイン成功後のレスポンスを JSON ではなく `FRONTEND_URL` へのリダイレクトに変更
- API ルートでセッションを利用できるようにし、Redis session/cache 設定を追加
- social profile の外部 avatar URL を `ImagePath` に渡さず、Identity 作成時の profile image を `null` にするよう修正
- 認証済みユーザー情報を返す `GET /auth/me` を追加
- `GetAuthenticatedIdentity` Query UseCase / ReadModel / Infrastructure Query を追加
- 対象テストを追加・更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Google OAuth callback 後に 500 エラーが発生していたため、`OAuthState` の生成、セッション保存先、callback 後の遷移先、外部 avatar URL の扱いを修正しました。
また、フロントエンド側でログイン状態を判定できるように `GET /auth/me` を追加しました。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存の対象テストが壊れていないことを確認

実行済み:

- `task test-no-db filter=SocialLoginCallbackActionTest`
- `task test-no-db filter=IdentityFactoryTest`
- `task test-no-db filter=AuthenticatedIdentityReadModelTest`
- `task test-no-db filter=GetAuthenticatedIdentityInputTest`
- `task test filter=GetAuthenticatedIdentityTest keepdb=1`

## 🔍 レビューのポイント

- `GET /auth/me` の Action 名と UseCase 名の対応
- Query UseCase が Repository を経由せず Eloquent Query として実装されている点
- Redis session/cache 設定と API ルートへの session middleware 追加
- social profile の avatar URL を profile image として保存しない判断

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- session/cache の保存先として Redis を使用します
- `FRONTEND_URL` 未設定時は `http://localhost:3000` にリダイレクトします

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
