### PR TITLE
テスト用Redisを分離

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,9 +4,9 @@ vars:
   PHPUNIT: ./vendor/bin/phpunit
   SLEEP_SECONDS: 5
   API_SERVICES: php nginx db redis mail
-  TEST_SERVICES: testing_db redis
+  TEST_SERVICES: testing_db testing_redis
   PHP_RUN: docker-compose run --rm --no-deps php
-  PHP_RUN_TEST: docker-compose run --rm --no-deps -e DB_HOST=testing_db php
+  PHP_RUN_TEST: docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php
   PHP_EXEC: docker-compose exec php
 
 tasks:
@@ -22,7 +22,7 @@ tasks:
     cmds:
       - docker-compose up -d {{.TEST_SERVICES}}
       - task: wait-for-db
-      - defer: '{{if not .keepdb}}docker-compose stop testing_db redis && docker-compose rm -v -f testing_db redis{{end}}'
+      - defer: '{{if not .keepdb}}docker-compose stop testing_db testing_redis && docker-compose rm -v -f testing_db testing_redis{{end}}'
       - '{{.PHP_RUN_TEST}} bash -c "{{.PHPUNIT}}{{if .filter}} --filter={{.filter}}{{end}} --coverage-html coverage-html"'
 
   test-no-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,13 @@ services:
     networks:
       - kpool-network
 
+  testing_redis:
+    image: redis:8-alpine
+    ports:
+      - "6380:6379"
+    networks:
+      - kpool-network
+
   mail:
     image: axllent/mailpit:latest
     ports:


### PR DESCRIPTION
## 📝 変更内容

テスト実行時に通常の Redis コンテナを止めないよう、テスト用 Redis を分離しました。

- `docker-compose.yml` に `testing_redis` サービスを追加
- `testing_redis` のホスト側ポートを `6380` に設定
- `task test` の対象サービスを `testing_db testing_redis` に変更
- PHPUnit 実行時に `REDIS_HOST=testing_redis` を渡すよう変更
- テスト後処理で停止・削除する対象を `testing_db testing_redis` に変更

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

`task test` が `redis` サービスを利用していたため、テスト完了時の後処理で通常開発用の Redis コンテナまで停止・削除されていました。

DB と同様にテスト専用 Redis を分けることで、テスト実行後も通常の Redis コンテナを維持できるようにします。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行済み:

- `docker-compose config --services`
- `task test filter=AuthCodeSessionRepositoryTest keepdb=1`

結果:

- `OK (6 tests, 13 assertions)`

## 🔍 レビューのポイント

- `task test` が通常の `redis` ではなく `testing_redis` を起動・利用しているか
- テスト後処理が `testing_db` / `testing_redis` のみに限定されているか
- `testing_redis` のポート `6380:6379` が既存サービスと競合しないか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

マイグレーションや破壊的変更はありません。

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した