### PR TITLE
DraftImage一覧取得APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Image/Query/ListDraftImages/ListDraftImagesAction.php
+++ b/application/Http/Action/Wiki/Image/Query/ListDraftImages/ListDraftImagesAction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Query\ListDraftImages;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Illuminate\Http\JsonResponse;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInput;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesOutput;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ListDraftImagesAction
+{
+    public function __construct(
+        private ListDraftImagesInterface $listDraftImages,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ListDraftImagesRequest $request): JsonResponse
+    {
+        try {
+            $input = new ListDraftImagesInput(
+                wikiIdentifier: $request->wikiIdentifier() !== null ? new WikiIdentifier($request->wikiIdentifier()) : null,
+                status: ApprovalStatus::from($request->status()),
+                perPage: $request->perPage(),
+            );
+            $output = new ListDraftImagesOutput();
+            $this->listDraftImages->process($input, $output);
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Query/ListDraftImages/ListDraftImagesRequest.php
+++ b/application/Http/Action/Wiki/Image/Query/ListDraftImages/ListDraftImagesRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Query\ListDraftImages;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+
+class ListDraftImagesRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'wikiIdentifier' => ['nullable', 'uuid'],
+            'status' => ['required', 'string', Rule::in(array_column(ApprovalStatus::cases(), 'value'))],
+        ];
+    }
+
+    public function perPage(): ?int
+    {
+        $perPage = $this->query('perPage');
+
+        return $perPage === null ? null : (int) $perPage;
+    }
+
+    public function wikiIdentifier(): ?string
+    {
+        $wikiIdentifier = $this->query('wikiIdentifier');
+
+        return $wikiIdentifier === null ? null : (string) $wikiIdentifier;
+    }
+
+    public function status(): string
+    {
+        return (string) $this->query('status');
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -21,7 +21,9 @@ use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImage;
 use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageInterface;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImage;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInterface;
 use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInterface;
+use Source\Wiki\Image\Infrastructure\Query\ListDraftImages;
 use Source\Wiki\Image\Infrastructure\Query\ListUploadedImages;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertification;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInterface;
@@ -122,6 +124,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RequestImageHideInterface::class, RequestImageHide::class);
         $this->app->singleton(ApproveImageHideRequestInterface::class, ApproveImageHideRequest::class);
         $this->app->singleton(RejectImageHideRequestInterface::class, RejectImageHideRequest::class);
+        $this->app->singleton(ListDraftImagesInterface::class, ListDraftImages::class);
         $this->app->singleton(ListUploadedImagesInterface::class, ListUploadedImages::class);
         $this->app->singleton(CreateWikiInterface::class, CreateWiki::class);
         $this->app->singleton(AutoCreateWikiInterface::class, AutoCreateWiki::class);

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -4,6 +4,58 @@ info:
   version: 0.0.0
 tags: []
 paths:
+  /draft-images:
+    get:
+      operationId: DraftImageListOperations_listDraftImages
+      description: List draft images.
+      parameters:
+        - name: wikiIdentifier
+          in: query
+          required: false
+          schema:
+            type: string
+            allOf:
+              - $ref: '#/components/schemas/KPool.Common.Uuid'
+            nullable: true
+          explode: false
+        - name: status
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/DraftImageStatus'
+          explode: false
+        - name: perPage
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+          explode: false
+      responses:
+        '200':
+          description: Response returned when draft image list retrieval succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListDraftImagesResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /image/upload:
     post:
       operationId: ImageOperations_uploadImage
@@ -1978,6 +2030,75 @@ components:
       allOf:
         - $ref: '#/components/schemas/WikiAssociationTargets'
       description: Request body for creating a wiki draft.
+    DraftImageListItem:
+      type: object
+      required:
+        - imageIdentifier
+        - publishedImageIdentifier
+        - url
+        - resourceType
+        - wikiIdentifier
+        - imageUsage
+        - displayOrder
+        - sourceUrl
+        - sourceName
+        - altText
+        - status
+        - uploadedAt
+      properties:
+        imageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Draft image identifier.
+        publishedImageIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
+          description: Published image identifier linked to this draft.
+        url:
+          type: string
+          description: Absolute image URL.
+        resourceType:
+          type: string
+          description: Resource type that the image belongs to.
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Wiki identifier that the image belongs to.
+        imageUsage:
+          type: string
+          description: Usage category of the image.
+        displayOrder:
+          type: integer
+          format: int32
+          description: Display order of the image.
+        sourceUrl:
+          type: string
+          description: Original source URL of the image.
+        sourceName:
+          type: string
+          description: Original source name of the image.
+        altText:
+          type: string
+          description: Alternative text for the image.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/DraftImageStatus'
+          description: Approval status of the draft image.
+        uploadedAt:
+          type: string
+          nullable: true
+          description: Timestamp when the image was uploaded.
+      description: Draft image item returned by the draft image list endpoint.
+    DraftImageStatus:
+      type: string
+      enum:
+        - approved
+        - pending
+        - rejected
+        - under_review
+      description: Approval status assigned to a draft image.
     DraftWikiDetail:
       type: object
       required:
@@ -2235,6 +2356,37 @@ components:
       type: string
       format: uuid
       description: UUID identifier.
+    ListDraftImagesResponseBody:
+      type: object
+      required:
+        - images
+        - current_page
+        - last_page
+        - total
+        - per_page
+      properties:
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/DraftImageListItem'
+          description: Draft images for the requested page.
+        current_page:
+          type: integer
+          format: int32
+          description: Current page number.
+        last_page:
+          type: integer
+          format: int32
+          description: Last page number.
+        total:
+          type: integer
+          format: int32
+          description: Total number of draft images.
+        per_page:
+          type: integer
+          format: int32
+          description: Number of images per page.
+      description: Response body for the draft image list endpoint.
     ListUploadedImagesResponseBody:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -7,6 +7,7 @@ use Application\Http\Action\Wiki\Image\Command\DeleteImage\DeleteImageAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImage\RejectImageAction;
 use Application\Http\Action\Wiki\Image\Command\UnhideImage\UnhideImageAction;
 use Application\Http\Action\Wiki\Image\Command\UploadImage\UploadImageAction;
+use Application\Http\Action\Wiki\Image\Query\ListDraftImages\ListDraftImagesAction;
 use Application\Http\Action\Wiki\Image\Query\ListUploadedImages\ListUploadedImagesAction;
 use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleAction;
@@ -70,6 +71,7 @@ Route::get('/wiki/{language}/talent/{slug}', GetTalentWikiAction::class);
 Route::get('/wiki/{language}/talent/{slug}/draft', GetTalentDraftWikiAction::class);
 
 // Image
+Route::get('/draft-images', ListDraftImagesAction::class)->middleware('auth.api');
 Route::get('/images', ListUploadedImagesAction::class)->middleware('auth.api');
 Route::post('/image/{imageId}/approve', ApproveImageAction::class);
 Route::delete('/image/{imageId}', DeleteImageAction::class);

--- a/src/Wiki/Image/Application/UseCase/Query/DraftImageReadModel.php
+++ b/src/Wiki/Image/Application/UseCase/Query/DraftImageReadModel.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query;
+
+readonly class DraftImageReadModel
+{
+    public function __construct(
+        private string $imageIdentifier,
+        private ?string $publishedImageIdentifier,
+        private string $url,
+        private string $resourceType,
+        private string $wikiIdentifier,
+        private string $imageUsage,
+        private int $displayOrder,
+        private string $sourceUrl,
+        private string $sourceName,
+        private string $altText,
+        private string $status,
+        private ?string $uploadedAt,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'imageIdentifier' => $this->imageIdentifier,
+            'publishedImageIdentifier' => $this->publishedImageIdentifier,
+            'url' => $this->url,
+            'resourceType' => $this->resourceType,
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'imageUsage' => $this->imageUsage,
+            'displayOrder' => $this->displayOrder,
+            'sourceUrl' => $this->sourceUrl,
+            'sourceName' => $this->sourceName,
+            'altText' => $this->altText,
+            'status' => $this->status,
+            'uploadedAt' => $this->uploadedAt,
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInput.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInput.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListDraftImages;
+
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+
+readonly class ListDraftImagesInput implements ListDraftImagesInputPort
+{
+    public function __construct(
+        private ApprovalStatus $status,
+        private ?WikiIdentifier $wikiIdentifier = null,
+        private ?int $perPage = null,
+    ) {
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage ?? 10;
+    }
+
+    public function wikiIdentifier(): ?WikiIdentifier
+    {
+        return $this->wikiIdentifier;
+    }
+
+    public function status(): ApprovalStatus
+    {
+        return $this->status;
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListDraftImages;
+
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+
+interface ListDraftImagesInputPort
+{
+    public function perPage(): int;
+
+    public function wikiIdentifier(): ?WikiIdentifier;
+
+    public function status(): ApprovalStatus;
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInterface.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListDraftImages;
+
+interface ListDraftImagesInterface
+{
+    public function process(ListDraftImagesInputPort $input, ListDraftImagesOutputPort $output): void;
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutput.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListDraftImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\DraftImageReadModel;
+
+class ListDraftImagesOutput implements ListDraftImagesOutputPort
+{
+    /** @var list<DraftImageReadModel> */
+    private array $images = [];
+
+    private ?int $currentPage = null;
+
+    private ?int $lastPage = null;
+
+    private ?int $total = null;
+
+    private ?int $perPage = null;
+
+    /**
+     * @param list<DraftImageReadModel> $images
+     */
+    public function output(array $images, int $currentPage, int $lastPage, int $total, int $perPage): void
+    {
+        $this->images = $images;
+        $this->currentPage = $currentPage;
+        $this->lastPage = $lastPage;
+        $this->total = $total;
+        $this->perPage = $perPage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'images' => array_map(static fn (DraftImageReadModel $image): array => $image->toArray(), $this->images),
+            'current_page' => $this->currentPage,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'per_page' => $this->perPage,
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListDraftImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\DraftImageReadModel;
+
+interface ListDraftImagesOutputPort
+{
+    /**
+     * @param list<DraftImageReadModel> $images
+     */
+    public function output(array $images, int $currentPage, int $lastPage, int $total, int $perPage): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Image/Infrastructure/Query/ListDraftImages.php
+++ b/src/Wiki/Image/Infrastructure/Query/ListDraftImages.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Infrastructure\Query;
+
+use Application\Models\Wiki\DraftWikiImage;
+use DateTimeInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Source\Wiki\Image\Application\UseCase\Query\DraftImageReadModel;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInputPort;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesOutputPort;
+
+readonly class ListDraftImages implements ListDraftImagesInterface
+{
+    public function process(ListDraftImagesInputPort $input, ListDraftImagesOutputPort $output): void
+    {
+        $query = DraftWikiImage::query()
+            ->where('status', $input->status()->value)
+            ->orderBy('uploaded_at', 'desc');
+
+        if ($input->wikiIdentifier() !== null) {
+            $query->where('wiki_id', (string) $input->wikiIdentifier());
+        }
+
+        /** @var LengthAwarePaginator<int, DraftWikiImage> $paginator */
+        $paginator = $query->paginate($input->perPage());
+
+        $output->output(
+            array_map(
+                fn (DraftWikiImage $image): DraftImageReadModel => $this->toReadModel($image),
+                $paginator->items(),
+            ),
+            $paginator->currentPage(),
+            $paginator->lastPage(),
+            $paginator->total(),
+            $paginator->perPage(),
+        );
+    }
+
+    private function toReadModel(DraftWikiImage $image): DraftImageReadModel
+    {
+        return new DraftImageReadModel(
+            imageIdentifier: $image->id,
+            publishedImageIdentifier: $image->published_id,
+            url: url($image->image_path),
+            resourceType: $image->resource_type,
+            wikiIdentifier: $image->wiki_id,
+            imageUsage: $image->image_usage,
+            displayOrder: $image->display_order,
+            sourceUrl: $image->source_url,
+            sourceName: $image->source_name,
+            altText: $image->alt_text,
+            status: $image->status,
+            uploadedAt: $this->formatDateTime($image->uploaded_at),
+        );
+    }
+
+    private function formatDateTime(mixed $dateTime): ?string
+    {
+        if ($dateTime === null) {
+            return null;
+        }
+
+        if ($dateTime instanceof DateTimeInterface) {
+            return $dateTime->format(DateTimeInterface::ATOM);
+        }
+
+        return (string) $dateTime;
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/DraftImageReadModelTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/DraftImageReadModelTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query;
+
+use Source\Wiki\Image\Application\UseCase\Query\DraftImageReadModel;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Tests\TestCase;
+
+class DraftImageReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $readModel = new DraftImageReadModel(
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            publishedImageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            url: 'https://example.com/images/talents/profile.jpg',
+            resourceType: 'talent',
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            imageUsage: 'profile',
+            displayOrder: 1,
+            sourceUrl: 'https://example.com/source',
+            sourceName: 'Example Source',
+            altText: 'Profile image',
+            status: ApprovalStatus::UnderReview->value,
+            uploadedAt: '2026-05-01T00:00:00+00:00',
+        );
+
+        $this->assertSame([
+            'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'publishedImageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            'url' => 'https://example.com/images/talents/profile.jpg',
+            'resourceType' => 'talent',
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'imageUsage' => 'profile',
+            'displayOrder' => 1,
+            'sourceUrl' => 'https://example.com/source',
+            'sourceName' => 'Example Source',
+            'altText' => 'Profile image',
+            'status' => ApprovalStatus::UnderReview->value,
+            'uploadedAt' => '2026-05-01T00:00:00+00:00',
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesInputTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query\ListDraftImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInput;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\TestCase;
+
+class ListDraftImagesInputTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $input = new ListDraftImagesInput(
+            status: ApprovalStatus::UnderReview,
+        );
+
+        $this->assertSame(10, $input->perPage());
+        $this->assertNull($input->wikiIdentifier());
+        $this->assertSame(ApprovalStatus::UnderReview, $input->status());
+    }
+
+    public function testAccessors(): void
+    {
+        $input = new ListDraftImagesInput(
+            status: ApprovalStatus::Pending,
+            wikiIdentifier: new WikiIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f102'),
+            perPage: 20,
+        );
+
+        $this->assertSame(20, $input->perPage());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f102', (string) $input->wikiIdentifier());
+        $this->assertSame(ApprovalStatus::Pending, $input->status());
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutputTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query\ListDraftImages;
+
+use Source\Wiki\Image\Application\UseCase\Query\DraftImageReadModel;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesOutput;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Tests\TestCase;
+
+class ListDraftImagesOutputTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $image = new DraftImageReadModel(
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            publishedImageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            url: 'https://example.com/images/talents/profile.jpg',
+            resourceType: 'talent',
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            imageUsage: 'profile',
+            displayOrder: 1,
+            sourceUrl: 'https://example.com/source',
+            sourceName: 'Example Source',
+            altText: 'Profile image',
+            status: ApprovalStatus::Pending->value,
+            uploadedAt: '2026-05-01T00:00:00+00:00',
+        );
+
+        $output = new ListDraftImagesOutput();
+        $output->output([$image], 1, 3, 5, 2);
+
+        $this->assertSame([
+            'images' => [$image->toArray()],
+            'current_page' => 1,
+            'last_page' => 3,
+            'total' => 5,
+            'per_page' => 2,
+        ], $output->toArray());
+    }
+}

--- a/tests/Wiki/Image/Infrastructure/Query/ListDraftImagesTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListDraftImagesTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInput;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesOutput;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\CreateDraftImage;
+use Tests\TestCase;
+
+class ListDraftImagesTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessFiltersByStatusSortedByUploadedAtDesc(): void
+    {
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f101', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+            'status' => ApprovalStatus::UnderReview->value,
+            'image_path' => '/images/talents/alpha.jpg',
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f102', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+            'status' => ApprovalStatus::UnderReview->value,
+            'image_path' => '/images/talents/beta.jpg',
+            'uploaded_at' => '2026-05-03 00:00:00',
+        ]);
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f103', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+            'status' => ApprovalStatus::Pending->value,
+            'uploaded_at' => '2026-05-04 00:00:00',
+        ]);
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f104', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'status' => ApprovalStatus::UnderReview->value,
+            'uploaded_at' => '2026-05-05 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftImagesInput(
+            status: ApprovalStatus::UnderReview,
+        ))->toArray();
+
+        $this->assertSame(1, $payload['current_page']);
+        $this->assertSame(1, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+        $this->assertSame(10, $payload['per_page']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f104',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+        ], array_column($payload['images'], 'imageIdentifier'));
+        $this->assertSame('http://localhost:8080/images/test/sample.jpg', $payload['images'][0]['url']);
+        $this->assertSame([
+            ApprovalStatus::UnderReview->value,
+            ApprovalStatus::UnderReview->value,
+            ApprovalStatus::UnderReview->value,
+        ], array_column($payload['images'], 'status'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByWikiIdentifierWhenSpecified(): void
+    {
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f301', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            'status' => ApprovalStatus::UnderReview->value,
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f302', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f402',
+            'status' => ApprovalStatus::UnderReview->value,
+            'uploaded_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f303', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            'status' => ApprovalStatus::Pending->value,
+            'uploaded_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftImagesInput(
+            status: ApprovalStatus::UnderReview,
+            wikiIdentifier: new WikiIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f401'),
+        ))->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+        ], array_column($payload['images'], 'imageIdentifier'));
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+        ], array_column($payload['images'], 'wikiIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessAppliesPerPage(): void
+    {
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f201', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'status' => ApprovalStatus::Pending->value,
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f202', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'status' => ApprovalStatus::Pending->value,
+            'uploaded_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f203', [
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'status' => ApprovalStatus::Pending->value,
+            'uploaded_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftImagesInput(
+            status: ApprovalStatus::Pending,
+            wikiIdentifier: new WikiIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f902'),
+            perPage: 2,
+        ))->toArray();
+
+        $this->assertCount(2, $payload['images']);
+        $this->assertSame(2, $payload['per_page']);
+        $this->assertSame(2, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsDraftImageMetadata(): void
+    {
+        CreateDraftImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f501', [
+            'published_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
+            'resource_type' => 'group',
+            'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'image_path' => '/images/groups/cover.jpg',
+            'image_usage' => 'cover',
+            'display_order' => 2,
+            'source_url' => 'https://example.com/source-image',
+            'source_name' => 'Source Name',
+            'alt_text' => 'Cover image',
+            'status' => ApprovalStatus::Approved->value,
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftImagesInput(
+            status: ApprovalStatus::Approved,
+            wikiIdentifier: new WikiIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f601'),
+        ))->toArray();
+
+        $this->assertSame([
+            'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f501',
+            'publishedImageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
+            'url' => 'http://localhost:8080/images/groups/cover.jpg',
+            'resourceType' => 'group',
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'imageUsage' => 'cover',
+            'displayOrder' => 2,
+            'sourceUrl' => 'https://example.com/source-image',
+            'sourceName' => 'Source Name',
+            'altText' => 'Cover image',
+            'status' => ApprovalStatus::Approved->value,
+            'uploadedAt' => '2026-05-01T00:00:00+00:00',
+        ], $payload['images'][0]);
+    }
+
+    private function listDraftImages(): ListDraftImagesInterface
+    {
+        return $this->app->make(ListDraftImagesInterface::class);
+    }
+
+    private function process(ListDraftImagesInput $input): ListDraftImagesOutput
+    {
+        $output = new ListDraftImagesOutput();
+        $this->listDraftImages()->process($input, $output);
+
+        return $output;
+    }
+}

--- a/typespec/services/wiki-private-api/image.tsp
+++ b/typespec/services/wiki-private-api/image.tsp
@@ -69,6 +69,42 @@ model UploadedImageListItem {
   uploadedAt: string | null;
 }
 
+@doc("Approval status assigned to a draft image.")
+union DraftImageStatus {
+  "approved",
+  "pending",
+  "rejected",
+  "under_review",
+}
+
+@doc("Draft image item returned by the draft image list endpoint.")
+model DraftImageListItem {
+  @doc("Draft image identifier.")
+  imageIdentifier: Uuid;
+  @doc("Published image identifier linked to this draft.")
+  publishedImageIdentifier: Uuid | null;
+  @doc("Absolute image URL.")
+  url: string;
+  @doc("Resource type that the image belongs to.")
+  resourceType: string;
+  @doc("Wiki identifier that the image belongs to.")
+  wikiIdentifier: Uuid;
+  @doc("Usage category of the image.")
+  imageUsage: string;
+  @doc("Display order of the image.")
+  displayOrder: int32;
+  @doc("Original source URL of the image.")
+  sourceUrl: string;
+  @doc("Original source name of the image.")
+  sourceName: string;
+  @doc("Alternative text for the image.")
+  altText: string;
+  @doc("Approval status of the draft image.")
+  status: DraftImageStatus;
+  @doc("Timestamp when the image was uploaded.")
+  uploadedAt: string | null;
+}
+
 @doc("Response body for the uploaded image list endpoint.")
 model ListUploadedImagesResponseBody {
   @doc("Uploaded images for the requested page.")
@@ -83,10 +119,30 @@ model ListUploadedImagesResponseBody {
   per_page: int32;
 }
 
+@doc("Response body for the draft image list endpoint.")
+model ListDraftImagesResponseBody {
+  @doc("Draft images for the requested page.")
+  images: DraftImageListItem[];
+  @doc("Current page number.")
+  current_page: int32;
+  @doc("Last page number.")
+  last_page: int32;
+  @doc("Total number of draft images.")
+  total: int32;
+  @doc("Number of images per page.")
+  per_page: int32;
+}
+
 @doc("Response returned when uploaded image list retrieval succeeds.")
 model ListUploadedImagesResponse {
   @statusCode statusCode: 200;
   @body body: ListUploadedImagesResponseBody;
+}
+
+@doc("Response returned when draft image list retrieval succeeds.")
+model ListDraftImagesResponse {
+  @statusCode statusCode: 200;
+  @body body: ListDraftImagesResponseBody;
 }
 
 @doc("Response returned when a draft image is created.")
@@ -183,4 +239,15 @@ interface ImageListOperations {
     @query wikiIdentifier: Uuid,
     @query perPage?: int32,
   ): ListUploadedImagesResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+
+@route("/draft-images")
+interface DraftImageListOperations {
+  @get
+  @doc("List draft images.")
+  listDraftImages(
+    @query wikiIdentifier?: Uuid | null,
+    @query status: DraftImageStatus,
+    @query perPage?: int32,
+  ): ListDraftImagesResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- Wiki Private API に `GET /draft-images` を追加
- `status` 必須、`wikiIdentifier` / `perPage` 任意のクエリで下書き画像を一覧取得
- DraftImage 用の ReadModel / Input / Output / Query 実装を追加
- TypeSpec と OpenAPI 定義に DraftImage 一覧レスポンスを追加
- ReadModel、Input、Output、DBクエリのテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

下書き画像を管理画面などから確認できるようにするため、ステータス別・Wiki別に絞り込める一覧取得APIを追加します。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `status` 必須、`wikiIdentifier` / `perPage` 任意のリクエスト仕様
- `uploaded_at desc` での並び順とページネーション
- DraftImage のレスポンス項目と OpenAPI / TypeSpec 定義の整合性
- `auth.api` ミドルウェア付きでルーティングされていること

## 📖 関連情報

### 関連Issue・タスク

Closes #352

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
