### PR TITLE
Wiki画像一覧取得APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Image/Query/ListUploadedImages/ListUploadedImagesAction.php
+++ b/application/Http/Action/Wiki/Image/Query/ListUploadedImages/ListUploadedImagesAction.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Query\ListUploadedImages;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Illuminate\Http\JsonResponse;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInput;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ListUploadedImagesAction
+{
+    public function __construct(
+        private ListUploadedImagesInterface $listUploadedImages,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ListUploadedImagesRequest $request): JsonResponse
+    {
+        try {
+            $input = new ListUploadedImagesInput(
+                perPage: $request->perPage(),
+                wikiIdentifier: $request->wikiIdentifier(),
+            );
+            $output = new ListUploadedImagesOutput();
+            $this->listUploadedImages->process($input, $output);
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Query/ListUploadedImages/ListUploadedImagesRequest.php
+++ b/application/Http/Action/Wiki/Image/Query/ListUploadedImages/ListUploadedImagesRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Query\ListUploadedImages;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListUploadedImagesRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'wikiIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function perPage(): ?int
+    {
+        $perPage = $this->query('perPage');
+
+        return $perPage === null ? null : (int) $perPage;
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return (string) $this->query('wikiIdentifier');
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -21,6 +21,8 @@ use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImage;
 use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageInterface;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImage;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInterface;
+use Source\Wiki\Image\Infrastructure\Query\ListUploadedImages;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertification;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInterface;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\RejectCertification\RejectCertification;
@@ -120,6 +122,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RequestImageHideInterface::class, RequestImageHide::class);
         $this->app->singleton(ApproveImageHideRequestInterface::class, ApproveImageHideRequest::class);
         $this->app->singleton(RejectImageHideRequestInterface::class, RejectImageHideRequest::class);
+        $this->app->singleton(ListUploadedImagesInterface::class, ListUploadedImages::class);
         $this->app->singleton(CreateWikiInterface::class, CreateWiki::class);
         $this->app->singleton(AutoCreateWikiInterface::class, AutoCreateWiki::class);
         $this->app->singleton(EditWikiInterface::class, EditWiki::class);

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -365,6 +365,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /images:
+    get:
+      operationId: ImageListOperations_listUploadedImages
+      description: List uploaded images.
+      parameters:
+        - name: wikiIdentifier
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          explode: false
+        - name: perPage
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+          explode: false
+      responses:
+        '200':
+          description: Response returned when uploaded image list retrieval succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListUploadedImagesResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /official-certification/request:
     post:
       operationId: OfficialCertificationOperations_requestCertification
@@ -2187,6 +2230,37 @@ components:
       type: string
       format: uuid
       description: UUID identifier.
+    ListUploadedImagesResponseBody:
+      type: object
+      required:
+        - images
+        - current_page
+        - last_page
+        - total
+        - per_page
+      properties:
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/UploadedImageListItem'
+          description: Uploaded images for the requested page.
+        current_page:
+          type: integer
+          format: int32
+          description: Current page number.
+        last_page:
+          type: integer
+          format: int32
+          description: Last page number.
+        total:
+          type: integer
+          format: int32
+          description: Total number of uploaded images.
+        per_page:
+          type: integer
+          format: int32
+          description: Number of images per page.
+      description: Response body for the uploaded image list endpoint.
     ListWikisResponseBody:
       type: object
       required:
@@ -3061,6 +3135,59 @@ components:
           type: string
           description: Timestamp when the uploader agreed to the terms.
       description: Request body for uploading an image.
+    UploadedImageListItem:
+      type: object
+      required:
+        - imageIdentifier
+        - url
+        - resourceType
+        - wikiIdentifier
+        - imageUsage
+        - displayOrder
+        - sourceUrl
+        - sourceName
+        - altText
+        - isHidden
+        - uploadedAt
+      properties:
+        imageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Image identifier.
+        url:
+          type: string
+          description: Absolute image URL.
+        resourceType:
+          type: string
+          description: Resource type that the image belongs to.
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Wiki identifier that the image belongs to.
+        imageUsage:
+          type: string
+          description: Usage category of the image.
+        displayOrder:
+          type: integer
+          format: int32
+          description: Display order of the image.
+        sourceUrl:
+          type: string
+          description: Original source URL of the image.
+        sourceName:
+          type: string
+          description: Original source name of the image.
+        altText:
+          type: string
+          description: Alternative text for the image.
+        isHidden:
+          type: boolean
+          description: Whether the image is hidden.
+        uploadedAt:
+          type: string
+          nullable: true
+          description: Timestamp when the image was uploaded.
+      description: Uploaded image item returned by the uploaded image list endpoint.
     VideoLinkInput:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -7,6 +7,7 @@ use Application\Http\Action\Wiki\Image\Command\DeleteImage\DeleteImageAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImage\RejectImageAction;
 use Application\Http\Action\Wiki\Image\Command\UnhideImage\UnhideImageAction;
 use Application\Http\Action\Wiki\Image\Command\UploadImage\UploadImageAction;
+use Application\Http\Action\Wiki\Image\Query\ListUploadedImages\ListUploadedImagesAction;
 use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupAction;
@@ -69,6 +70,7 @@ Route::get('/wiki/{language}/talent/{slug}', GetTalentWikiAction::class);
 Route::get('/wiki/{language}/talent/{slug}/draft', GetTalentDraftWikiAction::class);
 
 // Image
+Route::get('/images', ListUploadedImagesAction::class)->middleware('auth.api');
 Route::post('/image/{imageId}/approve', ApproveImageAction::class);
 Route::delete('/image/{imageId}', DeleteImageAction::class);
 Route::post('/image/{imageId}/reject', RejectImageAction::class);

--- a/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInput.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInput.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages;
+
+readonly class ListUploadedImagesInput implements ListUploadedImagesInputPort
+{
+    public function __construct(
+        private string $wikiIdentifier,
+        private ?int $perPage = null,
+    ) {
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage ?? 10;
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return $this->wikiIdentifier;
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages;
+
+interface ListUploadedImagesInputPort
+{
+    public function perPage(): int;
+
+    public function wikiIdentifier(): string;
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInterface.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages;
+
+interface ListUploadedImagesInterface
+{
+    public function process(ListUploadedImagesInputPort $input, ListUploadedImagesOutputPort $output): void;
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesOutput.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\UploadedImageReadModel;
+
+class ListUploadedImagesOutput implements ListUploadedImagesOutputPort
+{
+    /** @var list<UploadedImageReadModel> */
+    private array $images = [];
+
+    private ?int $currentPage = null;
+
+    private ?int $lastPage = null;
+
+    private ?int $total = null;
+
+    private ?int $perPage = null;
+
+    /**
+     * @param list<UploadedImageReadModel> $images
+     */
+    public function output(array $images, int $currentPage, int $lastPage, int $total, int $perPage): void
+    {
+        $this->images = $images;
+        $this->currentPage = $currentPage;
+        $this->lastPage = $lastPage;
+        $this->total = $total;
+        $this->perPage = $perPage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'images' => array_map(static fn (UploadedImageReadModel $image): array => $image->toArray(), $this->images),
+            'current_page' => $this->currentPage,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'per_page' => $this->perPage,
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\UploadedImageReadModel;
+
+interface ListUploadedImagesOutputPort
+{
+    /**
+     * @param list<UploadedImageReadModel> $images
+     */
+    public function output(array $images, int $currentPage, int $lastPage, int $total, int $perPage): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Image/Application/UseCase/Query/UploadedImageReadModel.php
+++ b/src/Wiki/Image/Application/UseCase/Query/UploadedImageReadModel.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query;
+
+readonly class UploadedImageReadModel
+{
+    public function __construct(
+        private string $imageIdentifier,
+        private string $url,
+        private string $resourceType,
+        private string $wikiIdentifier,
+        private string $imageUsage,
+        private int $displayOrder,
+        private string $sourceUrl,
+        private string $sourceName,
+        private string $altText,
+        private bool $isHidden,
+        private ?string $uploadedAt,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'imageIdentifier' => $this->imageIdentifier,
+            'url' => $this->url,
+            'resourceType' => $this->resourceType,
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'imageUsage' => $this->imageUsage,
+            'displayOrder' => $this->displayOrder,
+            'sourceUrl' => $this->sourceUrl,
+            'sourceName' => $this->sourceName,
+            'altText' => $this->altText,
+            'isHidden' => $this->isHidden,
+            'uploadedAt' => $this->uploadedAt,
+        ];
+    }
+}

--- a/src/Wiki/Image/Infrastructure/Query/ListUploadedImages.php
+++ b/src/Wiki/Image/Infrastructure/Query/ListUploadedImages.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Infrastructure\Query;
+
+use Application\Models\Wiki\WikiImage;
+use DateTimeInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInputPort;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesOutputPort;
+use Source\Wiki\Image\Application\UseCase\Query\UploadedImageReadModel;
+
+readonly class ListUploadedImages implements ListUploadedImagesInterface
+{
+    public function process(ListUploadedImagesInputPort $input, ListUploadedImagesOutputPort $output): void
+    {
+        /** @var LengthAwarePaginator<int, WikiImage> $paginator */
+        $paginator = WikiImage::query()
+            ->where('wiki_id', $input->wikiIdentifier())
+            ->orderBy('uploaded_at', 'desc')
+            ->paginate($input->perPage());
+
+        $output->output(
+            array_map(
+                fn (WikiImage $image): UploadedImageReadModel => $this->toReadModel($image),
+                $paginator->items(),
+            ),
+            $paginator->currentPage(),
+            $paginator->lastPage(),
+            $paginator->total(),
+            $paginator->perPage(),
+        );
+    }
+
+    private function toReadModel(WikiImage $image): UploadedImageReadModel
+    {
+        return new UploadedImageReadModel(
+            imageIdentifier: $image->id,
+            url: url($image->image_path),
+            resourceType: $image->resource_type,
+            wikiIdentifier: $image->wiki_id,
+            imageUsage: $image->image_usage,
+            displayOrder: $image->display_order,
+            sourceUrl: $image->source_url,
+            sourceName: $image->source_name,
+            altText: $image->alt_text,
+            isHidden: $image->is_hidden,
+            uploadedAt: $this->formatDateTime($image->uploaded_at),
+        );
+    }
+
+    private function formatDateTime(mixed $dateTime): ?string
+    {
+        if ($dateTime === null) {
+            return null;
+        }
+
+        if ($dateTime instanceof DateTimeInterface) {
+            return $dateTime->format(DateTimeInterface::ATOM);
+        }
+
+        return (string) $dateTime;
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesInputTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query\ListUploadedImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInput;
+use Tests\TestCase;
+
+class ListUploadedImagesInputTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $input = new ListUploadedImagesInput(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+        );
+
+        $this->assertSame(10, $input->perPage());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f101', $input->wikiIdentifier());
+    }
+
+    public function testAccessors(): void
+    {
+        $input = new ListUploadedImagesInput(
+            perPage: 20,
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+        );
+
+        $this->assertSame(20, $input->perPage());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f102', $input->wikiIdentifier());
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ListUploadedImages/ListUploadedImagesOutputTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query\ListUploadedImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesOutput;
+use Source\Wiki\Image\Application\UseCase\Query\UploadedImageReadModel;
+use Tests\TestCase;
+
+class ListUploadedImagesOutputTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $image = new UploadedImageReadModel(
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            url: 'https://example.com/images/talents/profile.jpg',
+            resourceType: 'talent',
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            imageUsage: 'profile',
+            displayOrder: 1,
+            sourceUrl: 'https://example.com/source',
+            sourceName: 'Example Source',
+            altText: 'Profile image',
+            isHidden: false,
+            uploadedAt: '2026-05-01T00:00:00+00:00',
+        );
+
+        $output = new ListUploadedImagesOutput();
+        $output->output([$image], 1, 3, 5, 2);
+
+        $this->assertSame([
+            'images' => [$image->toArray()],
+            'current_page' => 1,
+            'last_page' => 3,
+            'total' => 5,
+            'per_page' => 2,
+        ], $output->toArray());
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/UploadedImageReadModelTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/UploadedImageReadModelTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query;
+
+use Source\Wiki\Image\Application\UseCase\Query\UploadedImageReadModel;
+use Tests\TestCase;
+
+class UploadedImageReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $readModel = new UploadedImageReadModel(
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            url: 'https://example.com/images/talents/profile.jpg',
+            resourceType: 'talent',
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            imageUsage: 'profile',
+            displayOrder: 1,
+            sourceUrl: 'https://example.com/source',
+            sourceName: 'Example Source',
+            altText: 'Profile image',
+            isHidden: false,
+            uploadedAt: '2026-05-01T00:00:00+00:00',
+        );
+
+        $this->assertSame([
+            'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'url' => 'https://example.com/images/talents/profile.jpg',
+            'resourceType' => 'talent',
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'imageUsage' => 'profile',
+            'displayOrder' => 1,
+            'sourceUrl' => 'https://example.com/source',
+            'sourceName' => 'Example Source',
+            'altText' => 'Profile image',
+            'isHidden' => false,
+            'uploadedAt' => '2026-05-01T00:00:00+00:00',
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Image/Infrastructure/Query/ListUploadedImagesTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListUploadedImagesTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInput;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesOutput;
+use Tests\Helper\CreateImage;
+use Tests\TestCase;
+
+class ListUploadedImagesTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsDefaultPaginationSortedByUploadedAtDesc(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f101', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+            'image_path' => '/images/talents/alpha.jpg',
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f102', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+            'image_path' => '/images/talents/beta.jpg',
+            'uploaded_at' => '2026-05-03 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f103', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+            'image_path' => '/images/talents/gamma.jpg',
+            'uploaded_at' => '2026-05-02 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListUploadedImagesInput(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+        ))->toArray();
+
+        $this->assertSame(1, $payload['current_page']);
+        $this->assertSame(1, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+        $this->assertSame(10, $payload['per_page']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+        ], array_column($payload['images'], 'imageIdentifier'));
+        $this->assertSame('http://localhost:8080/images/talents/beta.jpg', $payload['images'][0]['url']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessAppliesPerPage(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f201', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f202', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'uploaded_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f203', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'uploaded_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListUploadedImagesInput(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            perPage: 2,
+        ))->toArray();
+
+        $this->assertCount(2, $payload['images']);
+        $this->assertSame(2, $payload['per_page']);
+        $this->assertSame(2, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByWikiIdentifier(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f301', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f302', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f402',
+            'uploaded_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f303', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            'uploaded_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListUploadedImagesInput(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+        ))->toArray();
+
+        $this->assertSame(2, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f303',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+        ], array_column($payload['images'], 'imageIdentifier'));
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+        ], array_column($payload['images'], 'wikiIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsImageMetadata(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f501', [
+            'resource_type' => 'group',
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'image_path' => '/images/groups/cover.jpg',
+            'image_usage' => 'cover',
+            'display_order' => 2,
+            'source_url' => 'https://example.com/source-image',
+            'source_name' => 'Source Name',
+            'alt_text' => 'Cover image',
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListUploadedImagesInput(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+        ))->toArray();
+
+        $this->assertSame([
+            'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f501',
+            'url' => 'http://localhost:8080/images/groups/cover.jpg',
+            'resourceType' => 'group',
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'imageUsage' => 'cover',
+            'displayOrder' => 2,
+            'sourceUrl' => 'https://example.com/source-image',
+            'sourceName' => 'Source Name',
+            'altText' => 'Cover image',
+            'isHidden' => false,
+            'uploadedAt' => '2026-05-01T00:00:00+00:00',
+        ], $payload['images'][0]);
+    }
+
+    private function listUploadedImages(): ListUploadedImagesInterface
+    {
+        return $this->app->make(ListUploadedImagesInterface::class);
+    }
+
+    private function process(ListUploadedImagesInput $input): ListUploadedImagesOutput
+    {
+        $output = new ListUploadedImagesOutput();
+        $this->listUploadedImages()->process($input, $output);
+
+        return $output;
+    }
+}

--- a/typespec/services/wiki-private-api/image.tsp
+++ b/typespec/services/wiki-private-api/image.tsp
@@ -43,6 +43,52 @@ model ReviewImageHideRequestBody {
   reviewerComment: string;
 }
 
+@doc("Uploaded image item returned by the uploaded image list endpoint.")
+model UploadedImageListItem {
+  @doc("Image identifier.")
+  imageIdentifier: Uuid;
+  @doc("Absolute image URL.")
+  url: string;
+  @doc("Resource type that the image belongs to.")
+  resourceType: string;
+  @doc("Wiki identifier that the image belongs to.")
+  wikiIdentifier: Uuid;
+  @doc("Usage category of the image.")
+  imageUsage: string;
+  @doc("Display order of the image.")
+  displayOrder: int32;
+  @doc("Original source URL of the image.")
+  sourceUrl: string;
+  @doc("Original source name of the image.")
+  sourceName: string;
+  @doc("Alternative text for the image.")
+  altText: string;
+  @doc("Whether the image is hidden.")
+  isHidden: boolean;
+  @doc("Timestamp when the image was uploaded.")
+  uploadedAt: string | null;
+}
+
+@doc("Response body for the uploaded image list endpoint.")
+model ListUploadedImagesResponseBody {
+  @doc("Uploaded images for the requested page.")
+  images: UploadedImageListItem[];
+  @doc("Current page number.")
+  current_page: int32;
+  @doc("Last page number.")
+  last_page: int32;
+  @doc("Total number of uploaded images.")
+  total: int32;
+  @doc("Number of images per page.")
+  per_page: int32;
+}
+
+@doc("Response returned when uploaded image list retrieval succeeds.")
+model ListUploadedImagesResponse {
+  @statusCode statusCode: 200;
+  @body body: ListUploadedImagesResponseBody;
+}
+
 @doc("Response returned when a draft image is created.")
 model CreateDraftImageResponse {
   @statusCode statusCode: 201;
@@ -127,4 +173,14 @@ interface ImageOperations {
     @path imageId: Uuid,
     @body body: ReviewImageHideRequestBody,
   ): ReviewImageHideRequestResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+
+@route("/images")
+interface ImageListOperations {
+  @get
+  @doc("List uploaded images.")
+  listUploadedImages(
+    @query wikiIdentifier: Uuid,
+    @query perPage?: int32,
+  ): ListUploadedImagesResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- Wikiに紐づくアップロード済み画像一覧を取得する `GET /images` API を追加
- `wikiIdentifier` による絞り込みと `perPage` によるページング指定に対応
- 画像メタデータを返す ReadModel / Output / Query 実装を追加
- Wiki Private API の TypeSpec / OpenAPI 定義を更新
- 入力、出力、ReadModel、DB Query のテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki管理側で、対象Wikiにアップロード済みの画像を一覧取得できるようにするため。
画像ID、URL、用途、表示順、出典、alt、非表示状態、アップロード日時など、画面表示や管理に必要なメタデータを取得できるようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行結果:

- PHP CS Fixer: 変更なし
- PHPStan: No errors
- PHPUnit: OK (2571 tests, 8208 assertions)

## 🔍 レビューのポイント

- `GET /images` の認証ミドルウェア設定が妥当か
- `wikiIdentifier` / `perPage` のバリデーションがAPI仕様と一致しているか
- 画像一覧のソート順が `uploaded_at desc` で問題ないか
- レスポンス項目と TypeSpec / OpenAPI 定義の整合性
- `url($image->image_path)` による画像URL生成が期待仕様に合っているか

## 📖 関連情報

### 関連Issue・タスク

Closes #348

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
