### PR TITLE
/auth/me に accountIdentifier を追加

### DIFF
--- a/doc/openapi/KPool.IdentityApi.openapi.yaml
+++ b/doc/openapi/KPool.IdentityApi.openapi.yaml
@@ -64,6 +64,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /auth/me:
+    get:
+      operationId: IdentityAuthOperations_getAuthenticatedIdentity
+      description: Get the current authenticated identity.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when fetching the current authenticated identity succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticatedIdentitySummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /auth/register:
     post:
       operationId: IdentityAuthOperations_createIdentity
@@ -304,6 +334,20 @@ paths:
               $ref: '#/components/schemas/VerifyEmailRequestBody'
 components:
   schemas:
+    AuthenticatedIdentitySummary:
+      type: object
+      required:
+        - accountIdentifier
+      properties:
+        accountIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
+          description: Account identifier associated with the authenticated identity.
+      allOf:
+        - $ref: '#/components/schemas/IdentitySummary'
+      description: Authenticated identity summary returned for the current identity.
     CreateIdentityRequestBody:
       type: object
       required:

--- a/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
+++ b/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
@@ -12,6 +12,7 @@ readonly class AuthenticatedIdentityReadModel
         private string $email,
         private string $language,
         private ?string $profileImage,
+        private ?string $accountIdentifier,
     ) {
     }
 
@@ -40,6 +41,11 @@ readonly class AuthenticatedIdentityReadModel
         return $this->profileImage;
     }
 
+    public function accountIdentifier(): ?string
+    {
+        return $this->accountIdentifier;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -51,6 +57,7 @@ readonly class AuthenticatedIdentityReadModel
             'email' => $this->email,
             'language' => $this->language,
             'profileImage' => $this->profileImage,
+            'accountIdentifier' => $this->accountIdentifier,
         ];
     }
 }

--- a/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
+++ b/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Identity\Infrastructure\Query;
 
+use Application\Models\Account\IdentityGroup as IdentityGroupModel;
 use Application\Models\Identity\Identity as IdentityModel;
 use Source\Identity\Application\UseCase\Query\AuthenticatedIdentityReadModel;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInputPort;
@@ -25,12 +26,23 @@ readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInter
             throw new IdentityNotFoundException();
         }
 
+        $accountIdentifier = IdentityGroupModel::query()
+            ->join(
+                'identity_group_memberships',
+                'identity_groups.id',
+                '=',
+                'identity_group_memberships.identity_group_id'
+            )
+            ->where('identity_group_memberships.identity_id', (string) $input->identityIdentifier())
+            ->value('identity_groups.account_id');
+
         return new AuthenticatedIdentityReadModel(
             identityIdentifier: $model->id,
             username: $model->username,
             email: $model->email,
             language: $model->language,
             profileImage: $model->profile_image,
+            accountIdentifier: $accountIdentifier === null ? null : (string) $accountIdentifier,
         );
     }
 }

--- a/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
+++ b/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
@@ -17,6 +17,7 @@ class AuthenticatedIdentityReadModelTest extends TestCase
             email: 'test@example.com',
             language: 'ja',
             profileImage: '/storage/profile/test.png',
+            accountIdentifier: '019de7f3-78f3-7b55-9ed5-17f63e14d5aa',
         );
 
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5fe', $readModel->identityIdentifier());
@@ -24,12 +25,14 @@ class AuthenticatedIdentityReadModelTest extends TestCase
         $this->assertSame('test@example.com', $readModel->email());
         $this->assertSame('ja', $readModel->language());
         $this->assertSame('/storage/profile/test.png', $readModel->profileImage());
+        $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5aa', $readModel->accountIdentifier());
         $this->assertSame([
             'identityIdentifier' => '019de7f3-78f3-7b55-9ed5-17f63e14d5fe',
             'username' => 'test-user',
             'email' => 'test@example.com',
             'language' => 'ja',
             'profileImage' => '/storage/profile/test.png',
+            'accountIdentifier' => '019de7f3-78f3-7b55-9ed5-17f63e14d5aa',
         ], $readModel->toArray());
     }
 }

--- a/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
+++ b/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Identity\Infrastructure\Query;
 
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Group;
+use Source\Account\Shared\Domain\ValueObject\IdentityGroupIdentifier;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInput;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
 use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\CreateAccount;
 use Tests\Helper\CreateIdentity;
+use Tests\Helper\CreateIdentityGroup;
+use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
 class GetAuthenticatedIdentityTest extends TestCase
@@ -17,12 +23,23 @@ class GetAuthenticatedIdentityTest extends TestCase
     #[Group('useDb')]
     public function testProcessReturnsAuthenticatedIdentity(): void
     {
+        $accountIdentifier = new AccountIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5aa');
+        $identityGroupIdentifier = new IdentityGroupIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5bb');
         $identityIdentifier = new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5fe');
+        CreateAccount::create((string) $accountIdentifier);
         CreateIdentity::create($identityIdentifier, [
             'username' => 'test-user',
             'email' => 'test@example.com',
             'language' => 'ja',
             'profile_image' => '/storage/profile/test.png',
+        ]);
+        CreateIdentityGroup::create($identityGroupIdentifier, $accountIdentifier);
+        DB::table('identity_group_memberships')->insert([
+            'id' => StrTestHelper::generateUuid(),
+            'identity_group_id' => (string) $identityGroupIdentifier,
+            'identity_id' => (string) $identityIdentifier,
+            'created_at' => now(),
+            'updated_at' => now(),
         ]);
 
         $useCase = $this->app->make(GetAuthenticatedIdentityInterface::class);
@@ -33,6 +50,29 @@ class GetAuthenticatedIdentityTest extends TestCase
         $this->assertSame('test@example.com', $readModel->email());
         $this->assertSame('ja', $readModel->language());
         $this->assertSame('/storage/profile/test.png', $readModel->profileImage());
+        $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5aa', $readModel->accountIdentifier());
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsNullAccountIdentifierWhenIdentityDoesNotBelongToAccount(): void
+    {
+        $identityIdentifier = new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5fe');
+        CreateIdentity::create($identityIdentifier, [
+            'username' => 'test-user',
+            'email' => 'test@example.com',
+            'language' => 'ja',
+            'profile_image' => null,
+        ]);
+
+        $useCase = $this->app->make(GetAuthenticatedIdentityInterface::class);
+        $readModel = $useCase->process(new GetAuthenticatedIdentityInput($identityIdentifier));
+
+        $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5fe', $readModel->identityIdentifier());
+        $this->assertSame('test-user', $readModel->username());
+        $this->assertSame('test@example.com', $readModel->email());
+        $this->assertSame('ja', $readModel->language());
+        $this->assertNull($readModel->profileImage());
+        $this->assertNull($readModel->accountIdentifier());
     }
 
     #[Group('useDb')]

--- a/typespec/services/identity-api.tsp
+++ b/typespec/services/identity-api.tsp
@@ -19,6 +19,12 @@ model IdentitySummary {
   profileImage?: string | null;
 }
 
+@doc("Authenticated identity summary returned for the current identity.")
+model AuthenticatedIdentitySummary extends IdentitySummary {
+  @doc("Account identifier associated with the authenticated identity.")
+  accountIdentifier: Uuid | null;
+}
+
 @doc("Identity summary returned after switching active identity.")
 model SwitchedIdentitySummary extends IdentitySummary {
   @doc("Whether the active identity is delegated.")
@@ -101,6 +107,12 @@ model OkIdentityResponse {
   @body body: IdentitySummary;
 }
 
+@doc("Response returned when fetching the current authenticated identity succeeds.")
+model AuthenticatedIdentityResponse {
+  @statusCode statusCode: 200;
+  @body body: AuthenticatedIdentitySummary;
+}
+
 @doc("Response returned when email verification succeeds.")
 model VerifyEmailResponse {
   @statusCode statusCode: 200;
@@ -171,6 +183,11 @@ interface IdentityAuthOperations {
   @route("/logout")
   @doc("Log out the current authenticated identity.")
   logout(): OkEmptyResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/me")
+  @doc("Get the current authenticated identity.")
+  getAuthenticatedIdentity(): AuthenticatedIdentityResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/switch-identity")


### PR DESCRIPTION
## 📝 変更内容

`GET /auth/me` のレスポンスに、ログイン中 identity が所属する account の ID を示す `accountIdentifier` を追加しました。

- `AuthenticatedIdentityReadModel` に `accountIdentifier` を追加
- identity group membership 経由で所属 account id を解決
- account 未所属の場合は `accountIdentifier: null` を返却
- TypeSpec / OpenAPI 定義を更新
- ReadModel と Query のテストを更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

マイページ表示でログイン中ユーザーに紐づく account id が必要なため、既存の `/auth/me` レスポンスを拡張して `accountIdentifier` を返せるようにしました。

## 🧪 テスト

### テストの実行確認

- [x] `task test -- tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行結果: `OK (2585 tests, 8247 assertions)`

## 🔍 レビューのポイント

- identity group membership 経由で account id を解決する実装で問題ないか
- account 未所属時に `null` を返す仕様で問題ないか
- `/auth/me` の既存レスポンス項目に破壊的変更がないか
- TypeSpec / OpenAPI の `AuthenticatedIdentitySummary` 定義が期待通りか

## 📖 関連情報

### 関連Issue・タスク

Closes #357

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した