### PR TITLE
Wiki current principal 取得APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Principal/Query/GetCurrentPrincipal/GetCurrentPrincipalAction.php
+++ b/application/Http/Action/Wiki/Principal/Query/GetCurrentPrincipal/GetCurrentPrincipalAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Query\GetCurrentPrincipal;
+
+use Application\Http\Context\ActorContext;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Illuminate\Http\JsonResponse;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInput;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class GetCurrentPrincipalAction
+{
+    public function __construct(
+        private GetCurrentPrincipalInterface $getCurrentPrincipal,
+        private ActorContext $actorContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(): JsonResponse
+    {
+        try {
+            try {
+                $input = new GetCurrentPrincipalInput($this->actorContext->identityIdentifier);
+                $readModel = $this->getCurrentPrincipal->process($input);
+            } catch (PrincipalNotFoundException $e) {
+                throw new NotFoundHttpException(detail: error_message('principal_not_found', $this->actorContext->language->value), previous: $e);
+            }
+        } catch (NotFoundHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($readModel->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -57,6 +57,8 @@ use Source\Wiki\Principal\Application\UseCase\Command\DetachRoleFromPrincipalGro
 use Source\Wiki\Principal\Application\UseCase\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupInterface;
 use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroup;
 use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInterface;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
+use Source\Wiki\Principal\Infrastructure\Query\GetCurrentPrincipal;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWiki;
@@ -113,6 +115,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RemovePrincipalFromPrincipalGroupInterface::class, RemovePrincipalFromPrincipalGroup::class);
         $this->app->singleton(AttachRoleToPrincipalGroupInterface::class, AttachRoleToPrincipalGroup::class);
         $this->app->singleton(DetachRoleFromPrincipalGroupInterface::class, DetachRoleFromPrincipalGroup::class);
+        $this->app->singleton(GetCurrentPrincipalInterface::class, GetCurrentPrincipal::class);
         $this->app->singleton(RequestCertificationInterface::class, RequestCertification::class);
         $this->app->singleton(ApproveCertificationInterface::class, ApproveCertification::class);
         $this->app->singleton(RejectCertificationInterface::class, RejectCertification::class);

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -916,6 +916,30 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreatePrincipalRequestBody'
+  /principal/me:
+    get:
+      operationId: PrincipalOperations_getCurrentPrincipal
+      description: Get the principal associated with the authenticated identity.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned for the authenticated identity's principal.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipalSummary'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /role/create:
     post:
       operationId: PrincipalOperations_createRole

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -93,6 +93,7 @@ return [
 
     // Wiki Principal
     'principal_group_not_found' => 'The specified principal group was not found.',
+    'principal_not_found' => 'The specified principal was not found.',
     'policy_not_found' => 'The specified policy was not found.',
     'role_not_found' => 'The specified role was not found.',
     'principal_already_exists' => 'A principal already exists for this identity.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -93,6 +93,7 @@ return [
 
     // Wiki Principal
     'principal_group_not_found' => 'No se encontró el grupo de principal especificado.',
+    'principal_not_found' => 'No se encontró el principal especificado.',
     'policy_not_found' => 'No se encontró la política especificada.',
     'role_not_found' => 'No se encontró el rol especificado.',
     'principal_already_exists' => 'Ya existe un principal para esta identidad.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -93,6 +93,7 @@ return [
 
     // Wiki Principal
     'principal_group_not_found' => '指定されたプリンシパルグループが見つかりません。',
+    'principal_not_found' => '指定されたプリンシパルが見つかりません。',
     'policy_not_found' => '指定されたポリシーが見つかりません。',
     'role_not_found' => '指定されたロールが見つかりません。',
     'principal_already_exists' => 'このアイデンティティにはプリンシパルが既に存在します。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -93,6 +93,7 @@ return [
 
     // Wiki Principal
     'principal_group_not_found' => '지정된 프린시펄 그룹을 찾을 수 없습니다.',
+    'principal_not_found' => '지정된 프린시펄을 찾을 수 없습니다.',
     'policy_not_found' => '지정된 정책을 찾을 수 없습니다.',
     'role_not_found' => '지정된 역할을 찾을 수 없습니다.',
     'principal_already_exists' => '이 아이덴티티에는 이미 프린시펄이 존재합니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -93,6 +93,7 @@ return [
 
     // Wiki Principal
     'principal_group_not_found' => '未找到指定的主体组。',
+    'principal_not_found' => '未找到指定的主体。',
     'policy_not_found' => '未找到指定的策略。',
     'role_not_found' => '未找到指定的角色。',
     'principal_already_exists' => '此身份已存在主体。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -93,6 +93,7 @@ return [
 
     // Wiki Principal
     'principal_group_not_found' => '找不到指定的主體群組。',
+    'principal_not_found' => '找不到指定的主體。',
     'policy_not_found' => '找不到指定的政策。',
     'role_not_found' => '找不到指定的角色。',
     'principal_already_exists' => '此身分已存在主體。',

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -25,6 +25,7 @@ use Application\Http\Action\Wiki\Principal\Command\DeleteRole\DeleteRoleAction;
 use Application\Http\Action\Wiki\Principal\Command\DetachPolicyFromRole\DetachPolicyFromRoleAction;
 use Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupAction;
+use Application\Http\Action\Wiki\Principal\Query\GetCurrentPrincipal\GetCurrentPrincipalAction;
 use Application\Http\Action\Wiki\Wiki\Command\ApproveWiki\ApproveWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\AutoCreateWiki\AutoCreateWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\CreateWiki\CreateWikiAction;
@@ -80,6 +81,7 @@ Route::post('/image/{imageId}/unhide', UnhideImageAction::class);
 Route::post('/image/upload', UploadImageAction::class);
 
 // Principal
+Route::get('/principal/me', GetCurrentPrincipalAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::post('/principal/create', CreatePrincipalAction::class);
 Route::post('/principal-group/create', CreatePrincipalGroupAction::class);
 Route::post('/principal-group/{principalGroupId}/add-member', AddPrincipalToPrincipalGroupAction::class);

--- a/src/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInput.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInput.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal;
+
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+readonly class GetCurrentPrincipalInput implements GetCurrentPrincipalInputPort
+{
+    public function __construct(
+        private IdentityIdentifier $identityIdentifier,
+    ) {
+    }
+
+    public function identityIdentifier(): IdentityIdentifier
+    {
+        return $this->identityIdentifier;
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal;
+
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+interface GetCurrentPrincipalInputPort
+{
+    public function identityIdentifier(): IdentityIdentifier;
+}

--- a/src/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal;
+
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalReadModel;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+
+interface GetCurrentPrincipalInterface
+{
+    /**
+     * @throws PrincipalNotFoundException
+     */
+    public function process(GetCurrentPrincipalInputPort $input): PrincipalReadModel;
+}

--- a/src/Wiki/Principal/Application/UseCase/Query/PrincipalReadModel.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/PrincipalReadModel.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query;
+
+readonly class PrincipalReadModel
+{
+    public function __construct(
+        private string $principalIdentifier,
+        private string $identityIdentifier,
+        private bool $isDelegatedPrincipal,
+        private bool $isEnabled,
+    ) {
+    }
+
+    /**
+     * @return array{principalIdentifier: string, identityIdentifier: string, isDelegatedPrincipal: bool, isEnabled: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'principalIdentifier' => $this->principalIdentifier,
+            'identityIdentifier' => $this->identityIdentifier,
+            'isDelegatedPrincipal' => $this->isDelegatedPrincipal,
+            'isEnabled' => $this->isEnabled,
+        ];
+    }
+}

--- a/src/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipal.php
+++ b/src/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipal.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Infrastructure\Query;
+
+use Application\Models\Wiki\Principal as PrincipalModel;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInputPort;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalReadModel;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+
+readonly class GetCurrentPrincipal implements GetCurrentPrincipalInterface
+{
+    /**
+     * @throws PrincipalNotFoundException
+     */
+    public function process(GetCurrentPrincipalInputPort $input): PrincipalReadModel
+    {
+        $principal = PrincipalModel::query()
+            ->where('identity_id', (string) $input->identityIdentifier())
+            ->first();
+
+        if ($principal === null) {
+            throw new PrincipalNotFoundException();
+        }
+
+        return $this->toReadModel($principal);
+    }
+
+    private function toReadModel(PrincipalModel $principal): PrincipalReadModel
+    {
+        return new PrincipalReadModel(
+            principalIdentifier: $principal->id,
+            identityIdentifier: $principal->identity_id,
+            isDelegatedPrincipal: $principal->delegation_identifier !== null,
+            isEnabled: $principal->enabled,
+        );
+    }
+}

--- a/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
+++ b/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
@@ -45,6 +45,7 @@ class AuthenticatedRouteProtectionTest extends TestCase
 
             // Wiki (all routes require auth)
             'wiki: create wiki' => ['POST', '/api/wiki/wiki/create'],
+            'wiki: current principal' => ['GET', '/api/wiki/principal/me'],
         ];
     }
 }

--- a/tests/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInputTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal;
+
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInput;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class GetCurrentPrincipalInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $input = new GetCurrentPrincipalInput($identityIdentifier);
+
+        $this->assertSame((string) $identityIdentifier, (string) $input->identityIdentifier());
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Query/PrincipalReadModelTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Query/PrincipalReadModelTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Query;
+
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalReadModel;
+use Tests\TestCase;
+
+class PrincipalReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $readModel = new PrincipalReadModel(
+            principalIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            identityIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            isDelegatedPrincipal: true,
+            isEnabled: false,
+        );
+
+        $this->assertSame([
+            'principalIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'identityIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'isDelegatedPrincipal' => true,
+            'isEnabled' => false,
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipalTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipalTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Infrastructure\Query;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use JsonException;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInput;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\CreateIdentity;
+use Tests\Helper\CreatePrincipal;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class GetCurrentPrincipalTest extends TestCase
+{
+    /**
+     * @throws PrincipalNotFoundException
+     * @throws BindingResolutionException
+     * @throws JsonException
+     */
+    #[Group('useDb')]
+    public function testProcessReturnsCurrentPrincipal(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        CreateIdentity::create($identityIdentifier);
+
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        CreatePrincipal::create($principalIdentifier, $identityIdentifier);
+
+        $useCase = $this->app->make(GetCurrentPrincipalInterface::class);
+        $readModel = $useCase->process(new GetCurrentPrincipalInput($identityIdentifier));
+
+        $result = $readModel->toArray();
+        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
+        $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
+        $this->assertFalse($result['isDelegatedPrincipal']);
+        $this->assertTrue($result['isEnabled']);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    #[Group('useDb')]
+    public function testProcessThrowsExceptionWhenPrincipalDoesNotExist(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+
+        $this->expectException(PrincipalNotFoundException::class);
+
+        $useCase = $this->app->make(GetCurrentPrincipalInterface::class);
+        $useCase->process(new GetCurrentPrincipalInput($identityIdentifier));
+    }
+}

--- a/typespec/services/wiki-private-api/principal.tsp
+++ b/typespec/services/wiki-private-api/principal.tsp
@@ -63,6 +63,12 @@ model CreatePrincipalResponse {
   @body body: PrincipalSummary;
 }
 
+@doc("Response returned for the authenticated identity's principal.")
+model GetCurrentPrincipalResponse {
+  @statusCode statusCode: 200;
+  @body body: PrincipalSummary;
+}
+
 @doc("Response returned when a principal group is created.")
 model CreatePrincipalGroupResponse {
   @statusCode statusCode: 201;
@@ -89,6 +95,11 @@ model CreatePolicyResponse {
 
 @route("/")
 interface PrincipalOperations {
+  @get
+  @route("/principal/me")
+  @doc("Get the principal associated with the authenticated identity.")
+  getCurrentPrincipal(): GetCurrentPrincipalResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
   @post
   @route("/principal/create")
   @doc("Create a principal.")


### PR DESCRIPTION
## 📝 変更内容

認証中 Identity に紐づく Wiki Principal を取得する `GET /principal/me` を追加しました。

- `GetCurrentPrincipalAction` を追加し、`ActorContext` の `identityIdentifier` から current principal を取得
- `GetCurrentPrincipal` Query UseCase、InputPort、Interface、`PrincipalReadModel` を追加
- Wiki UseCase の DI 登録と private API ルートを追加
- TypeSpec と OpenAPI に `GET /principal/me` の契約を追加
- `principal_not_found` の多言語エラーメッセージを追加
- 入力、ReadModel、Query、認証必須ルートのテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Identity API に Wiki 固有概念の Principal を混ぜず、Wiki コンテキスト側で認証中 Identity に対応する Principal を取得できるようにするためです。

クライアントは認証済み Identity の取得後、Wiki 機能で必要なタイミングに `GET /principal/me` を呼び出すことで、境界づけられたコンテキストの責務を保ったまま Principal 情報を取得できます。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

`task test -- tests/Wiki/Principal/Application/UseCase/Query/GetCurrentPrincipal/GetCurrentPrincipalInputTest.php tests/Wiki/Principal/Application/UseCase/Query/PrincipalReadModelTest.php tests/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipalTest.php tests/Http/Middleware/AuthenticatedRouteProtectionTest.php` を実行しましたが、Task 定義により全 PHPUnit が実行され、PHP コンテナ内から `testing_db` / `redis` を名前解決できない環境エラーで失敗しました。

結果: `Tests: 2584, Assertions: 6773, Errors: 459, Failures: 1, Risky: 19`

## 🔍 レビューのポイント

- `GET /principal/me` が `auth.api` と `resolve.actor` を通り、Action 内で直接セッションやトークンを読まない構成になっているか
- Principal が存在しない場合に `PrincipalNotFoundException` を 404 Problem Details に変換できているか
- レスポンスが既存の `PrincipalSummary` と互換の `principalIdentifier`, `identityIdentifier`, `isDelegatedPrincipal`, `isEnabled` になっているか
- TypeSpec と OpenAPI の契約が実装と一致しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #354

## ⚠️ 注意事項

`task test` は環境の名前解決エラーで失敗しています。マイグレーションや破壊的変更はありません。

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した