### PR TITLE
公開Wiki取得Queryを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/GetAgencyWiki/GetAgencyWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetAgencyWiki/GetAgencyWikiAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetAgencyWiki;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class GetAgencyWikiAction
+{
+    public function __construct(
+        private GetAgencyWikiInterface $getAgencyWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GetAgencyWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetAgencyWikiInput(
+                    new Slug($request->slug()),
+                    Language::from($request->language()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $readModel = $this->getAgencyWiki->process($input);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Wiki not found.', previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetAgencyWiki/GetAgencyWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetAgencyWiki/GetAgencyWikiRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetAgencyWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetAgencyWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validationData(): array
+    {
+        return [
+            ...parent::validationData(),
+            'language' => $this->route('language'),
+            'slug' => $this->route('slug'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetGroupWiki/GetGroupWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetGroupWiki/GetGroupWikiAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetGroupWiki;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class GetGroupWikiAction
+{
+    public function __construct(
+        private GetGroupWikiInterface $getGroupWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GetGroupWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetGroupWikiInput(
+                    new Slug($request->slug()),
+                    Language::from($request->language()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $readModel = $this->getGroupWiki->process($input);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Wiki not found.', previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetGroupWiki/GetGroupWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetGroupWiki/GetGroupWikiRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetGroupWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetGroupWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validationData(): array
+    {
+        return [
+            ...parent::validationData(),
+            'language' => $this->route('language'),
+            'slug' => $this->route('slug'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetSongWiki/GetSongWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetSongWiki/GetSongWikiAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetSongWiki;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class GetSongWikiAction
+{
+    public function __construct(
+        private GetSongWikiInterface $getSongWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GetSongWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetSongWikiInput(
+                    new Slug($request->slug()),
+                    Language::from($request->language()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $readModel = $this->getSongWiki->process($input);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Wiki not found.', previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetSongWiki/GetSongWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetSongWiki/GetSongWikiRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetSongWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetSongWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validationData(): array
+    {
+        return [
+            ...parent::validationData(),
+            'language' => $this->route('language'),
+            'slug' => $this->route('slug'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetTalentWiki/GetTalentWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetTalentWiki/GetTalentWikiAction.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetTalentWiki;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class GetTalentWikiAction
+{
+    public function __construct(
+        private GetTalentWikiInterface $getTalentWiki,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(GetTalentWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetTalentWikiInput(
+                    new Slug($request->slug()),
+                    Language::from($request->language()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $readModel = $this->getTalentWiki->process($input);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Wiki not found.', previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/GetTalentWiki/GetTalentWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/GetTalentWiki/GetTalentWikiRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\GetTalentWiki;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetTalentWikiRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validationData(): array
+    {
+        return [
+            ...parent::validationData(),
+            'language' => $this->route('language'),
+            'slug' => $this->route('slug'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -74,13 +74,21 @@ use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyDraftWiki\GetAgencyDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyDraftWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetGroupDraftWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\GetGroupWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetSongDraftWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\GetSongWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentDraftWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\GetTalentWiki;
 
 class UseCaseServiceProvider extends ServiceProvider
 {
@@ -121,8 +129,12 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RollbackWikiInterface::class, RollbackWiki::class);
         $this->app->singleton(TranslateWikiInterface::class, TranslateWiki::class);
         $this->app->singleton(GetAgencyDraftWikiInterface::class, GetAgencyDraftWiki::class);
+        $this->app->singleton(GetAgencyWikiInterface::class, GetAgencyWiki::class);
         $this->app->singleton(GetGroupDraftWikiInterface::class, GetGroupDraftWiki::class);
+        $this->app->singleton(GetGroupWikiInterface::class, GetGroupWiki::class);
         $this->app->singleton(GetSongDraftWikiInterface::class, GetSongDraftWiki::class);
+        $this->app->singleton(GetSongWikiInterface::class, GetSongWiki::class);
         $this->app->singleton(GetTalentDraftWikiInterface::class, GetTalentDraftWiki::class);
+        $this->app->singleton(GetTalentWikiInterface::class, GetTalentWiki::class);
     }
 }

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -33,9 +33,13 @@ use Application\Http\Action\Wiki\Wiki\Command\RejectWiki\RejectWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RollbackWiki\RollbackWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetAgencyDraftWiki\GetAgencyDraftWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\GetAgencyWiki\GetAgencyWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetGroupDraftWiki\GetGroupDraftWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\GetGroupWiki\GetGroupWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetSongDraftWiki\GetSongDraftWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\GetSongWiki\GetSongWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki\GetTalentDraftWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\GetTalentWiki\GetTalentWikiAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RequestImageHide\RequestImageHideAction;
@@ -53,9 +57,13 @@ Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
 Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
 Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
 Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);
 Route::get('/wiki/{language}/agency/{slug}/draft', GetAgencyDraftWikiAction::class);
+Route::get('/wiki/{language}/group/{slug}', GetGroupWikiAction::class);
 Route::get('/wiki/{language}/group/{slug}/draft', GetGroupDraftWikiAction::class);
+Route::get('/wiki/{language}/song/{slug}', GetSongWikiAction::class);
 Route::get('/wiki/{language}/song/{slug}/draft', GetSongDraftWikiAction::class);
+Route::get('/wiki/{language}/talent/{slug}', GetTalentWikiAction::class);
 Route::get('/wiki/{language}/talent/{slug}/draft', GetTalentDraftWikiAction::class);
 
 // Image

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class GetAgencyWikiInput implements GetAgencyWikiInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+    ) {
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface GetAgencyWikiInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+interface GetAgencyWikiInterface
+{
+    public function process(GetAgencyWikiInputPort $input): WikiReadModel;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class GetGroupWikiInput implements GetGroupWikiInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+    ) {
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface GetGroupWikiInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki;
+
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+interface GetGroupWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetGroupWikiInputPort $input): WikiReadModel;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class GetSongWikiInput implements GetSongWikiInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+    ) {
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface GetSongWikiInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki;
+
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+interface GetSongWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetSongWikiInputPort $input): WikiReadModel;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class GetTalentWikiInput implements GetTalentWikiInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+    ) {
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface GetTalentWikiInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki;
+
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+interface GetTalentWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetTalentWikiInputPort $input): WikiReadModel;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/WikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/WikiReadModel.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query;
+
+readonly class WikiReadModel
+{
+    /**
+     * @param array<string, mixed> $heroImage
+     * @param array<string, mixed> $basic
+     * @param list<array<string, mixed>> $sections
+     */
+    public function __construct(
+        private string $wikiIdentifier,
+        private string $slug,
+        private string $language,
+        private string $resourceType,
+        private int $version,
+        private ?string $themeColor,
+        private array $heroImage,
+        private array $basic,
+        private array $sections,
+    ) {
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return $this->wikiIdentifier;
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function language(): string
+    {
+        return $this->language;
+    }
+
+    public function resourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function version(): int
+    {
+        return $this->version;
+    }
+
+    public function themeColor(): ?string
+    {
+        return $this->themeColor;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function heroImage(): array
+    {
+        return $this->heroImage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function basic(): array
+    {
+        return $this->basic;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function sections(): array
+    {
+        return $this->sections;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'slug' => $this->slug,
+            'language' => $this->language,
+            'resourceType' => $this->resourceType,
+            'version' => $this->version,
+            'themeColor' => $this->themeColor,
+            'heroImage' => $this->heroImage,
+            'basic' => $this->basic,
+            'sections' => $this->sections,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use Application\Models\Wiki\WikiAgencyBasic as WikiAgencyBasicModel;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+readonly class GetAgencyWiki implements GetAgencyWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetAgencyWikiInputPort $input): WikiReadModel
+    {
+        $model = WikiModel::query()
+            ->with(['agencyBasic'])
+            ->where('resource_type', ResourceType::AGENCY->value)
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->first();
+
+        if ($model === null) {
+            throw new WikiNotFoundException("Wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        $basic = $this->agencyBasic($model->agencyBasic);
+
+        return new WikiReadModel(
+            wikiIdentifier: $model->id,
+            slug: $model->slug,
+            language: $model->language,
+            resourceType: ResourceType::AGENCY->value,
+            version: $model->version,
+            themeColor: $model->theme_color,
+            heroImage: [
+                'imageIdentifier' => $basic->logo_image_identifier,
+            ],
+            basic: [
+                'name' => $basic->name,
+                'normalizedName' => $basic->normalized_name,
+                'ceo' => $basic->ceo,
+                'normalizedCeo' => $basic->normalized_ceo,
+                'foundedIn' => $basic->founded_in,
+                'parentAgencyIdentifier' => $basic->parent_agency_identifier,
+                'status' => $basic->status,
+                'logoImageIdentifier' => $basic->logo_image_identifier,
+                'officialWebsite' => $basic->official_website,
+                'socialLinks' => $basic->social_links,
+            ],
+            sections: $model->sections,
+        );
+    }
+
+    private function agencyBasic(?WikiAgencyBasicModel $basic): WikiAgencyBasicModel
+    {
+        if ($basic === null) {
+            throw new InvalidArgumentException('AgencyBasic not found for Wiki.');
+        }
+
+        return $basic;
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use Application\Models\Wiki\WikiGroupBasic as WikiGroupBasicModel;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+readonly class GetGroupWiki implements GetGroupWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetGroupWikiInputPort $input): WikiReadModel
+    {
+        $model = WikiModel::query()
+            ->with(['groupBasic'])
+            ->where('resource_type', ResourceType::GROUP->value)
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->first();
+
+        if ($model === null) {
+            throw new WikiNotFoundException("Wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        $basic = $this->groupBasic($model->groupBasic);
+
+        return new WikiReadModel(
+            wikiIdentifier: $model->id,
+            slug: $model->slug,
+            language: $model->language,
+            resourceType: ResourceType::GROUP->value,
+            version: $model->version,
+            themeColor: $model->theme_color,
+            heroImage: [
+                'imageIdentifier' => $basic->main_image_identifier,
+            ],
+            basic: [
+                'name' => $basic->name,
+                'normalizedName' => $basic->normalized_name,
+                'agencyIdentifier' => $basic->agency_identifier,
+                'groupType' => $basic->group_type,
+                'status' => $basic->status,
+                'generation' => $basic->generation,
+                'debutDate' => $basic->debut_date,
+                'disbandDate' => $basic->disband_date,
+                'fandomName' => $basic->fandom_name,
+                'officialColors' => $basic->official_colors,
+                'emoji' => $basic->emoji,
+                'representativeSymbol' => $basic->representative_symbol,
+                'mainImageIdentifier' => $basic->main_image_identifier,
+            ],
+            sections: $model->sections,
+        );
+    }
+
+    private function groupBasic(?WikiGroupBasicModel $basic): WikiGroupBasicModel
+    {
+        if ($basic === null) {
+            throw new InvalidArgumentException('GroupBasic not found for Wiki.');
+        }
+
+        return $basic;
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use Application\Models\Wiki\WikiSongBasic as WikiSongBasicModel;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+readonly class GetSongWiki implements GetSongWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetSongWikiInputPort $input): WikiReadModel
+    {
+        $model = WikiModel::query()
+            ->with(['songBasic.groups.groupBasic', 'songBasic.talents.talentBasic'])
+            ->where('resource_type', ResourceType::SONG->value)
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->first();
+
+        if ($model === null) {
+            throw new WikiNotFoundException("Wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        $basic = $this->songBasic($model->songBasic);
+
+        return new WikiReadModel(
+            wikiIdentifier: $model->id,
+            slug: $model->slug,
+            language: $model->language,
+            resourceType: ResourceType::SONG->value,
+            version: $model->version,
+            themeColor: $model->theme_color,
+            heroImage: [
+                'imageIdentifier' => $basic->cover_image_identifier,
+            ],
+            basic: [
+                'name' => $basic->name,
+                'normalizedName' => $basic->normalized_name,
+                'songType' => $basic->song_type,
+                'genres' => $basic->genres,
+                'agencyIdentifier' => $basic->agency_identifier,
+                'releaseDate' => $basic->release_date,
+                'albumName' => $basic->album_name,
+                'coverImageIdentifier' => $basic->cover_image_identifier,
+                'lyricist' => $basic->lyricist,
+                'normalizedLyricist' => $basic->normalized_lyricist,
+                'composer' => $basic->composer,
+                'normalizedComposer' => $basic->normalized_composer,
+                'arranger' => $basic->arranger,
+                'normalizedArranger' => $basic->normalized_arranger,
+                'groups' => $basic->groups->map(fn (WikiModel $group) => $this->groupToArray($group))->values()->all(),
+                'talents' => $basic->talents->map(fn (WikiModel $talent) => $this->talentToArray($talent))->values()->all(),
+            ],
+            sections: $model->sections,
+        );
+    }
+
+    private function songBasic(?WikiSongBasicModel $basic): WikiSongBasicModel
+    {
+        if ($basic === null) {
+            throw new InvalidArgumentException('SongBasic not found for Wiki.');
+        }
+
+        return $basic;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function groupToArray(WikiModel $group): array
+    {
+        $basic = $group->groupBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('GroupBasic not found for Wiki.');
+        }
+
+        return [
+            'wikiIdentifier' => $group->id,
+            'slug' => $group->slug,
+            'language' => $group->language,
+            'name' => $basic->name,
+            'normalizedName' => $basic->normalized_name,
+            'agencyIdentifier' => $basic->agency_identifier,
+            'groupType' => $basic->group_type,
+            'status' => $basic->status,
+            'generation' => $basic->generation,
+            'debutDate' => $basic->debut_date,
+            'disbandDate' => $basic->disband_date,
+            'fandomName' => $basic->fandom_name,
+            'officialColors' => $basic->official_colors,
+            'emoji' => $basic->emoji,
+            'representativeSymbol' => $basic->representative_symbol,
+            'mainImageIdentifier' => $basic->main_image_identifier,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function talentToArray(WikiModel $talent): array
+    {
+        $basic = $talent->talentBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('TalentBasic not found for Wiki.');
+        }
+
+        return [
+            'wikiIdentifier' => $talent->id,
+            'slug' => $talent->slug,
+            'language' => $talent->language,
+            'name' => $basic->name,
+            'normalizedName' => $basic->normalized_name,
+            'realName' => $basic->real_name,
+            'normalizedRealName' => $basic->normalized_real_name,
+            'birthday' => $basic->birthday,
+            'agencyIdentifier' => $basic->agency_identifier,
+            'emoji' => $basic->emoji,
+            'representativeSymbol' => $basic->representative_symbol,
+            'position' => $basic->position,
+            'mbti' => $basic->mbti,
+            'zodiacSign' => $basic->zodiac_sign,
+            'englishLevel' => $basic->english_level,
+            'height' => $basic->height,
+            'bloodType' => $basic->blood_type,
+            'fandomName' => $basic->fandom_name,
+            'profileImageIdentifier' => $basic->profile_image_identifier,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+
+readonly class GetTalentWiki implements GetTalentWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(GetTalentWikiInputPort $input): WikiReadModel
+    {
+        $model = WikiModel::query()
+            ->with(['talentBasic.groups.groupBasic'])
+            ->where('resource_type', ResourceType::TALENT->value)
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->first();
+
+        if ($model === null) {
+            throw new WikiNotFoundException("Wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        $basic = $model->talentBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('TalentBasic not found for Wiki.');
+        }
+
+        return new WikiReadModel(
+            wikiIdentifier: $model->id,
+            slug: $model->slug,
+            language: $model->language,
+            resourceType: ResourceType::TALENT->value,
+            version: $model->version,
+            themeColor: $model->theme_color,
+            heroImage: [
+                'imageIdentifier' => $basic->profile_image_identifier,
+            ],
+            basic: [
+                'name' => $basic->name,
+                'normalizedName' => $basic->normalized_name,
+                'realName' => $basic->real_name,
+                'normalizedRealName' => $basic->normalized_real_name,
+                'birthday' => $basic->birthday,
+                'agencyIdentifier' => $basic->agency_identifier,
+                'emoji' => $basic->emoji,
+                'representativeSymbol' => $basic->representative_symbol,
+                'position' => $basic->position,
+                'mbti' => $basic->mbti,
+                'zodiacSign' => $basic->zodiac_sign,
+                'englishLevel' => $basic->english_level,
+                'height' => $basic->height,
+                'bloodType' => $basic->blood_type,
+                'fandomName' => $basic->fandom_name,
+                'profileImageIdentifier' => $basic->profile_image_identifier,
+                'groups' => $basic->groups->map(fn (WikiModel $group) => $this->groupToArray($group))->values()->all(),
+            ],
+            sections: $model->sections,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function groupToArray(WikiModel $group): array
+    {
+        $basic = $group->groupBasic;
+        if ($basic === null) {
+            throw new InvalidArgumentException('GroupBasic not found for Wiki.');
+        }
+
+        return [
+            'wikiIdentifier' => $group->id,
+            'slug' => $group->slug,
+            'language' => $group->language,
+            'name' => $basic->name,
+            'normalizedName' => $basic->normalized_name,
+            'agencyIdentifier' => $basic->agency_identifier,
+            'groupType' => $basic->group_type,
+            'status' => $basic->status,
+            'generation' => $basic->generation,
+            'debutDate' => $basic->debut_date,
+            'disbandDate' => $basic->disband_date,
+            'fandomName' => $basic->fandom_name,
+            'officialColors' => $basic->official_colors,
+            'emoji' => $basic->emoji,
+            'representativeSymbol' => $basic->representative_symbol,
+            'mainImageIdentifier' => $basic->main_image_identifier,
+        ];
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInput;
+use Tests\TestCase;
+
+class GetAgencyWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $slug = new Slug('ag-jyp-entertainment');
+        $language = Language::KOREAN;
+        $input = new GetAgencyWikiInput($slug, $language);
+
+        $this->assertSame((string) $slug, (string) $input->slug());
+        $this->assertSame($language, $input->language());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/GetGroupWiki/GetGroupWikiInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInput;
+use Tests\TestCase;
+
+class GetGroupWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $slug = new Slug('gr-twice');
+        $language = Language::KOREAN;
+        $input = new GetGroupWikiInput($slug, $language);
+
+        $this->assertSame((string) $slug, (string) $input->slug());
+        $this->assertSame($language, $input->language());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/GetSongWiki/GetSongWikiInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\GetSongWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInput;
+use Tests\TestCase;
+
+class GetSongWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $slug = new Slug('sg-signal');
+        $language = Language::KOREAN;
+        $input = new GetSongWikiInput($slug, $language);
+
+        $this->assertSame((string) $slug, (string) $input->slug());
+        $this->assertSame($language, $input->language());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/GetTalentWiki/GetTalentWikiInputTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInput;
+use Tests\TestCase;
+
+class GetTalentWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $slug = new Slug('tl-chaeyoung');
+        $language = Language::KOREAN;
+        $input = new GetTalentWikiInput($slug, $language);
+
+        $this->assertSame((string) $slug, (string) $input->slug());
+        $this->assertSame($language, $input->language());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/WikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/WikiReadModelTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+use Tests\TestCase;
+
+class WikiReadModelTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $readModel = new WikiReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            slug: 'gr-twice',
+            language: 'ko',
+            resourceType: 'group',
+            version: 2,
+            themeColor: '#FE5F8F',
+            heroImage: [
+                'imageIdentifier' => null,
+            ],
+            basic: [
+                'name' => 'TWICE',
+                'normalizedName' => 'twice',
+                'agencyIdentifier' => null,
+                'groupType' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debutDate' => '2015-10-20',
+                'disbandDate' => null,
+                'fandomName' => 'ONCE',
+                'officialColors' => ['#FE5F8F', '#FEE500'],
+                'emoji' => '',
+                'representativeSymbol' => 'Candy Bong',
+                'mainImageIdentifier' => null,
+            ],
+            sections: [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Published sample for checking the TWICE group wiki state.',
+                ],
+            ],
+        );
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('gr-twice', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('group', $readModel->resourceType());
+        $this->assertSame(2, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('TWICE', $readModel->basic()['name']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'slug' => 'gr-twice',
+            'language' => 'ko',
+            'resourceType' => 'group',
+            'version' => 2,
+            'themeColor' => '#FE5F8F',
+            'heroImage' => [
+                'imageIdentifier' => null,
+            ],
+            'basic' => [
+                'name' => 'TWICE',
+                'normalizedName' => 'twice',
+                'agencyIdentifier' => null,
+                'groupType' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debutDate' => '2015-10-20',
+                'disbandDate' => null,
+                'fandomName' => 'ONCE',
+                'officialColors' => ['#FE5F8F', '#FEE500'],
+                'emoji' => '',
+                'representativeSymbol' => 'Candy Bong',
+                'mainImageIdentifier' => null,
+            ],
+            'sections' => [
+                [
+                    'id' => 'overview',
+                    'type' => 'plaintext',
+                    'title' => 'Overview',
+                    'content' => 'Published sample for checking the TWICE group wiki state.',
+                ],
+            ],
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyWikiTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class GetAgencyWikiTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsAgencyWiki(): void
+    {
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            'agency',
+            [
+                'slug' => 'ag-jyp-entertainment',
+                'language' => 'ko',
+                'version' => 3,
+                'theme_color' => '#1A1A1A',
+                'sections' => json_encode([
+                    [
+                        'id' => 'overview',
+                        'type' => 'plaintext',
+                        'title' => 'Overview',
+                        'content' => 'Published sample for checking the agency wiki state.',
+                    ],
+                ]),
+            ],
+            [
+                'name' => 'JYP Entertainment',
+                'normalized_name' => 'jypentertainment',
+                'ceo' => 'J.Y. Park',
+                'normalized_ceo' => 'jypark',
+                'founded_in' => '1997-04-25',
+                'parent_agency_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f403',
+                'status' => 'active',
+                'logo_image_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f404',
+                'official_website' => 'https://www.jype.com',
+                'social_links' => json_encode([
+                    'https://twitter.com/jypnation',
+                    'https://www.instagram.com/jypentertainment/',
+                ]),
+            ],
+        );
+
+        $useCase = $this->app->make(GetAgencyWikiInterface::class);
+        $readModel = $useCase->process(new GetAgencyWikiInput(new Slug('ag-jyp-entertainment'), Language::KOREAN));
+
+        $this->assertInstanceOf(WikiReadModel::class, $readModel);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f401', $readModel->wikiIdentifier());
+        $this->assertSame('ag-jyp-entertainment', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('agency', $readModel->resourceType());
+        $this->assertSame(3, $readModel->version());
+        $this->assertSame('#1A1A1A', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f404'], $readModel->heroImage());
+        $this->assertSame('JYP Entertainment', $readModel->basic()['name']);
+        $this->assertSame('J.Y. Park', $readModel->basic()['ceo']);
+        $this->assertSame('1997-04-25', $readModel->basic()['foundedIn']);
+        $this->assertSame('https://twitter.com/jypnation', $readModel->basic()['socialLinks'][0]);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenAgencyWikiDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetAgencyWikiInterface::class);
+
+        $this->expectException(WikiNotFoundException::class);
+
+        $useCase->process(new GetAgencyWikiInput(new Slug('ag-jyp-entertainment'), Language::KOREAN));
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupWiki\GetGroupWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class GetGroupWikiTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsGroupWiki(): void
+    {
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'group',
+            [
+                'slug' => 'gr-twice',
+                'language' => 'ko',
+                'version' => 2,
+                'theme_color' => '#FE5F8F',
+                'sections' => json_encode([
+                    [
+                        'id' => 'overview',
+                        'type' => 'plaintext',
+                        'title' => 'Overview',
+                        'content' => 'Published sample for checking the TWICE group wiki state.',
+                    ],
+                ]),
+            ],
+            [
+                'name' => 'TWICE',
+                'normalized_name' => 'twice',
+                'group_type' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debut_date' => '2015-10-20',
+                'fandom_name' => 'ONCE',
+                'official_colors' => json_encode(['#FE5F8F', '#FEE500']),
+                'representative_symbol' => 'Candy Bong',
+            ],
+        );
+
+        $useCase = $this->app->make(GetGroupWikiInterface::class);
+        $readModel = $useCase->process(new GetGroupWikiInput(new Slug('gr-twice'), Language::KOREAN));
+
+        $this->assertInstanceOf(WikiReadModel::class, $readModel);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('gr-twice', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('group', $readModel->resourceType());
+        $this->assertSame(2, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('TWICE', $readModel->basic()['name']);
+        $this->assertSame('girl_group', $readModel->basic()['groupType']);
+        $this->assertSame(['#FE5F8F', '#FEE500'], $readModel->basic()['officialColors']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenGroupWikiDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetGroupWikiInterface::class);
+
+        $this->expectException(WikiNotFoundException::class);
+
+        $useCase->process(new GetGroupWikiInput(new Slug('gr-twice'), Language::KOREAN));
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetSongWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetSongWikiTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class GetSongWikiTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsSongWiki(): void
+    {
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'group',
+            [
+                'slug' => 'gr-twice',
+                'language' => 'ko',
+            ],
+            [
+                'name' => 'TWICE',
+                'normalized_name' => 'twice',
+                'group_type' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debut_date' => '2015-10-20',
+                'fandom_name' => 'ONCE',
+                'official_colors' => json_encode(['#FE5F8F', '#FEE500']),
+                'representative_symbol' => 'Candy Bong',
+            ],
+        );
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'talent',
+            [
+                'slug' => 'tl-chaeyoung',
+                'language' => 'ko',
+            ],
+            [
+                'name' => '채영',
+                'normalized_name' => 'chaeyoung',
+                'real_name' => '손채영',
+                'normalized_real_name' => 'sonchaeyoung',
+                'birthday' => '1999-04-23',
+                'representative_symbol' => 'Strawberry Princess',
+                'position' => 'rapper',
+                'mbti' => 'infp',
+                'zodiac_sign' => 'taurus',
+                'height' => 159,
+                'blood_type' => 'B',
+                'fandom_name' => 'ONCE',
+            ],
+        );
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'song',
+            [
+                'slug' => 'sg-signal',
+                'language' => 'ko',
+                'version' => 5,
+                'theme_color' => '#FE5F8F',
+                'sections' => json_encode([
+                    [
+                        'id' => 'overview',
+                        'type' => 'plaintext',
+                        'title' => 'Overview',
+                        'content' => 'Published sample for checking the song wiki state.',
+                    ],
+                ]),
+            ],
+            [
+                'name' => 'TT',
+                'normalized_name' => 'tt',
+                'song_type' => 'title_track',
+                'genres' => json_encode(['dance_pop']),
+                'group_identifiers' => json_encode(['01965bb2-bcc9-7c6f-8b90-89f7f217f002']),
+                'talent_identifiers' => json_encode(['01965bb2-bcc9-7c6f-8b90-89f7f217f101']),
+                'release_date' => '2016-10-24',
+                'album_name' => 'TWICEcoaster: Lane 1',
+                'lyricist' => 'Black Eyed Pilseung',
+                'normalized_lyricist' => 'black eyed pilseung',
+                'composer' => 'Black Eyed Pilseung',
+                'normalized_composer' => 'black eyed pilseung',
+                'arranger' => 'Rado',
+                'normalized_arranger' => 'rado',
+            ],
+        );
+
+        $useCase = $this->app->make(GetSongWikiInterface::class);
+        $readModel = $useCase->process(new GetSongWikiInput(new Slug('sg-signal'), Language::KOREAN));
+
+        $this->assertInstanceOf(WikiReadModel::class, $readModel);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f201', $readModel->wikiIdentifier());
+        $this->assertSame('sg-signal', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('song', $readModel->resourceType());
+        $this->assertSame(5, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('TT', $readModel->basic()['name']);
+        $this->assertSame('title_track', $readModel->basic()['songType']);
+        $this->assertSame(['dance_pop'], $readModel->basic()['genres']);
+        $this->assertSame('TWICE', $readModel->basic()['groups'][0]['name']);
+        $this->assertSame('girl_group', $readModel->basic()['groups'][0]['groupType']);
+        $this->assertSame('채영', $readModel->basic()['talents'][0]['name']);
+        $this->assertSame('rapper', $readModel->basic()['talents'][0]['position']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenSongWikiDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetSongWikiInterface::class);
+
+        $this->expectException(WikiNotFoundException::class);
+
+        $useCase->process(new GetSongWikiInput(new Slug('sg-signal'), Language::KOREAN));
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetTalentWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetTalentWikiTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class GetTalentWikiTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsTalentWiki(): void
+    {
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'group',
+            [
+                'slug' => 'gr-twice',
+                'language' => 'ko',
+            ],
+            [
+                'name' => 'TWICE',
+                'normalized_name' => 'twice',
+                'group_type' => 'girl_group',
+                'status' => 'active',
+                'generation' => '3',
+                'debut_date' => '2015-10-20',
+                'fandom_name' => 'ONCE',
+                'official_colors' => json_encode(['#FE5F8F', '#FEE500']),
+                'representative_symbol' => 'Candy Bong',
+            ],
+        );
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'talent',
+            [
+                'slug' => 'tl-chaeyoung',
+                'language' => 'ko',
+                'version' => 4,
+                'theme_color' => '#FE5F8F',
+                'sections' => json_encode([
+                    [
+                        'id' => 'overview',
+                        'type' => 'plaintext',
+                        'title' => 'Overview',
+                        'content' => 'Published sample for checking the talent wiki state.',
+                    ],
+                ]),
+            ],
+            [
+                'name' => '채영',
+                'normalized_name' => 'chaeyoung',
+                'real_name' => '손채영',
+                'normalized_real_name' => 'sonchaeyoung',
+                'birthday' => '1999-04-23',
+                'representative_symbol' => 'Strawberry Princess',
+                'position' => 'rapper',
+                'mbti' => 'infp',
+                'zodiac_sign' => 'taurus',
+                'height' => 159,
+                'blood_type' => 'B',
+                'fandom_name' => 'ONCE',
+                'group_identifiers' => json_encode(['01965bb2-bcc9-7c6f-8b90-89f7f217f002']),
+            ],
+        );
+
+        $useCase = $this->app->make(GetTalentWikiInterface::class);
+        $readModel = $useCase->process(new GetTalentWikiInput(new Slug('tl-chaeyoung'), Language::KOREAN));
+
+        $this->assertInstanceOf(WikiReadModel::class, $readModel);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f101', $readModel->wikiIdentifier());
+        $this->assertSame('tl-chaeyoung', $readModel->slug());
+        $this->assertSame('ko', $readModel->language());
+        $this->assertSame('talent', $readModel->resourceType());
+        $this->assertSame(4, $readModel->version());
+        $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame(['imageIdentifier' => null], $readModel->heroImage());
+        $this->assertSame('채영', $readModel->basic()['name']);
+        $this->assertSame('손채영', $readModel->basic()['realName']);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->basic()['groups'][0]['wikiIdentifier']);
+        $this->assertSame('TWICE', $readModel->basic()['groups'][0]['name']);
+        $this->assertSame('girl_group', $readModel->basic()['groups'][0]['groupType']);
+        $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWhenTalentWikiDoesNotExist(): void
+    {
+        $useCase = $this->app->make(GetTalentWikiInterface::class);
+
+        $this->expectException(WikiNotFoundException::class);
+
+        $useCase->process(new GetTalentWikiInput(new Slug('tl-chaeyoung'), Language::KOREAN));
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

公開済み Wiki を `slug` / `language` から取得する Query を追加しました。

- agency / group / song / talent の公開 Wiki 取得 API を追加
- 公開 Wiki 用の Input / InputPort / Interface / Infrastructure Query を追加
- Draft 版と同等の `WikiReadModel` 形式でレスポンスを返却
- song は関連 group / talent、talent は所属 group を含めて取得
- 追加 Query を `UseCaseServiceProvider` に DI 登録
- 各 Query / Input / ReadModel のテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Draft Wiki 取得 Query は揃っていましたが、公開済み Wiki を同じ read model 形式で取得する経路が不足していました。公開 Wiki 表示や公開データ確認で利用できるように、Draft 版の構成に倣って公開 Wiki 用 Query を追加しました。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Draft 版 Query と同等のレスポンス構造になっているか
- song / talent の関連 Wiki 取得と eager load が適切か
- 未存在時の `WikiNotFoundException` と HTTP 例外変換が既存パターンに沿っているか

## 📖 関連情報

### 関連Issue・タスク

Closes #340

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
