### PR TITLE
Wiki一覧取得エンドポイントを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/ListWikis/ListWikisAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListWikis/ListWikisAction.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListWikis;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class ListWikisAction
+{
+    public function __construct(
+        private ListWikisInterface $listWikis,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ListWikisRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ListWikisInput(
+                    perPage: $request->perPage(),
+                    resourceType: $request->resourceType(),
+                    keyword: $request->keyword(),
+                    sort: $request->sort(),
+                    order: $request->order(),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            $output = new ListWikisOutput();
+            $this->listWikis->process($input, $output);
+        } catch (UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/ListWikis/ListWikisRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListWikis/ListWikisRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListWikis;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+class ListWikisRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'resourceType' => ['nullable', 'string', Rule::in([
+                ResourceType::AGENCY->value,
+                ResourceType::GROUP->value,
+                ResourceType::TALENT->value,
+                ResourceType::SONG->value,
+            ])],
+            'keyword' => ['nullable', 'string'],
+            'sort' => ['nullable', 'string', Rule::in(['updatedAt', 'name'])],
+            'order' => ['nullable', 'string', Rule::in(['asc', 'desc'])],
+        ];
+    }
+
+    public function perPage(): ?int
+    {
+        $perPage = $this->query('perPage');
+
+        return $perPage === null ? null : (int) $perPage;
+    }
+
+    public function resourceType(): ?string
+    {
+        $resourceType = $this->query('resourceType');
+
+        return $resourceType === null ? null : (string) $resourceType;
+    }
+
+    public function keyword(): ?string
+    {
+        $keyword = $this->query('keyword');
+
+        return $keyword === null ? null : (string) $keyword;
+    }
+
+    public function sort(): ?string
+    {
+        $sort = $this->query('sort');
+
+        return $sort === null ? null : (string) $sort;
+    }
+
+    public function order(): ?string
+    {
+        $order = $this->query('order');
+
+        return $order === null ? null : (string) $order;
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -81,6 +81,7 @@ use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWiki
 use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetGroupDraftWiki;
@@ -89,6 +90,7 @@ use Source\Wiki\Wiki\Infrastructure\Query\GetSongDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetSongWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\ListWikis;
 
 class UseCaseServiceProvider extends ServiceProvider
 {
@@ -136,5 +138,6 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(GetSongWikiInterface::class, GetSongWiki::class);
         $this->app->singleton(GetTalentDraftWikiInterface::class, GetTalentDraftWiki::class);
         $this->app->singleton(GetTalentWikiInterface::class, GetTalentWiki::class);
+        $this->app->singleton(ListWikisInterface::class, ListWikis::class);
     }
 }

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -40,6 +40,7 @@ use Application\Http\Action\Wiki\Wiki\Query\GetSongDraftWiki\GetSongDraftWikiAct
 use Application\Http\Action\Wiki\Wiki\Query\GetSongWiki\GetSongWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki\GetTalentDraftWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentWiki\GetTalentWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\ListWikis\ListWikisAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RequestImageHide\RequestImageHideAction;
@@ -57,6 +58,7 @@ Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
 Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
 Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
 Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+Route::get('/wikis', ListWikisAction::class);
 Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);
 Route::get('/wiki/{language}/agency/{slug}/draft', GetAgencyDraftWikiAction::class);
 Route::get('/wiki/{language}/group/{slug}', GetGroupWikiAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInput.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListWikis;
+
+readonly class ListWikisInput implements ListWikisInputPort
+{
+    public function __construct(
+        private ?int $perPage = null,
+        private ?string $resourceType = null,
+        private ?string $keyword = null,
+        private ?string $sort = null,
+        private ?string $order = null,
+    ) {
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage ?? 10;
+    }
+
+    public function resourceType(): ?string
+    {
+        return $this->resourceType;
+    }
+
+    public function keyword(): ?string
+    {
+        return $this->keyword;
+    }
+
+    public function sort(): string
+    {
+        return $this->sort ?? 'updatedAt';
+    }
+
+    public function order(): string
+    {
+        return $this->order ?? 'desc';
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInputPort.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListWikis;
+
+interface ListWikisInputPort
+{
+    public function perPage(): int;
+
+    public function resourceType(): ?string;
+
+    public function keyword(): ?string;
+
+    public function sort(): string;
+
+    public function order(): string;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListWikis;
+
+interface ListWikisInterface
+{
+    public function process(ListWikisInputPort $input, ListWikisOutputPort $output): void;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutput.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+
+class ListWikisOutput implements ListWikisOutputPort
+{
+    /** @var list<WikiListItemReadModel> */
+    private array $wikis = [];
+
+    private ?int $currentPage = null;
+
+    private ?int $lastPage = null;
+
+    private ?int $total = null;
+
+    private ?int $perPage = null;
+
+    /**
+     * @param list<WikiListItemReadModel> $wikis
+     */
+    public function output(array $wikis, int $currentPage, int $lastPage, int $total, int $perPage): void
+    {
+        $this->wikis = $wikis;
+        $this->currentPage = $currentPage;
+        $this->lastPage = $lastPage;
+        $this->total = $total;
+        $this->perPage = $perPage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikis' => array_map(static fn (WikiListItemReadModel $wiki): array => $wiki->toArray(), $this->wikis),
+            'current_page' => $this->currentPage,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'per_page' => $this->perPage,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+
+interface ListWikisOutputPort
+{
+    /**
+     * @param list<WikiListItemReadModel> $wikis
+     */
+    public function output(array $wikis, int $currentPage, int $lastPage, int $total, int $perPage): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query;
+
+readonly class WikiListItemReadModel
+{
+    public function __construct(
+        private string $wikiIdentifier,
+        private string $slug,
+        private string $language,
+        private string $resourceType,
+        private int $version,
+        private ?string $themeColor,
+        private string $name,
+        private string $normalizedName,
+        private ?string $publishedAt,
+        private ?string $updatedAt,
+    ) {
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return $this->wikiIdentifier;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'slug' => $this->slug,
+            'language' => $this->language,
+            'resourceType' => $this->resourceType,
+            'version' => $this->version,
+            'themeColor' => $this->themeColor,
+            'name' => $this->name,
+            'normalizedName' => $this->normalizedName,
+            'publishedAt' => $this->publishedAt,
+            'updatedAt' => $this->updatedAt,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use Application\Models\Wiki\WikiAgencyBasic;
+use Application\Models\Wiki\WikiGroupBasic;
+use Application\Models\Wiki\WikiSongBasic;
+use Application\Models\Wiki\WikiTalentBasic;
+use DateTimeInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisOutputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+
+readonly class ListWikis implements ListWikisInterface
+{
+    /** @var array<string, array{relation: string, table: string}> */
+    private const BASIC_TABLES = [
+        ResourceType::TALENT->value => ['relation' => 'talentBasic', 'table' => 'wiki_talent_basics'],
+        ResourceType::GROUP->value => ['relation' => 'groupBasic', 'table' => 'wiki_group_basics'],
+        ResourceType::AGENCY->value => ['relation' => 'agencyBasic', 'table' => 'wiki_agency_basics'],
+        ResourceType::SONG->value => ['relation' => 'songBasic', 'table' => 'wiki_song_basics'],
+    ];
+
+    public function process(ListWikisInputPort $input, ListWikisOutputPort $output): void
+    {
+        $query = WikiModel::query()
+            ->select('wikis.*')
+            ->with(['talentBasic', 'groupBasic', 'agencyBasic', 'songBasic']);
+
+        $this->joinBasicTables($query);
+
+        if ($input->resourceType() !== null) {
+            $query->where('wikis.resource_type', $input->resourceType());
+        } else {
+            $query->whereIn('wikis.resource_type', array_keys(self::BASIC_TABLES));
+        }
+
+        if ($input->keyword() !== null && $input->keyword() !== '') {
+            $this->applyKeywordSearch($query, $input->keyword(), $input->resourceType());
+        }
+
+        $this->applySort($query, $input->sort(), $input->order());
+
+        /** @var LengthAwarePaginator<int, WikiModel> $paginator */
+        $paginator = $query->paginate($input->perPage());
+
+        $output->output(
+            array_map(
+                fn (WikiModel $wiki): WikiListItemReadModel => $this->toReadModel($wiki),
+                $paginator->items(),
+            ),
+            $paginator->currentPage(),
+            $paginator->lastPage(),
+            $paginator->total(),
+            $paginator->perPage(),
+        );
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function joinBasicTables(Builder $query): void
+    {
+        foreach (self::BASIC_TABLES as $basic) {
+            $query->leftJoin($basic['table'], "{$basic['table']}.wiki_id", '=', 'wikis.id');
+        }
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyKeywordSearch(Builder $query, string $keyword, ?string $resourceType): void
+    {
+        $query->where(function (Builder $query) use ($keyword, $resourceType): void {
+            foreach ($this->targetBasicTables($resourceType) as $type => $basic) {
+                $query->orWhere(function (Builder $query) use ($type, $basic, $keyword): void {
+                    $query->where('wikis.resource_type', $type)
+                        ->where("{$basic['table']}.normalized_name", 'like', $keyword . '%');
+                });
+            }
+        });
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applySort(Builder $query, string $sort, string $order): void
+    {
+        if ($sort === 'name') {
+            $query->orderBy(DB::raw($this->nameSortExpression()), $order)
+                ->orderBy('wikis.updated_at', 'desc');
+
+            return;
+        }
+
+        $query->orderBy('wikis.updated_at', $order);
+    }
+
+    private function nameSortExpression(): string
+    {
+        return 'COALESCE(wiki_talent_basics.name, wiki_group_basics.name, wiki_agency_basics.name, wiki_song_basics.name)';
+    }
+
+    /**
+     * @return array<string, array{relation: string, table: string}>
+     */
+    private function targetBasicTables(?string $resourceType): array
+    {
+        if ($resourceType === null) {
+            return self::BASIC_TABLES;
+        }
+
+        return [$resourceType => self::BASIC_TABLES[$resourceType]];
+    }
+
+    private function toReadModel(WikiModel $wiki): WikiListItemReadModel
+    {
+        $basic = $this->basicModel($wiki);
+
+        return new WikiListItemReadModel(
+            wikiIdentifier: $wiki->id,
+            slug: $wiki->slug,
+            language: $wiki->language,
+            resourceType: $wiki->resource_type,
+            version: $wiki->version,
+            themeColor: $wiki->theme_color,
+            name: (string) $basic->getAttribute('name'),
+            normalizedName: (string) $basic->getAttribute('normalized_name'),
+            publishedAt: $this->formatDateTime($wiki->published_at),
+            updatedAt: $this->formatDateTime($wiki->updated_at),
+        );
+    }
+
+    private function basicModel(WikiModel $wiki): Model
+    {
+        $relation = self::BASIC_TABLES[$wiki->resource_type]['relation'] ?? null;
+        if ($relation === null) {
+            throw new InvalidArgumentException("Unsupported wiki resource type: {$wiki->resource_type}");
+        }
+
+        $basic = $wiki->{$relation};
+        if (
+            ! $basic instanceof WikiTalentBasic
+            && ! $basic instanceof WikiGroupBasic
+            && ! $basic instanceof WikiAgencyBasic
+            && ! $basic instanceof WikiSongBasic
+        ) {
+            throw new InvalidArgumentException("Basic not found for Wiki: {$wiki->id}");
+        }
+
+        return $basic;
+    }
+
+    private function formatDateTime(mixed $dateTime): ?string
+    {
+        if ($dateTime === null) {
+            return null;
+        }
+
+        if ($dateTime instanceof DateTimeInterface) {
+            return $dateTime->format(DateTimeInterface::ATOM);
+        }
+
+        return (string) $dateTime;
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisInputTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInput;
+use Tests\TestCase;
+
+class ListWikisInputTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $input = new ListWikisInput();
+
+        $this->assertSame(10, $input->perPage());
+        $this->assertNull($input->resourceType());
+        $this->assertNull($input->keyword());
+        $this->assertSame('updatedAt', $input->sort());
+        $this->assertSame('desc', $input->order());
+    }
+
+    public function testAccessors(): void
+    {
+        $input = new ListWikisInput(
+            perPage: 20,
+            resourceType: 'talent',
+            keyword: 'chae',
+            sort: 'name',
+            order: 'asc',
+        );
+
+        $this->assertSame(20, $input->perPage());
+        $this->assertSame('talent', $input->resourceType());
+        $this->assertSame('chae', $input->keyword());
+        $this->assertSame('name', $input->sort());
+        $this->assertSame('asc', $input->order());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutputTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisOutput;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+use Tests\TestCase;
+
+class ListWikisOutputTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $item = new WikiListItemReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            slug: 'tl-chaeyoung',
+            language: 'ko',
+            resourceType: 'talent',
+            version: 2,
+            themeColor: '#FE5F8F',
+            name: 'Chaeyoung',
+            normalizedName: 'chaeyoung',
+            publishedAt: '2026-05-01T00:00:00+00:00',
+            updatedAt: '2026-05-02T00:00:00+00:00',
+        );
+
+        $output = new ListWikisOutput();
+        $output->output([$item], 1, 3, 5, 2);
+
+        $this->assertSame([
+            'wikis' => [$item->toArray()],
+            'current_page' => 1,
+            'last_page' => 3,
+            'total' => 5,
+            'per_page' => 2,
+        ], $output->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModelTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+use Tests\TestCase;
+
+class WikiListItemReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $readModel = new WikiListItemReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            slug: 'tl-chaeyoung',
+            language: 'ko',
+            resourceType: 'talent',
+            version: 2,
+            themeColor: '#FE5F8F',
+            name: 'Chaeyoung',
+            normalizedName: 'chaeyoung',
+            publishedAt: '2026-05-01T00:00:00+00:00',
+            updatedAt: '2026-05-02T00:00:00+00:00',
+        );
+
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'slug' => 'tl-chaeyoung',
+            'language' => 'ko',
+            'resourceType' => 'talent',
+            'version' => 2,
+            'themeColor' => '#FE5F8F',
+            'name' => 'Chaeyoung',
+            'normalizedName' => 'chaeyoung',
+            'publishedAt' => '2026-05-01T00:00:00+00:00',
+            'updatedAt' => '2026-05-02T00:00:00+00:00',
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Http/Action/Query/ListWikis/ListWikisActionTest.php
+++ b/tests/Wiki/Wiki/Http/Action/Query/ListWikis/ListWikisActionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Http\Action\Query\ListWikis;
+
+use Application\Http\Action\Wiki\Wiki\Query\ListWikis\ListWikisAction;
+use Application\Http\Action\Wiki\Wiki\Query\ListWikis\ListWikisRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Mockery;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisOutput;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class ListWikisActionTest extends TestCase
+{
+    public function testInvokeReturnsOkResponse(): void
+    {
+        /** @var ListWikisRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(ListWikisRequest::class);
+        $request->shouldReceive('perPage')->andReturn(10);
+        $request->shouldReceive('resourceType')->andReturn('talent');
+        $request->shouldReceive('keyword')->andReturn('chae');
+        $request->shouldReceive('sort')->andReturn('name');
+        $request->shouldReceive('order')->andReturn('asc');
+
+        /** @var ListWikisInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(ListWikisInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(Mockery::type(ListWikisInput::class), Mockery::type(ListWikisOutput::class))
+            ->andReturnUsing(static function (ListWikisInput $input, ListWikisOutput $output): void {
+                $output->output([
+                    new WikiListItemReadModel(
+                        wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+                        slug: 'tl-chaeyoung',
+                        language: 'ko',
+                        resourceType: 'talent',
+                        version: 1,
+                        themeColor: null,
+                        name: 'Chaeyoung',
+                        normalizedName: 'chaeyoung',
+                        publishedAt: null,
+                        updatedAt: '2026-05-01T00:00:00+00:00',
+                    ),
+                ], 1, 1, 1, 10);
+            });
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $response = (new ListWikisAction($useCase, $logger))($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f101', $payload['wikis'][0]['wikiIdentifier']);
+        $this->assertArrayNotHasKey('sections', $payload['wikis'][0]);
+        $this->assertSame(10, $payload['per_page']);
+    }
+
+    #[Group('useDb')]
+    public function testEndpointReturnsOkWithoutAuthentication(): void
+    {
+        $this->loadWikiRoutes();
+
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'talent',
+            [
+                'slug' => 'tl-chaeyoung',
+                'language' => 'ko',
+            ],
+            [
+                'name' => 'Chaeyoung',
+                'normalized_name' => 'chaeyoung',
+            ],
+        );
+        DB::table('wikis')
+            ->where('id', '01965bb2-bcc9-7c6f-8b90-89f7f217f201')
+            ->update(['updated_at' => '2026-05-01 00:00:00']);
+
+        $response = $this->getJson('/api/wiki/wikis?resourceType=talent&keyword=chae');
+
+        $response->assertOk();
+        $response->assertJsonPath('total', 1);
+        $response->assertJsonPath('wikis.0.name', 'Chaeyoung');
+        $response->assertJsonMissingPath('wikis.0.sections');
+    }
+
+    public function testEndpointReturnsValidationError(): void
+    {
+        $this->loadWikiRoutes();
+
+        $response = $this->getJson('/api/wiki/wikis?resourceType=image&sort=unknown&order=sideways&perPage=0');
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['resourceType', 'sort', 'order', 'perPage']);
+    }
+
+    private function loadWikiRoutes(): void
+    {
+        Route::middleware(['api'])
+            ->prefix('api/wiki')
+            ->group(dirname(__DIR__, 7) . '/routes/wiki_private_api.php');
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListWikisTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisOutput;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class ListWikisTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsDefaultPaginationSortedByUpdatedAtDesc(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f101', 'talent', 'tl-alpha', 'Alpha', 'alpha', '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f102', 'group', 'gr-beta', 'Beta', 'beta', '2026-05-03 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f103', 'agency', 'ag-gamma', 'Gamma', 'gamma', '2026-05-02 00:00:00');
+
+        $payload = $this->process(new ListWikisInput())->toArray();
+
+        $this->assertSame(1, $payload['current_page']);
+        $this->assertSame(1, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+        $this->assertSame(10, $payload['per_page']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+        $this->assertArrayNotHasKey('sections', $payload['wikis'][0]);
+    }
+
+    #[Group('useDb')]
+    public function testProcessAppliesPerPage(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f201', 'talent', 'tl-alpha', 'Alpha', 'alpha', '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f202', 'group', 'gr-beta', 'Beta', 'beta', '2026-05-02 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f203', 'agency', 'ag-gamma', 'Gamma', 'gamma', '2026-05-03 00:00:00');
+
+        $payload = $this->process(new ListWikisInput(perPage: 2))->toArray();
+
+        $this->assertCount(2, $payload['wikis']);
+        $this->assertSame(2, $payload['per_page']);
+        $this->assertSame(2, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByResourceType(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f301', 'talent', 'tl-alpha', 'Alpha', 'alpha', '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f302', 'group', 'gr-beta', 'Beta', 'beta', '2026-05-02 00:00:00');
+
+        $payload = $this->process(new ListWikisInput(resourceType: 'group'))->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame('group', $payload['wikis'][0]['resourceType']);
+        $this->assertSame('Beta', $payload['wikis'][0]['name']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessSearchesKeywordByNormalizedNamePrefix(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f401', 'talent', 'tl-chaeyoung', 'Chaeyoung', 'chaeyoung', '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f402', 'agency', 'ag-chae-agency', 'Chae Agency', 'chaeagency', '2026-05-02 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f403', 'group', 'gr-twice', 'TWICE', 'twice', '2026-05-03 00:00:00');
+
+        $payload = $this->process(new ListWikisInput(keyword: 'chae', sort: 'name', order: 'asc'))->toArray();
+
+        $this->assertSame(2, $payload['total']);
+        $this->assertSame(['Chae Agency', 'Chaeyoung'], array_column($payload['wikis'], 'name'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessSortsByNameAndOrder(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f501', 'talent', 'tl-charlie', 'Charlie', 'charlie', '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f502', 'song', 'sg-alpha', 'Alpha', 'alpha', '2026-05-02 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f503', 'group', 'gr-bravo', 'Bravo', 'bravo', '2026-05-03 00:00:00');
+
+        $payload = $this->process(new ListWikisInput(sort: 'name', order: 'desc'))->toArray();
+
+        $this->assertSame(['Charlie', 'Bravo', 'Alpha'], array_column($payload['wikis'], 'name'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessSortsByUpdatedAtAscending(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f601', 'talent', 'tl-alpha', 'Alpha', 'alpha', '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f602', 'group', 'gr-beta', 'Beta', 'beta', '2026-05-02 00:00:00');
+
+        $payload = $this->process(new ListWikisInput(sort: 'updatedAt', order: 'asc'))->toArray();
+
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f602',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+    }
+
+    private function listWikis(): ListWikisInterface
+    {
+        return $this->app->make(ListWikisInterface::class);
+    }
+
+    private function process(ListWikisInput $input): ListWikisOutput
+    {
+        $output = new ListWikisOutput();
+        $this->listWikis()->process($input, $output);
+
+        return $output;
+    }
+
+    private function createWiki(
+        string $wikiId,
+        string $resourceType,
+        string $slug,
+        string $name,
+        string $normalizedName,
+        string $updatedAt,
+    ): void {
+        CreateWiki::create(
+            $wikiId,
+            $resourceType,
+            [
+                'slug' => $slug,
+                'language' => 'ko',
+                'published_at' => '2026-04-01 00:00:00',
+            ],
+            [
+                'name' => $name,
+                'normalized_name' => $normalizedName,
+            ],
+        );
+
+        DB::table('wikis')
+            ->where('id', $wikiId)
+            ->update([
+                'updated_at' => $updatedAt,
+                'created_at' => $updatedAt,
+            ]);
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

Wikiの一覧取得APIを追加しました。

- `GET /api/wiki/wikis` を追加
- `perPage`, `resourceType`, `keyword`, `sort`, `order` による絞り込み・並び替えに対応
- 一覧用の `WikiListItemReadModel` とページネーション付き出力を追加
- Talent / Group / Agency / Song の各 basic 情報を参照して一覧表示用の名前情報を返却
- Action / UseCase / Infrastructure Query のテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

管理画面などからWikiを検索・一覧表示するため、公開済み/下書き取得とは別に、軽量な一覧取得用QueryとAPIエンドポイントが必要になったためです。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `ListWikis` の検索条件・ソート条件が期待する一覧仕様に合っているか
- `resourceType` 未指定時に Talent / Group / Agency / Song のみを対象にしている点
- レスポンス項目が一覧用途として過不足ないか
- `GET /api/wiki/wikis` のルート位置とバリデーション仕様

## 📖 関連情報

### 関連Issue・タスク

Closes #342

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した