### PR TITLE
グループ下書きWikiのnullable契約を修正

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2075,8 +2075,10 @@ components:
           type: string
           description: Normalized name of the group.
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         groupType:
           type: string
@@ -2094,6 +2096,7 @@ components:
         disbandDate:
           type: string
           format: date
+          nullable: true
           description: Disband date of the group.
         fandomName:
           type: string
@@ -2110,8 +2113,10 @@ components:
           type: string
           description: Representative symbol of the group.
         mainImageIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Main image identifier of the group.
       description: Basic payload for a group draft wiki.
     ImageDraftSummary:

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -50,7 +50,7 @@ model GroupDraftWikiBasic {
   @doc("Normalized name of the group.")
   normalizedName: string;
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier?: Uuid | null;
   @doc("Group type.")
   groupType: string;
   @doc("Current activity status of the group.")
@@ -60,7 +60,7 @@ model GroupDraftWikiBasic {
   @doc("Debut date of the group.")
   debutDate?: plainDate;
   @doc("Disband date of the group.")
-  disbandDate?: plainDate;
+  disbandDate?: plainDate | null;
   @doc("Fandom name of the group.")
   fandomName: string;
   @doc("Official colors of the group.")
@@ -70,7 +70,7 @@ model GroupDraftWikiBasic {
   @doc("Representative symbol of the group.")
   representativeSymbol: string;
   @doc("Main image identifier of the group.")
-  mainImageIdentifier?: Uuid;
+  mainImageIdentifier?: Uuid | null;
 }
 
 @doc("Detailed draft wiki payload used by the editor.")


### PR DESCRIPTION
## 📝 変更内容

グループ下書きWiki取得レスポンスの `GroupDraftWikiBasic` で、実レスポンスが `null` を返す項目を TypeSpec/OpenAPI 上でも nullable として定義しました。

- `agencyIdentifier`
- `disbandDate`
- `mainImageIdentifier`

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

`GET /wiki/{language}/group/{slug}/draft` のレスポンスで、該当項目が `null` の場合に Zodios のレスポンス検証で `Expected string, received null` が発生していました。

バックエンドの実レスポンスではキーを省略せず `null` を返すため、API契約を実装に合わせます。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

確認内容:

- `task openapi-generate` を実行し、TypeSpec から OpenAPI を正常に生成できることを確認

## 🔍 レビューのポイント

- `GroupDraftWikiBasic` の nullable 定義が実レスポンスと一致していること
- 生成後の OpenAPI に `nullable: true` が反映されていること
- リクエスト共通定義など不要な契約変更が含まれていないこと

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
