### PR TITLE
画像保存先と表示URL変換を整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ clover.xml
 /build/
 /dist/
 /node_modules/
+/public/storage/
 
 .codex/*
 !.codex/skills/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,6 +128,13 @@ tasks:
       - task: wait-for-db
       - '{{.PHP_RUN}} php artisan migrate --force'
 
+  migrate-fresh:
+    desc: "Drop all tables, run migrations, and seed the database. Usage: task migrate-fresh"
+    cmds:
+      - docker-compose up -d db
+      - task: wait-for-db
+      - '{{.PHP_RUN}} php artisan migrate:fresh --seed --force'
+
   seed:
     desc: "Run database seeders. Usage: task seed [class=Database\\\\Seeders\\\\WikiEditorSampleSeeder]"
     cmds:

--- a/application/Http/Action/Identity/Command/CreateIdentity/CreateIdentityAction.php
+++ b/application/Http/Action/Identity/Command/CreateIdentity/CreateIdentityAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Identity\Command\CreateIdentity;
 
+use Application\Http\Action\Identity\Support\IdentityResponsePayload;
 use Application\Http\Exceptions\ConflictHttpException;
 use Application\Http\Exceptions\ForbiddenHttpException;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
@@ -104,6 +105,6 @@ readonly class CreateIdentityAction
             throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
         }
 
-        return response()->json($output->toArray(), Response::HTTP_CREATED);
+        return response()->json(IdentityResponsePayload::normalizeProfileImage($output->toArray()), Response::HTTP_CREATED);
     }
 }

--- a/application/Http/Action/Identity/Command/Login/LoginAction.php
+++ b/application/Http/Action/Identity/Command/Login/LoginAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Identity\Command\Login;
 
+use Application\Http\Action\Identity\Support\IdentityResponsePayload;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
 use Application\Http\Exceptions\UnauthorizedHttpException;
 use Application\Http\Exceptions\UnprocessableEntityHttpException;
@@ -77,6 +78,6 @@ readonly class LoginAction
             throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
         }
 
-        return response()->json($output->toArray(), Response::HTTP_OK);
+        return response()->json(IdentityResponsePayload::normalizeProfileImage($output->toArray()), Response::HTTP_OK);
     }
 }

--- a/application/Http/Action/Identity/Command/SwitchIdentity/SwitchIdentityAction.php
+++ b/application/Http/Action/Identity/Command/SwitchIdentity/SwitchIdentityAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Identity\Command\SwitchIdentity;
 
+use Application\Http\Action\Identity\Support\IdentityResponsePayload;
 use Application\Http\Context\ActorContext;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
 use Application\Http\Exceptions\NotFoundHttpException;
@@ -80,6 +81,6 @@ readonly class SwitchIdentityAction
             throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
         }
 
-        return response()->json($output->toArray(), Response::HTTP_OK);
+        return response()->json(IdentityResponsePayload::normalizeProfileImage($output->toArray()), Response::HTTP_OK);
     }
 }

--- a/application/Http/Action/Identity/Support/IdentityResponsePayload.php
+++ b/application/Http/Action/Identity/Support/IdentityResponsePayload.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Identity\Support;
+
+use Source\Shared\Infrastructure\Support\ImageUrl;
+
+final readonly class IdentityResponsePayload
+{
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<string, mixed>
+     */
+    public static function normalizeProfileImage(array $payload): array
+    {
+        if (! array_key_exists('profileImage', $payload)) {
+            return $payload;
+        }
+
+        $profileImage = $payload['profileImage'];
+        $payload['profileImage'] = is_string($profileImage) ? ImageUrl::fromPath($profileImage) : null;
+
+        return $payload;
+    }
+}

--- a/application/Http/Action/Wiki/Image/Command/UploadImage/UploadImageRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/UploadImage/UploadImageRequest.php
@@ -6,6 +6,8 @@ namespace Application\Http\Action\Wiki\Image\Command\UploadImage;
 
 use Application\Http\Action\Concerns\ResolvesLanguage;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Image\Domain\ValueObject\ImageUsage;
 
 class UploadImageRequest extends FormRequest
 {
@@ -21,7 +23,7 @@ class UploadImageRequest extends FormRequest
             'resourceType' => ['required', 'string'],
             'wikiIdentifier' => ['required', 'uuid'],
             'base64EncodedImage' => ['required', 'string'],
-            'imageUsage' => ['required', 'string'],
+            'imageUsage' => ['required', 'string', Rule::in(array_column(ImageUsage::cases(), 'value'))],
             'displayOrder' => ['required', 'integer'],
             'sourceUrl' => ['required', 'string'],
             'sourceName' => ['required', 'string'],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -2,11 +2,20 @@
 
 return [
     'default' => env('FILESYSTEM_DISK', 'local'),
+    'image_disk' => env('IMAGE_STORAGE_DISK', 'public'),
 
     'disks' => [
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app'),
+            'throw' => false,
+        ],
+
+        'public' => [
+            'driver' => 'local',
+            'root' => public_path('storage'),
+            'url' => env('APP_URL') . '/storage',
+            'visibility' => 'public',
             'throw' => false,
         ],
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -11,6 +11,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            SystemPolicySeeder::class,
+            SystemRoleSeeder::class,
             WikiEditorSampleSeeder::class,
         ]);
     }

--- a/database/seeders/WikiEditorSampleSeeder.php
+++ b/database/seeders/WikiEditorSampleSeeder.php
@@ -247,7 +247,7 @@ class WikiEditorSampleSeeder extends Seeder
                 'agency_identifier' => null,
                 'group_type' => 'girl_group',
                 'status' => 'active',
-                'generation' => '3',
+                'generation' => '3rd',
                 'debut_date' => '2015-10-20',
                 'disband_date' => null,
                 'fandom_name' => 'ONCE',
@@ -295,7 +295,7 @@ class WikiEditorSampleSeeder extends Seeder
                 'agency_identifier' => null,
                 'group_type' => 'girl_group',
                 'status' => 'active',
-                'generation' => '3',
+                'generation' => '3rd',
                 'debut_date' => '2015-10-20',
                 'disband_date' => null,
                 'fandom_name' => 'ONCE',
@@ -467,9 +467,16 @@ class WikiEditorSampleSeeder extends Seeder
         return json_encode([
             [
                 'id' => 'overview',
-                'type' => 'plaintext',
+                'type' => 'section',
                 'title' => 'Overview',
-                'content' => $summary,
+                'display_order' => 1,
+                'contents' => [
+                    [
+                        'block_type' => 'text',
+                        'display_order' => 1,
+                        'content' => $summary,
+                    ],
+                ],
             ],
         ], JSON_THROW_ON_ERROR);
     }
@@ -479,11 +486,18 @@ class WikiEditorSampleSeeder extends Seeder
         return json_encode([
             [
                 'id' => 'overview',
-                'type' => 'plaintext',
+                'type' => 'section',
                 'title' => 'Overview',
-                'content' => $isDraft
-                    ? "{$name} draft profile linked to the TWICE editor sample."
-                    : "{$name} published profile linked to the TWICE group sample.",
+                'display_order' => 1,
+                'contents' => [
+                    [
+                        'block_type' => 'text',
+                        'display_order' => 1,
+                        'content' => $isDraft
+                            ? "{$name} draft profile linked to the TWICE editor sample."
+                            : "{$name} published profile linked to the TWICE group sample.",
+                    ],
+                ],
             ],
         ], JSON_THROW_ON_ERROR);
     }

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -51,16 +51,18 @@ use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinks
 use Application\Http\Action\Wiki\Wiki\Command\TranslateWiki\TranslateWikiAction;
 use Illuminate\Support\Facades\Route;
 
-Route::post('/wiki/create', CreateWikiAction::class);
-Route::post('/wiki/auto-create', AutoCreateWikiAction::class);
-Route::post('/wiki/{wikiId}/approve', ApproveWikiAction::class);
-Route::post('/wiki/{wikiId}/edit', EditWikiAction::class);
-Route::post('/wiki/{wikiId}/merge', MergeWikiAction::class);
-Route::post('/wiki/{wikiId}/publish', PublishWikiAction::class);
-Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
-Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
-Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
-Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function () {
+    Route::post('/wiki/create', CreateWikiAction::class);
+    Route::post('/wiki/auto-create', AutoCreateWikiAction::class);
+    Route::post('/wiki/{wikiId}/approve', ApproveWikiAction::class);
+    Route::post('/wiki/{wikiId}/edit', EditWikiAction::class);
+    Route::post('/wiki/{wikiId}/merge', MergeWikiAction::class);
+    Route::post('/wiki/{wikiId}/publish', PublishWikiAction::class);
+    Route::post('/wiki/{wikiId}/reject', RejectWikiAction::class);
+    Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
+    Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
+    Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+});
 Route::get('/wikis/{language}', ListWikisAction::class);
 Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);
 Route::get('/wiki/{language}/agency/{slug}/draft', GetAgencyDraftWikiAction::class);
@@ -74,11 +76,13 @@ Route::get('/wiki/{language}/talent/{slug}/draft', GetTalentDraftWikiAction::cla
 // Image
 Route::get('/draft-images', ListDraftImagesAction::class)->middleware('auth.api');
 Route::get('/images', ListUploadedImagesAction::class)->middleware('auth.api');
-Route::post('/image/{imageId}/approve', ApproveImageAction::class);
-Route::delete('/image/{imageId}', DeleteImageAction::class);
-Route::post('/image/{imageId}/reject', RejectImageAction::class);
-Route::post('/image/{imageId}/unhide', UnhideImageAction::class);
-Route::post('/image/upload', UploadImageAction::class);
+Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function () {
+    Route::post('/image/{imageId}/approve', ApproveImageAction::class);
+    Route::delete('/image/{imageId}', DeleteImageAction::class);
+    Route::post('/image/{imageId}/reject', RejectImageAction::class);
+    Route::post('/image/{imageId}/unhide', UnhideImageAction::class);
+    Route::post('/image/upload', UploadImageAction::class);
+});
 
 // Principal
 Route::get('/principal/me', GetCurrentPrincipalAction::class)->middleware(['auth.api', 'resolve.actor']);
@@ -97,9 +101,11 @@ Route::post('/policy/create', CreatePolicyAction::class);
 Route::delete('/policy/{policyId}', DeletePolicyAction::class);
 
 // ImageHideRequest
-Route::post('/image/{imageId}/request-hide', RequestImageHideAction::class);
-Route::post('/image/{imageId}/approve-hide-request', ApproveImageHideRequestAction::class);
-Route::post('/image/{imageId}/reject-hide-request', RejectImageHideRequestAction::class);
+Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function () {
+    Route::post('/image/{imageId}/request-hide', RequestImageHideAction::class);
+    Route::post('/image/{imageId}/approve-hide-request', ApproveImageHideRequestAction::class);
+    Route::post('/image/{imageId}/reject-hide-request', RejectImageHideRequestAction::class);
+});
 
 // OfficialCertification
 Route::post('/official-certification/request', RequestCertificationAction::class);
@@ -107,4 +113,4 @@ Route::post('/official-certification/{certificationId}/approve', ApproveCertific
 Route::post('/official-certification/{certificationId}/reject', RejectCertificationAction::class);
 
 // VideoLink
-Route::post('/video-link/save', SaveVideoLinksAction::class);
+Route::post('/video-link/save', SaveVideoLinksAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);

--- a/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
+++ b/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
@@ -10,6 +10,7 @@ use Source\Identity\Application\UseCase\Query\AuthenticatedIdentityReadModel;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInputPort;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
 use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Source\Shared\Infrastructure\Support\ImageUrl;
 
 readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInterface
 {
@@ -41,7 +42,7 @@ readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInter
             username: $model->username,
             email: $model->email,
             language: $model->language,
-            profileImage: $model->profile_image,
+            profileImage: ImageUrl::fromPath($model->profile_image),
             accountIdentifier: $accountIdentifier === null ? null : (string) $accountIdentifier,
         );
     }

--- a/src/Shared/Infrastructure/Service/ImageService.php
+++ b/src/Shared/Infrastructure/Service/ImageService.php
@@ -34,7 +34,7 @@ class ImageService implements ImageServiceInterface
             throw new InvalidBase64ImageException();
         }
 
-        $baseFileName = Str::uuid()->toString();
+        $baseFileName = 'images/' . Str::uuid();
 
         // オリジナル画像をwebpで保存
         $originalPath = $this->saveAsWebp($gdImage, $baseFileName . '_original.webp');
@@ -62,7 +62,7 @@ class ImageService implements ImageServiceInterface
         imagewebp($image);
         $webpData = ob_get_clean();
 
-        Storage::disk('s3')->put($fileName, $webpData);
+        Storage::disk((string) config('filesystems.image_disk', 'public'))->put($fileName, $webpData);
 
         return $fileName;
     }

--- a/src/Shared/Infrastructure/Support/ImageUrl.php
+++ b/src/Shared/Infrastructure/Support/ImageUrl.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Shared\Infrastructure\Support;
+
+use Illuminate\Support\Facades\Storage;
+
+final readonly class ImageUrl
+{
+    public static function fromPath(?string $path): ?string
+    {
+        if ($path === null || $path === '') {
+            return null;
+        }
+
+        if (str_starts_with($path, '/')) {
+            return url($path);
+        }
+
+        return Storage::disk((string) config('filesystems.image_disk', 'public'))->url($path);
+    }
+}

--- a/src/Wiki/Image/Infrastructure/Query/ListDraftImages.php
+++ b/src/Wiki/Image/Infrastructure/Query/ListDraftImages.php
@@ -7,6 +7,7 @@ namespace Source\Wiki\Image\Infrastructure\Query;
 use Application\Models\Wiki\DraftWikiImage;
 use DateTimeInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Image\Application\UseCase\Query\DraftImageReadModel;
 use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInputPort;
 use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInterface;
@@ -44,7 +45,7 @@ readonly class ListDraftImages implements ListDraftImagesInterface
         return new DraftImageReadModel(
             imageIdentifier: $image->id,
             publishedImageIdentifier: $image->published_id,
-            url: url($image->image_path),
+            url: ImageUrl::fromPath($image->image_path) ?? '',
             resourceType: $image->resource_type,
             wikiIdentifier: $image->wiki_id,
             imageUsage: $image->image_usage,

--- a/src/Wiki/Image/Infrastructure/Query/ListUploadedImages.php
+++ b/src/Wiki/Image/Infrastructure/Query/ListUploadedImages.php
@@ -7,6 +7,7 @@ namespace Source\Wiki\Image\Infrastructure\Query;
 use Application\Models\Wiki\WikiImage;
 use DateTimeInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInputPort;
 use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInterface;
 use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesOutputPort;
@@ -38,7 +39,7 @@ readonly class ListUploadedImages implements ListUploadedImagesInterface
     {
         return new UploadedImageReadModel(
             imageIdentifier: $image->id,
-            url: url($image->image_path),
+            url: ImageUrl::fromPath($image->image_path) ?? '',
             resourceType: $image->resource_type,
             wikiIdentifier: $image->wiki_id,
             imageUsage: $image->image_usage,

--- a/tests/Application/Http/Action/Identity/Support/IdentityResponsePayloadTest.php
+++ b/tests/Application/Http/Action/Identity/Support/IdentityResponsePayloadTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Http\Action\Identity\Support;
+
+use Application\Http\Action\Identity\Support\IdentityResponsePayload;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class IdentityResponsePayloadTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'app.url' => 'http://localhost:8080',
+            'filesystems.disks.public.url' => 'http://localhost:8080/storage',
+        ]);
+        URL::forceRootUrl('http://localhost:8080');
+    }
+
+    public function testNormalizeProfileImageConvertsRelativePathToPublicUrl(): void
+    {
+        $payload = IdentityResponsePayload::normalizeProfileImage([
+            'profileImage' => 'images/profile.webp',
+        ]);
+
+        $this->assertSame('http://localhost:8080/storage/images/profile.webp', $payload['profileImage']);
+    }
+
+    public function testNormalizeProfileImageConvertsAbsolutePathToAppUrl(): void
+    {
+        $payload = IdentityResponsePayload::normalizeProfileImage([
+            'profileImage' => '/storage/images/profile.webp',
+        ]);
+
+        $this->assertSame('http://localhost:8080/storage/images/profile.webp', $payload['profileImage']);
+    }
+
+    public function testNormalizeProfileImageKeepsNull(): void
+    {
+        $payload = IdentityResponsePayload::normalizeProfileImage([
+            'profileImage' => null,
+        ]);
+
+        $this->assertNull($payload['profileImage']);
+    }
+}

--- a/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
+++ b/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
@@ -31,7 +31,7 @@ class GetAuthenticatedIdentityTest extends TestCase
             'username' => 'test-user',
             'email' => 'test@example.com',
             'language' => 'ja',
-            'profile_image' => '/storage/profile/test.png',
+            'profile_image' => 'profile/test.png',
         ]);
         CreateIdentityGroup::create($identityGroupIdentifier, $accountIdentifier);
         DB::table('identity_group_memberships')->insert([
@@ -49,7 +49,7 @@ class GetAuthenticatedIdentityTest extends TestCase
         $this->assertSame('test-user', $readModel->username());
         $this->assertSame('test@example.com', $readModel->email());
         $this->assertSame('ja', $readModel->language());
-        $this->assertSame('/storage/profile/test.png', $readModel->profileImage());
+        $this->assertSame('http://localhost:8080/storage/profile/test.png', $readModel->profileImage());
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5aa', $readModel->accountIdentifier());
     }
 

--- a/tests/Shared/Infrastructure/Service/ImageServiceTest.php
+++ b/tests/Shared/Infrastructure/Service/ImageServiceTest.php
@@ -14,6 +14,13 @@ use Tests\TestCase;
 
 class ImageServiceTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.image_disk' => 's3']);
+    }
+
     /**
      * 正常系: DIコンテナからImageServiceInterfaceを解決できること.
      *

--- a/tests/Wiki/Image/Infrastructure/Query/ListDraftImagesTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListDraftImagesTest.php
@@ -133,7 +133,7 @@ class ListDraftImagesTest extends TestCase
             'published_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
             'resource_type' => 'group',
             'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
-            'image_path' => '/images/groups/cover.jpg',
+            'image_path' => 'images/groups/cover.jpg',
             'image_usage' => 'cover',
             'display_order' => 2,
             'source_url' => 'https://example.com/source-image',
@@ -151,7 +151,7 @@ class ListDraftImagesTest extends TestCase
         $this->assertSame([
             'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f501',
             'publishedImageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
-            'url' => 'http://localhost:8080/images/groups/cover.jpg',
+            'url' => 'http://localhost:8080/storage/images/groups/cover.jpg',
             'resourceType' => 'group',
             'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
             'imageUsage' => 'cover',

--- a/tests/Wiki/Image/Infrastructure/Query/ListUploadedImagesTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListUploadedImagesTest.php
@@ -112,7 +112,7 @@ class ListUploadedImagesTest extends TestCase
         CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f501', [
             'resource_type' => 'group',
             'wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
-            'image_path' => '/images/groups/cover.jpg',
+            'image_path' => 'images/groups/cover.jpg',
             'image_usage' => 'cover',
             'display_order' => 2,
             'source_url' => 'https://example.com/source-image',
@@ -127,7 +127,7 @@ class ListUploadedImagesTest extends TestCase
 
         $this->assertSame([
             'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f501',
-            'url' => 'http://localhost:8080/images/groups/cover.jpg',
+            'url' => 'http://localhost:8080/storage/images/groups/cover.jpg',
             'resourceType' => 'group',
             'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
             'imageUsage' => 'cover',


### PR DESCRIPTION
## 📝 変更内容

- 画像保存先を `filesystems.image_disk` で切り替えられるようにし、デフォルトを `public` ディスクに変更
- ローカル保存した画像を `/storage/...` の公開URLとして返す `ImageUrl` を追加
- Identity の `profileImage` と Wiki 画像一覧の URL を表示用URLに正規化
- Wiki 作成・編集・画像操作・動画リンク保存系ルートに `auth.api` / `resolve.actor` / `resolve.wiki` を適用
- 画像アップロード時の `imageUsage` を `ImageUsage` enum の値に制限
- サンプル Seeder の Wiki body 構造と初期 Seeder 呼び出しを更新
- `task migrate-fresh` を追加
- 画像URL変換と関連クエリのテストを更新・追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

ローカル環境でアップロード画像を保存・参照できるようにしつつ、API レスポンスでは保存パスではなく表示可能な URL を返す必要があったためです。

また、Wiki 画像アップロードなどで Actor / Wiki コンテキストが解決されないまま処理される経路があったため、関連する更新系ルートに必要な middleware を適用しました。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `ImageUrl::fromPath()` による相対パス・絶対パスの URL 変換が期待通りか
- `filesystems.image_disk` のデフォルトを `public` にした影響範囲
- Wiki / Image / VideoLink 系更新ルートに追加した middleware の範囲が適切か
- `imageUsage` バリデーションが既存クライアントの送信値と整合しているか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- ローカル保存画像は `public/storage/` 配下に保存され、Git 管理対象外です
- 本番環境で S3 等を使う場合は `IMAGE_STORAGE_DISK` の設定確認が必要です

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
