### PR TITLE
アカウント作成時の認証コード送信を非同期化

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,6 +61,13 @@ tasks:
     cmds:
       - docker-compose logs -f {{.API_SERVICES}}
 
+  queue-work:
+    desc: "Start Laravel queue worker. Usage: task queue-work [queue=default] [once=1]"
+    cmds:
+      - docker-compose up -d php db redis mail
+      - task: wait-for-db
+      - '{{.PHP_EXEC}} php artisan queue:work {{if .queue}}--queue={{.queue}}{{end}} {{if (index . "once")}}--once{{end}}'
+
   shell:
     desc: Open a shell in the php container
     cmds:

--- a/application/Http/Action/Account/Account/Command/CreateAccount/CreateAccountAction.php
+++ b/application/Http/Action/Account/Account/Command/CreateAccount/CreateAccountAction.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Account\Account\Command\CreateAccount;
 
-use Application\Http\Exceptions\ConflictHttpException;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
 use Application\Http\Exceptions\UnprocessableEntityHttpException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
-use Source\Account\Account\Application\Exception\AccountAlreadyExistsException;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountInput;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountInterface;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountOutput;
@@ -19,6 +17,7 @@ use Source\Account\Account\Domain\ValueObject\AccountName;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 use ValueError;
@@ -47,6 +46,7 @@ readonly class CreateAccountAction
                     identityIdentifier: $request->identityIdentifier() !== null
                         ? new IdentityIdentifier($request->identityIdentifier())
                         : null,
+                    language: Language::from($request->language()),
                 );
                 $output = new CreateAccountOutput();
             } catch (InvalidArgumentException|ValueError $e) {
@@ -55,21 +55,15 @@ readonly class CreateAccountAction
 
             DB::beginTransaction();
 
-            $language = $request->language();
-
             try {
                 $this->createAccount->process($input, $output);
                 DB::commit();
-            } catch (AccountAlreadyExistsException $e) {
-                DB::rollBack();
-
-                throw new ConflictHttpException(detail: error_message('account_already_exists', $language), previous: $e);
             } catch (Throwable $e) {
                 DB::rollBack();
 
                 throw $e;
             }
-        } catch (ConflictHttpException|UnprocessableEntityHttpException $e) {
+        } catch (UnprocessableEntityHttpException $e) {
             $this->logger->error((string) $e);
 
             return response()->json($e->toProblemDetails(), $e->getHttpStatus());

--- a/application/Http/Action/Concerns/ResolvesLanguage.php
+++ b/application/Http/Action/Concerns/ResolvesLanguage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Http\Action\Concerns;
 
 use Application\Http\Context\ActorContext;
+use Source\Shared\Domain\ValueObject\Language;
 
 trait ResolvesLanguage
 {
@@ -14,6 +15,30 @@ trait ResolvesLanguage
             return app(ActorContext::class)->language->value;
         }
 
-        return $this->header('Accept-Language', 'en');
+        return $this->resolveAcceptLanguage($this->header('Accept-Language'));
+    }
+
+    private function resolveAcceptLanguage(?string $header): string
+    {
+        if ($header === null || trim($header) === '') {
+            return Language::ENGLISH->value;
+        }
+
+        foreach (explode(',', $header) as $languageRange) {
+            $language = strtolower(trim(explode(';', $languageRange, 2)[0]));
+
+            if ($language === '' || $language === '*') {
+                continue;
+            }
+
+            $primaryLanguage = explode('-', $language, 2)[0];
+            foreach (Language::cases() as $supportedLanguage) {
+                if ($primaryLanguage === $supportedLanguage->value) {
+                    return $supportedLanguage->value;
+                }
+            }
+        }
+
+        return Language::ENGLISH->value;
     }
 }

--- a/application/Http/Exceptions/UnprocessableEntityHttpException.php
+++ b/application/Http/Exceptions/UnprocessableEntityHttpException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Http\Exceptions;
 
-use Exception;
+use Throwable;
 
 /**
  * 422 Unprocessable Entity例外
@@ -19,7 +19,7 @@ class UnprocessableEntityHttpException extends HttpException
         ?string $detail = null,
         ?string $instance = null,
         array $extensions = [],
-        ?Exception $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct(
             httpStatus: 422,

--- a/application/Jobs/SendAccountAuthCodeJob.php
+++ b/application/Jobs/SendAccountAuthCodeJob.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Source\Identity\Application\UseCase\Command\SendAuthCode\SendAuthCodeInput;
+use Source\Identity\Application\UseCase\Command\SendAuthCode\SendAuthCodeInterface;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\Language;
+use Throwable;
+
+class SendAccountAuthCodeJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $backoff = 60;
+
+    public function __construct(
+        private readonly Email $email,
+        private readonly Language $language,
+    ) {
+    }
+
+    public function handle(SendAuthCodeInterface $sendAuthCode): void
+    {
+        Log::info('SendAccountAuthCodeJob started', [
+            'email' => (string) $this->email,
+        ]);
+
+        $sendAuthCode->process(new SendAuthCodeInput($this->email, $this->language));
+
+        Log::info('SendAccountAuthCodeJob completed', [
+            'email' => (string) $this->email,
+        ]);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('SendAccountAuthCodeJob failed permanently', [
+            'email' => (string) $this->email,
+            'exception' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/application/Jobs/SendAccountConflictNotificationJob.php
+++ b/application/Jobs/SendAccountConflictNotificationJob.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Source\Identity\Domain\Service\AuthCodeServiceInterface;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\Language;
+use Throwable;
+
+class SendAccountConflictNotificationJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $backoff = 60;
+
+    public function __construct(
+        private readonly Email $email,
+        private readonly Language $language,
+    ) {
+    }
+
+    public function handle(AuthCodeServiceInterface $authCodeService): void
+    {
+        Log::info('SendAccountConflictNotificationJob started', [
+            'email' => (string) $this->email,
+        ]);
+
+        $authCodeService->notifyConflict($this->email, $this->language);
+
+        Log::info('SendAccountConflictNotificationJob completed', [
+            'email' => (string) $this->email,
+        ]);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('SendAccountConflictNotificationJob failed permanently', [
+            'email' => (string) $this->email,
+            'exception' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/application/Providers/Account/EventServiceProvider.php
+++ b/application/Providers/Account/EventServiceProvider.php
@@ -6,7 +6,11 @@ namespace Application\Providers\Account;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
+use Source\Account\Account\Application\EventHandler\AccountCreationConflictedHandler;
+use Source\Account\Account\Application\EventHandler\AccountCreatedHandler;
 use Source\Account\Account\Application\EventHandler\IdentityCreatedHandler;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
+use Source\Account\Account\Domain\Event\AccountCreated;
 use Source\Account\Invitation\Application\EventHandler\IdentityCreatedViaInvitationHandler;
 use Source\Account\Invitation\Application\EventHandler\InvitationCreatedHandler;
 use Source\Account\Invitation\Domain\Event\InvitationCreated;
@@ -19,6 +23,16 @@ class EventServiceProvider extends ServiceProvider
     {
         /** @var Dispatcher $events */
         $events = $this->app->make(Dispatcher::class);
+
+        $events->listen(
+            AccountCreationConflicted::class,
+            [AccountCreationConflictedHandler::class, 'handle'],
+        );
+
+        $events->listen(
+            AccountCreated::class,
+            [AccountCreatedHandler::class, 'handle'],
+        );
 
         $events->listen(
             IdentityCreated::class,

--- a/application/Providers/Account/EventServiceProvider.php
+++ b/application/Providers/Account/EventServiceProvider.php
@@ -6,11 +6,11 @@ namespace Application\Providers\Account;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
-use Source\Account\Account\Application\EventHandler\AccountCreationConflictedHandler;
 use Source\Account\Account\Application\EventHandler\AccountCreatedHandler;
+use Source\Account\Account\Application\EventHandler\AccountCreationConflictedHandler;
 use Source\Account\Account\Application\EventHandler\IdentityCreatedHandler;
-use Source\Account\Account\Domain\Event\AccountCreationConflicted;
 use Source\Account\Account\Domain\Event\AccountCreated;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
 use Source\Account\Invitation\Application\EventHandler\IdentityCreatedViaInvitationHandler;
 use Source\Account\Invitation\Application\EventHandler\InvitationCreatedHandler;
 use Source\Account\Invitation\Domain\Event\InvitationCreated;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -21,7 +21,7 @@ $app = Application::configure(basePath: dirname(__DIR__))
             Route::middleware(['api', 'session', 'auth.api', 'resolve.actor'])
                 ->prefix('api/monetization')
                 ->group(base_path('routes/monetization_api.php'));
-            Route::middleware(['api', 'session', 'auth.api', 'resolve.actor'])
+            Route::middleware(['api', 'session'])
                 ->prefix('api/account')
                 ->group(base_path('routes/account_api.php'));
 //            Route::middleware(['api', 'auth.api', 'resolve.actor', 'resolve.wiki'])

--- a/database/migrations/2024_01_01_000001_create_queue_tables.php
+++ b/database/migrations/2024_01_01_000001_create_queue_tables.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', static function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+
+        Schema::create('job_batches', static function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->string('name');
+            $table->integer('total_jobs');
+            $table->integer('pending_jobs');
+            $table->integer('failed_jobs');
+            $table->longText('failed_job_ids');
+            $table->mediumText('options')->nullable();
+            $table->integer('cancelled_at')->nullable();
+            $table->integer('created_at');
+            $table->integer('finished_at')->nullable();
+        });
+
+        Schema::create('failed_jobs', static function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_jobs');
+        Schema::dropIfExists('job_batches');
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -145,15 +145,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreatedAccountSummary'
+                $ref: '#/components/schemas/CreateAccountResult'
         '401':
           description: Access is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '409':
-          description: The request conflicts with the current state of the server.
           content:
             application/json:
               schema:
@@ -1058,6 +1052,29 @@ components:
           nullable: true
           description: Identity identifier to attach to the account.
       description: Request body for creating an account.
+    CreateAccountResult:
+      type: object
+      properties:
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Account identifier when a new account was created.
+        email:
+          type: string
+          description: Account email address when a new account was created.
+        type:
+          type: string
+          description: Account type when a new account was created.
+        name:
+          type: string
+          description: Account display name when a new account was created.
+        status:
+          type: string
+          description: Account status when a new account was created.
+        accountCategory:
+          type: string
+          description: Account category assigned during creation.
+      description: Account creation request result. Empty when the request is accepted without exposing whether an account already exists.
     CreateIdentityGroupRequestBody:
       type: object
       required:

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -25,33 +25,37 @@ use Illuminate\Support\Facades\Route;
 
 // Account
 Route::post('/accounts', CreateAccountAction::class);
-Route::delete('/accounts/{accountId}', DeleteAccountAction::class);
 
-// Delegation
-Route::post('/delegations', RequestDelegationAction::class);
-Route::post('/delegations/{delegationId}/approve', ApproveDelegationAction::class);
-Route::post('/delegations/{delegationId}/revoke', RevokeDelegationAction::class);
+Route::middleware(['auth.api', 'resolve.actor'])->group(function () {
+    // Account
+    Route::delete('/accounts/{accountId}', DeleteAccountAction::class);
 
-// DelegationPermission
-Route::post('/delegation-permissions', GrantDelegationPermissionAction::class);
-Route::delete('/delegation-permissions/{delegationPermissionId}', RevokeDelegationPermissionAction::class);
+    // Delegation
+    Route::post('/delegations', RequestDelegationAction::class);
+    Route::post('/delegations/{delegationId}/approve', ApproveDelegationAction::class);
+    Route::post('/delegations/{delegationId}/revoke', RevokeDelegationAction::class);
 
-// IdentityGroup
-Route::post('/identity-groups', CreateIdentityGroupAction::class);
-Route::post('/identity-groups/{identityGroupId}/add-member', AddIdentityToIdentityGroupAction::class);
-Route::post('/identity-groups/{identityGroupId}/remove-member', RemoveIdentityFromIdentityGroupAction::class);
-Route::delete('/identity-groups/{identityGroupId}', DeleteIdentityGroupAction::class);
+    // DelegationPermission
+    Route::post('/delegation-permissions', GrantDelegationPermissionAction::class);
+    Route::delete('/delegation-permissions/{delegationPermissionId}', RevokeDelegationPermissionAction::class);
 
-// Invitation
-Route::post('/invitations', CreateInvitationAction::class);
+    // IdentityGroup
+    Route::post('/identity-groups', CreateIdentityGroupAction::class);
+    Route::post('/identity-groups/{identityGroupId}/add-member', AddIdentityToIdentityGroupAction::class);
+    Route::post('/identity-groups/{identityGroupId}/remove-member', RemoveIdentityFromIdentityGroupAction::class);
+    Route::delete('/identity-groups/{identityGroupId}', DeleteIdentityGroupAction::class);
 
-// AccountVerification
-Route::post('/account-verifications', RequestVerificationAction::class);
-Route::post('/account-verifications/{verificationId}/approve', ApproveVerificationAction::class);
-Route::post('/account-verifications/{verificationId}/reject', RejectVerificationAction::class);
+    // Invitation
+    Route::post('/invitations', CreateInvitationAction::class);
 
-// Affiliation
-Route::post('/affiliations', RequestAffiliationAction::class);
-Route::post('/affiliations/{affiliationId}/approve', ApproveAffiliationAction::class);
-Route::post('/affiliations/{affiliationId}/reject', RejectAffiliationAction::class);
-Route::post('/affiliations/{affiliationId}/terminate', TerminateAffiliationAction::class);
+    // AccountVerification
+    Route::post('/account-verifications', RequestVerificationAction::class);
+    Route::post('/account-verifications/{verificationId}/approve', ApproveVerificationAction::class);
+    Route::post('/account-verifications/{verificationId}/reject', RejectVerificationAction::class);
+
+    // Affiliation
+    Route::post('/affiliations', RequestAffiliationAction::class);
+    Route::post('/affiliations/{affiliationId}/approve', ApproveAffiliationAction::class);
+    Route::post('/affiliations/{affiliationId}/reject', RejectAffiliationAction::class);
+    Route::post('/affiliations/{affiliationId}/terminate', TerminateAffiliationAction::class);
+});

--- a/src/Account/Account/Application/EventHandler/AccountCreatedHandler.php
+++ b/src/Account/Account/Application/EventHandler/AccountCreatedHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\EventHandler;
+
+use Application\Jobs\SendAccountAuthCodeJob;
+use Source\Account\Account\Domain\Event\AccountCreated;
+
+readonly class AccountCreatedHandler
+{
+    public function handle(AccountCreated $event): void
+    {
+        if ($event->identityIdentifier !== null) {
+            return;
+        }
+
+        SendAccountAuthCodeJob::dispatch($event->email, $event->language)->afterCommit();
+    }
+}

--- a/src/Account/Account/Application/EventHandler/AccountCreationConflictedHandler.php
+++ b/src/Account/Account/Application/EventHandler/AccountCreationConflictedHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\EventHandler;
+
+use Application\Jobs\SendAccountConflictNotificationJob;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
+
+readonly class AccountCreationConflictedHandler
+{
+    public function handle(AccountCreationConflicted $event): void
+    {
+        SendAccountConflictNotificationJob::dispatch($event->email, $event->language)->afterCommit();
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
+++ b/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\UseCase\Command\CreateAccount;
 
-use Source\Account\Account\Application\Exception\AccountAlreadyExistsException;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
+use Source\Account\Account\Domain\Event\AccountCreated;
 use Source\Account\Account\Domain\Factory\AccountFactoryInterface;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\IdentityGroup\Domain\Factory\IdentityGroupFactoryInterface;
 use Source\Account\IdentityGroup\Domain\Repository\IdentityGroupRepositoryInterface;
 use Source\Account\IdentityGroup\Domain\ValueObject\AccountRole;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class CreateAccount implements CreateAccountInterface
 {
@@ -20,6 +22,7 @@ readonly class CreateAccount implements CreateAccountInterface
         private AccountFactoryInterface $accountFactory,
         private IdentityGroupFactoryInterface $identityGroupFactory,
         private IdentityGroupRepositoryInterface $identityGroupRepository,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -27,14 +30,18 @@ readonly class CreateAccount implements CreateAccountInterface
      * @param CreateAccountInputPort $input
      * @param CreateAccountOutputPort $output
      * @return void
-     * @throws AccountAlreadyExistsException
      */
     public function process(CreateAccountInputPort $input, CreateAccountOutputPort $output): void
     {
         $account = $this->accountRepository->findByEmail($input->email());
 
         if ($account) {
-            throw new AccountAlreadyExistsException('Account already exists.');
+            $this->eventDispatcher->dispatch(new AccountCreationConflicted(
+                email: $input->email(),
+                language: $input->language(),
+            ));
+
+            return;
         }
 
         $account = $this->accountFactory->create(
@@ -57,6 +64,13 @@ readonly class CreateAccount implements CreateAccountInterface
         }
 
         $this->identityGroupRepository->save($identityGroup);
+
+        $this->eventDispatcher->dispatch(new AccountCreated(
+            accountIdentifier: $account->accountIdentifier(),
+            email: $account->email(),
+            identityIdentifier: $input->identityIdentifier(),
+            language: $input->language(),
+        ));
 
         $output->setAccount($account);
     }

--- a/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
+++ b/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\UseCase\Command\CreateAccount;
 
-use Source\Account\Account\Domain\Event\AccountCreationConflicted;
 use Source\Account\Account\Domain\Event\AccountCreated;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
 use Source\Account\Account\Domain\Factory\AccountFactoryInterface;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\IdentityGroup\Domain\Factory\IdentityGroupFactoryInterface;

--- a/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInput.php
+++ b/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInput.php
@@ -8,6 +8,7 @@ use Source\Account\Account\Domain\ValueObject\AccountName;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
 
 readonly class CreateAccountInput implements CreateAccountInputPort
 {
@@ -16,6 +17,7 @@ readonly class CreateAccountInput implements CreateAccountInputPort
         private AccountType $accountType,
         private AccountName $accountName,
         private ?IdentityIdentifier $identityIdentifier = null,
+        private Language $language = Language::ENGLISH,
     ) {
     }
 
@@ -37,5 +39,10 @@ readonly class CreateAccountInput implements CreateAccountInputPort
     public function identityIdentifier(): ?IdentityIdentifier
     {
         return $this->identityIdentifier;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
     }
 }

--- a/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInputPort.php
+++ b/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInputPort.php
@@ -8,6 +8,7 @@ use Source\Account\Account\Domain\ValueObject\AccountName;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
 
 interface CreateAccountInputPort
 {
@@ -18,4 +19,6 @@ interface CreateAccountInputPort
     public function accountName(): AccountName;
 
     public function identityIdentifier(): ?IdentityIdentifier;
+
+    public function language(): Language;
 }

--- a/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInterface.php
+++ b/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInterface.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\UseCase\Command\CreateAccount;
 
-use Source\Account\Account\Application\Exception\AccountAlreadyExistsException;
-
 interface CreateAccountInterface
 {
     /**
      * @param CreateAccountInputPort $input
      * @param CreateAccountOutputPort $output
      * @return void
-     * @throws AccountAlreadyExistsException
      */
     public function process(CreateAccountInputPort $input, CreateAccountOutputPort $output): void;
 }

--- a/src/Account/Account/Domain/Event/AccountCreated.php
+++ b/src/Account/Account/Domain/Event/AccountCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Domain\Event;
+
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
+
+readonly class AccountCreated
+{
+    public function __construct(
+        public AccountIdentifier $accountIdentifier,
+        public Email $email,
+        public ?IdentityIdentifier $identityIdentifier,
+        public Language $language,
+    ) {
+    }
+}

--- a/src/Account/Account/Domain/Event/AccountCreationConflicted.php
+++ b/src/Account/Account/Domain/Event/AccountCreationConflicted.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Domain\Event;
+
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\Language;
+
+readonly class AccountCreationConflicted
+{
+    public function __construct(
+        public Email $email,
+        public Language $language,
+    ) {
+    }
+}

--- a/tests/Account/Account/Application/EventHandler/AccountCreatedHandlerTest.php
+++ b/tests/Account/Account/Application/EventHandler/AccountCreatedHandlerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Account\Application\EventHandler;
+
+use Application\Jobs\SendAccountAuthCodeJob;
+use Illuminate\Support\Facades\Bus;
+use Source\Account\Account\Application\EventHandler\AccountCreatedHandler;
+use Source\Account\Account\Domain\Event\AccountCreated;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AccountCreatedHandlerTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $handler = $this->app->make(AccountCreatedHandler::class);
+
+        $this->assertInstanceOf(AccountCreatedHandler::class, $handler);
+    }
+
+    public function testHandleDispatchesSendAccountAuthCodeJob(): void
+    {
+        Bus::fake();
+
+        $email = new Email('user@example.com');
+        $language = Language::JAPANESE;
+        $event = new AccountCreated(
+            accountIdentifier: new AccountIdentifier(StrTestHelper::generateUuid()),
+            email: $email,
+            identityIdentifier: null,
+            language: $language,
+        );
+
+        $handler = $this->app->make(AccountCreatedHandler::class);
+        $handler->handle($event);
+
+        Bus::assertDispatched(
+            SendAccountAuthCodeJob::class,
+            static fn (SendAccountAuthCodeJob $job): bool => self::jobProperty($job, 'email') == $email
+                && self::jobProperty($job, 'language') === $language
+        );
+    }
+
+    public function testHandleDoesNotDispatchJobWhenAccountAlreadyHasIdentity(): void
+    {
+        Bus::fake();
+
+        $event = new AccountCreated(
+            accountIdentifier: new AccountIdentifier(StrTestHelper::generateUuid()),
+            email: new Email('user@example.com'),
+            identityIdentifier: new IdentityIdentifier(StrTestHelper::generateUuid()),
+            language: Language::ENGLISH,
+        );
+
+        $handler = $this->app->make(AccountCreatedHandler::class);
+        $handler->handle($event);
+
+        Bus::assertNotDispatched(SendAccountAuthCodeJob::class);
+    }
+
+    private static function jobProperty(SendAccountAuthCodeJob $job, string $name): mixed
+    {
+        $property = new \ReflectionProperty($job, $name);
+
+        return $property->getValue($job);
+    }
+}

--- a/tests/Account/Account/Application/EventHandler/AccountCreationConflictedHandlerTest.php
+++ b/tests/Account/Account/Application/EventHandler/AccountCreationConflictedHandlerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Account\Application\EventHandler;
+
+use Application\Jobs\SendAccountConflictNotificationJob;
+use Illuminate\Support\Facades\Bus;
+use Source\Account\Account\Application\EventHandler\AccountCreationConflictedHandler;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\Language;
+use Tests\TestCase;
+
+class AccountCreationConflictedHandlerTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $handler = $this->app->make(AccountCreationConflictedHandler::class);
+
+        $this->assertInstanceOf(AccountCreationConflictedHandler::class, $handler);
+    }
+
+    public function testHandleDispatchesSendAccountConflictNotificationJob(): void
+    {
+        Bus::fake();
+
+        $email = new Email('user@example.com');
+        $language = Language::JAPANESE;
+        $event = new AccountCreationConflicted(
+            email: $email,
+            language: $language,
+        );
+
+        $handler = $this->app->make(AccountCreationConflictedHandler::class);
+        $handler->handle($event);
+
+        Bus::assertDispatched(
+            SendAccountConflictNotificationJob::class,
+            static fn (SendAccountConflictNotificationJob $job): bool => self::jobProperty($job, 'email') == $email
+                && self::jobProperty($job, 'language') === $language
+        );
+    }
+
+    private static function jobProperty(SendAccountConflictNotificationJob $job, string $name): mixed
+    {
+        $property = new \ReflectionProperty($job, $name);
+
+        return $property->getValue($job);
+    }
+}

--- a/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInputTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountInputTest.php
@@ -10,6 +10,7 @@ use Source\Account\Account\Domain\ValueObject\AccountName;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
 use Tests\Helper\StrTestHelper;
 
 class CreateAccountInputTest extends TestCase
@@ -37,6 +38,7 @@ class CreateAccountInputTest extends TestCase
         $this->assertSame($accountType, $input->accountType());
         $this->assertSame($accountName, $input->accountName());
         $this->assertSame($identityIdentifier, $input->identityIdentifier());
+        $this->assertSame(Language::ENGLISH, $input->language());
     }
 
     /**
@@ -49,16 +51,20 @@ class CreateAccountInputTest extends TestCase
         $email = new Email('test@test.com');
         $accountType = AccountType::INDIVIDUAL;
         $accountName = new AccountName('test-account');
+        $language = Language::KOREAN;
 
         $input = new CreateAccountInput(
             $email,
             $accountType,
             $accountName,
+            null,
+            $language,
         );
 
         $this->assertSame($email, $input->email());
         $this->assertSame($accountType, $input->accountType());
         $this->assertSame($accountName, $input->accountName());
         $this->assertNull($input->identityIdentifier());
+        $this->assertSame($language, $input->language());
     }
 }

--- a/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
@@ -6,12 +6,13 @@ namespace Tests\Account\Account\Application\UseCase\Command\CreateAccount;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
-use Source\Account\Account\Application\Exception\AccountAlreadyExistsException;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccount;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountInput;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountInterface;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountOutput;
 use Source\Account\Account\Domain\Entity\Account;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
+use Source\Account\Account\Domain\Event\AccountCreated;
 use Source\Account\Account\Domain\Factory\AccountFactoryInterface;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Account\Domain\ValueObject\AccountName;
@@ -24,9 +25,11 @@ use Source\Account\IdentityGroup\Domain\Repository\IdentityGroupRepositoryInterf
 use Source\Account\IdentityGroup\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Account\Shared\Domain\ValueObject\IdentityGroupIdentifier;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -43,10 +46,12 @@ class CreateAccountTest extends TestCase
         $factory = Mockery::mock(AccountFactoryInterface::class);
         $identityGroupFactory = Mockery::mock(IdentityGroupFactoryInterface::class);
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $useCase = $this->app->make(CreateAccountInterface::class);
         $this->assertInstanceOf(CreateAccount::class, $useCase);
     }
@@ -54,7 +59,6 @@ class CreateAccountTest extends TestCase
     /**
      * 正常系: 正しくアカウントを作成できること（identityIdentifierあり）.
      *
-     * @throws AccountAlreadyExistsException
      * @throws BindingResolutionException
      */
     public function testProcess(): void
@@ -89,10 +93,22 @@ class CreateAccountTest extends TestCase
             ->with($testData->identityGroup)
             ->andReturnNull();
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn (object $event): bool => $event instanceof AccountCreated
+                    && (string) $event->accountIdentifier === (string) $testData->identifier
+                    && (string) $event->email === (string) $testData->email
+                    && (string) $event->identityIdentifier === (string) $testData->identityIdentifier
+                    && $event->language === $testData->language
+            ));
+
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(CreateAccountInterface::class);
 
@@ -110,7 +126,6 @@ class CreateAccountTest extends TestCase
     /**
      * 正常系: identityIdentifierがnullの場合もアカウントとデフォルトIdentityGroupが作成されること.
      *
-     * @throws AccountAlreadyExistsException
      * @throws BindingResolutionException
      */
     public function testProcessWithoutIdentityIdentifier(): void
@@ -145,10 +160,22 @@ class CreateAccountTest extends TestCase
             ->with($testData->identityGroup)
             ->andReturnNull();
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn (object $event): bool => $event instanceof AccountCreated
+                    && (string) $event->accountIdentifier === (string) $testData->identifier
+                    && (string) $event->email === (string) $testData->email
+                    && $event->identityIdentifier === null
+                    && $event->language === $testData->language
+            ));
+
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(CreateAccountInterface::class);
 
@@ -161,12 +188,11 @@ class CreateAccountTest extends TestCase
     }
 
     /**
-     * 異常系: アカウントが重複した時に、例外がスローされること.
+     * 正常系: アカウントが重複した時に、通知イベントを発火して早期returnすること.
      *
-     * @throws AccountAlreadyExistsException
      * @throws BindingResolutionException
      */
-    public function testThrowsWhenDuplicate(): void
+    public function testProcessDispatchesConflictEventWhenDuplicate(): void
     {
         $testData = $this->createDummyAccountTestData();
         $input = $testData->input;
@@ -187,17 +213,27 @@ class CreateAccountTest extends TestCase
         $identityGroupRepository = Mockery::mock(IdentityGroupRepositoryInterface::class);
         $identityGroupRepository->shouldNotReceive('save');
 
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(
+                static fn (object $event): bool => $event instanceof AccountCreationConflicted
+                    && (string) $event->email === (string) $testData->email
+                    && $event->language === $testData->language
+            ));
+
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
         $this->app->instance(IdentityGroupFactoryInterface::class, $identityGroupFactory);
         $this->app->instance(IdentityGroupRepositoryInterface::class, $identityGroupRepository);
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $useCase = $this->app->make(CreateAccountInterface::class);
 
-        $this->expectException(AccountAlreadyExistsException::class);
-
         $output = new CreateAccountOutput();
         $useCase->process($input, $output);
+
+        $this->assertSame([], $output->toArray());
     }
 
     private function createDummyAccountTestData(bool $includeIdentityIdentifier = true): CreateAccountTestData
@@ -206,6 +242,7 @@ class CreateAccountTest extends TestCase
         $email = new Email('test@test.com');
         $accountType = AccountType::CORPORATION;
         $accountName = new AccountName('Example Inc');
+        $language = Language::JAPANESE;
 
         $status = AccountStatus::ACTIVE;
         $accountCategory = AccountCategory::GENERAL;
@@ -236,6 +273,7 @@ class CreateAccountTest extends TestCase
             $accountType,
             $accountName,
             $includeIdentityIdentifier ? $identityIdentifier : null,
+            $language,
         );
 
         return new CreateAccountTestData(
@@ -248,6 +286,7 @@ class CreateAccountTest extends TestCase
             $input,
             $identityIdentifier,
             $identityGroup,
+            $language,
         );
     }
 }
@@ -264,6 +303,7 @@ readonly class CreateAccountTestData
         public CreateAccountInput $input,
         public IdentityIdentifier $identityIdentifier,
         public IdentityGroup $identityGroup,
+        public Language $language,
     ) {
     }
 }

--- a/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
@@ -11,8 +11,8 @@ use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccou
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountInterface;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccountOutput;
 use Source\Account\Account\Domain\Entity\Account;
-use Source\Account\Account\Domain\Event\AccountCreationConflicted;
 use Source\Account\Account\Domain\Event\AccountCreated;
+use Source\Account\Account\Domain\Event\AccountCreationConflicted;
 use Source\Account\Account\Domain\Factory\AccountFactoryInterface;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Account\Domain\ValueObject\AccountName;

--- a/tests/Account/Account/Domain/Entity/AccountTest.php
+++ b/tests/Account/Account/Domain/Entity/AccountTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Account\Domain\Entity;
+namespace Tests\Account\Account\Domain\Entity;
 
 use PHPUnit\Framework\TestCase;
 use Source\Account\Account\Domain\Entity\Account;

--- a/tests/Http/Context/ResolvesLanguageTest.php
+++ b/tests/Http/Context/ResolvesLanguageTest.php
@@ -41,6 +41,36 @@ class ResolvesLanguageTest extends TestCase
         $this->assertSame('ja', $request->language());
     }
 
+    public function testReturnsSupportedLanguageFromAcceptLanguageList(): void
+    {
+        $request = new class () extends FormRequest {
+            use ResolvesLanguage;
+        };
+        $request->headers->set('Accept-Language', 'fr-CA,ja-JP;q=0.9,en;q=0.8');
+
+        $this->assertSame('ja', $request->language());
+    }
+
+    public function testReturnsDefaultEnglishWhenAcceptLanguageWildcard(): void
+    {
+        $request = new class () extends FormRequest {
+            use ResolvesLanguage;
+        };
+        $request->headers->set('Accept-Language', '*');
+
+        $this->assertSame('en', $request->language());
+    }
+
+    public function testReturnsDefaultEnglishWhenAcceptLanguageIsUnsupported(): void
+    {
+        $request = new class () extends FormRequest {
+            use ResolvesLanguage;
+        };
+        $request->headers->set('Accept-Language', 'fr-CA,es;q=0.8');
+
+        $this->assertSame('en', $request->language());
+    }
+
     public function testReturnsDefaultEnglishWhenNoActorContextAndNoHeader(): void
     {
         $request = new class () extends FormRequest {

--- a/tests/Jobs/SendAccountAuthCodeJobTest.php
+++ b/tests/Jobs/SendAccountAuthCodeJobTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Jobs;
+
+use Application\Jobs\SendAccountAuthCodeJob;
+use Mockery;
+use Source\Identity\Application\UseCase\Command\SendAuthCode\SendAuthCodeInput;
+use Source\Identity\Application\UseCase\Command\SendAuthCode\SendAuthCodeInterface;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\Language;
+use Tests\TestCase;
+
+class SendAccountAuthCodeJobTest extends TestCase
+{
+    public function testHandleCallsSendAuthCodeUseCase(): void
+    {
+        $email = new Email('user@example.com');
+        $language = Language::KOREAN;
+        $job = new SendAccountAuthCodeJob($email, $language);
+
+        /** @var SendAuthCodeInterface&\Mockery\MockInterface $sendAuthCode */
+        $sendAuthCode = Mockery::mock(SendAuthCodeInterface::class);
+        $sendAuthCode->shouldReceive('process')
+            ->once()
+            ->with(Mockery::on(
+                static fn (SendAuthCodeInput $input): bool => (string) $input->email() === (string) $email
+                    && $input->language() === $language
+            ));
+
+        $job->handle($sendAuthCode);
+    }
+}

--- a/tests/Jobs/SendAccountConflictNotificationJobTest.php
+++ b/tests/Jobs/SendAccountConflictNotificationJobTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Jobs;
+
+use Application\Jobs\SendAccountConflictNotificationJob;
+use Mockery;
+use Source\Identity\Domain\Service\AuthCodeServiceInterface;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\Language;
+use Tests\TestCase;
+
+class SendAccountConflictNotificationJobTest extends TestCase
+{
+    public function testHandleCallsNotifyConflict(): void
+    {
+        $email = new Email('user@example.com');
+        $language = Language::KOREAN;
+        $job = new SendAccountConflictNotificationJob($email, $language);
+
+        /** @var AuthCodeServiceInterface&\Mockery\MockInterface $authCodeService */
+        $authCodeService = Mockery::mock(AuthCodeServiceInterface::class);
+        $authCodeService->shouldReceive('notifyConflict')
+            ->once()
+            ->with($email, $language);
+
+        $job->handle($authCodeService);
+    }
+}

--- a/typespec/services/account-api/account.tsp
+++ b/typespec/services/account-api/account.tsp
@@ -18,7 +18,7 @@ model CreateAccountRequestBody {
 @doc("Response returned when an account is created.")
 model CreateAccountResponse {
   @statusCode statusCode: 201;
-  @body body: CreatedAccountSummary;
+  @body body: CreateAccountResult;
 }
 
 @doc("Response returned when an account operation succeeds.")
@@ -33,7 +33,7 @@ interface AccountOperations {
   @doc("Create an account.")
   createAccount(
     @body body: CreateAccountRequestBody,
-  ): CreateAccountResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): CreateAccountResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @delete
   @route("/{accountId}")

--- a/typespec/services/account-api/common.tsp
+++ b/typespec/services/account-api/common.tsp
@@ -23,6 +23,22 @@ model CreatedAccountSummary extends AccountSummary {
   accountCategory: string;
 }
 
+@doc("Account creation request result. Empty when the request is accepted without exposing whether an account already exists.")
+model CreateAccountResult {
+  @doc("Account identifier when a new account was created.")
+  accountIdentifier?: Uuid;
+  @doc("Account email address when a new account was created.")
+  email?: string;
+  @doc("Account type when a new account was created.")
+  type?: string;
+  @doc("Account display name when a new account was created.")
+  name?: string;
+  @doc("Account status when a new account was created.")
+  status?: string;
+  @doc("Account category assigned during creation.")
+  accountCategory?: string;
+}
+
 @doc("Affiliation contract terms.")
 model AffiliationTermsSummary {
   @doc("Revenue share percentage.")


### PR DESCRIPTION
## 📝 変更内容

- アカウント作成時に `AccountCreated` / `AccountCreationConflicted` イベントを発火するように変更
- 新規アカウント作成後、Identity 未紐付けの場合に認証コードメール送信ジョブを dispatch
- 既存メールアドレスでのアカウント作成要求時は 409 を返さず、存在有無を露出しない空レスポンスとして処理し、競合通知ジョブを dispatch
- Laravel queue 用の migration と `task queue-work` を追加
- `Accept-Language` の解決を対応言語の primary language ベースに改善
- account API の認証 middleware 適用範囲を調整し、`POST /accounts` は未認証で利用可能なままに変更
- TypeSpec / OpenAPI のアカウント作成レスポンス仕様を更新
- イベントハンドラ、ジョブ、CreateAccount、言語解決のテストを追加・更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

アカウント作成フローで、作成後の認証コード送信を同期処理から切り離し、メール送信失敗や遅延が作成 API の応答に影響しにくい構成にするため。

また、既存アカウントの有無を API レスポンスから判別できないようにし、重複時は通知メール送信へ寄せることで、アカウント列挙リスクを抑える。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- 重複アカウント作成時に 409 を返さず、空レスポンスで受理する仕様が適切か
- `AccountCreated` / `AccountCreationConflicted` イベントと queue job の責務分離が妥当か
- `POST /accounts` のみ未認証で通し、それ以外の account API を `auth.api` / `resolve.actor` 配下に置く middleware 構成が意図通りか
- `Accept-Language` の primary language 解決とデフォルト英語 fallback が仕様に合っているか
- queue table migration の追加と既存環境への適用手順に問題がないか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- queue table 用の migration が追加されています
- 認証コード送信・重複通知は queue worker の稼働が必要です
- `POST /api/account/accounts` の重複時レスポンス仕様から 409 が削除されています

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
