### PR TITLE
下書き画像一覧にWiki表示情報を追加

### DIFF
--- a/application/Models/Wiki/DraftWikiImage.php
+++ b/application/Models/Wiki/DraftWikiImage.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Application\Models\Wiki;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property string $id
@@ -23,6 +25,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property Carbon $agreed_to_terms_at
  * @property bool $rights_confirmation_agreed
  * @property Carbon $uploaded_at
+ * @property-read Collection<int, Wiki> $wikis
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',
@@ -57,4 +60,12 @@ class DraftWikiImage extends Model
         'rights_confirmation_agreed' => 'boolean',
         'uploaded_at' => 'datetime',
     ];
+
+    /**
+     * @return HasMany<Wiki>
+     */
+    public function wikis(): HasMany
+    {
+        return $this->hasMany(Wiki::class, 'translation_set_identifier', 'translation_set_identifier');
+    }
 }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2067,6 +2067,7 @@ components:
         - sourceUrl
         - sourceName
         - altText
+        - wiki
         - status
         - uploadedAt
       properties:
@@ -2106,6 +2107,10 @@ components:
         altText:
           type: string
           description: Alternative text for the image.
+        wiki:
+          allOf:
+            - $ref: '#/components/schemas/DraftImageWikiDisplayInformation'
+          description: Wiki display information linked to this image through its translation set.
         status:
           allOf:
             - $ref: '#/components/schemas/DraftImageStatus'
@@ -2123,6 +2128,21 @@ components:
         - rejected
         - under_review
       description: Approval status assigned to a draft image.
+    DraftImageWikiDisplayInformation:
+      type: object
+      required:
+        - names
+        - slug
+      properties:
+        names:
+          type: object
+          additionalProperties:
+            type: string
+          description: Display names keyed by language.
+        slug:
+          type: string
+          description: Representative slug of the first linked wiki.
+      description: Wiki display information linked to a draft image through its translation set.
     DraftWikiDetail:
       type: object
       required:

--- a/src/Wiki/Image/Application/UseCase/Query/DraftImageReadModel.php
+++ b/src/Wiki/Image/Application/UseCase/Query/DraftImageReadModel.php
@@ -17,6 +17,8 @@ readonly class DraftImageReadModel
         private string $sourceUrl,
         private string $sourceName,
         private string $altText,
+        /** @var array{names: array<string, string>, slug: string} */
+        private array $wiki,
         private string $status,
         private ?string $uploadedAt,
     ) {
@@ -38,6 +40,7 @@ readonly class DraftImageReadModel
             'sourceUrl' => $this->sourceUrl,
             'sourceName' => $this->sourceName,
             'altText' => $this->altText,
+            'wiki' => $this->wiki,
             'status' => $this->status,
             'uploadedAt' => $this->uploadedAt,
         ];

--- a/src/Wiki/Image/Infrastructure/Query/ListDraftImages.php
+++ b/src/Wiki/Image/Infrastructure/Query/ListDraftImages.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Infrastructure\Query;
 
 use Application\Models\Wiki\DraftWikiImage;
+use Application\Models\Wiki\Wiki;
 use DateTimeInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Source\Shared\Infrastructure\Support\ImageUrl;
@@ -18,6 +19,12 @@ readonly class ListDraftImages implements ListDraftImagesInterface
     public function process(ListDraftImagesInputPort $input, ListDraftImagesOutputPort $output): void
     {
         $query = DraftWikiImage::query()
+            ->with([
+                'wikis.talentBasic',
+                'wikis.groupBasic',
+                'wikis.agencyBasic',
+                'wikis.songBasic',
+            ])
             ->where('status', $input->status()->value)
             ->orderBy('uploaded_at', 'desc');
 
@@ -53,9 +60,49 @@ readonly class ListDraftImages implements ListDraftImagesInterface
             sourceUrl: $image->source_url,
             sourceName: $image->source_name,
             altText: $image->alt_text,
+            wiki: $this->wikiDisplayInformation($image),
             status: $image->status,
             uploadedAt: $this->formatDateTime($image->uploaded_at),
         );
+    }
+
+    /**
+     * @return array{names: array<string, string>, slug: string}
+     */
+    private function wikiDisplayInformation(DraftWikiImage $image): array
+    {
+        $names = [];
+        $slug = '';
+
+        foreach ($image->wikis as $wiki) {
+            $names[$wiki->language] = $this->wikiName($wiki);
+            // Slug is unique per language, so the first linked wiki is enough as the representative slug.
+            if ($slug === '') {
+                $slug = $wiki->slug;
+            }
+        }
+
+        return [
+            'names' => $names,
+            'slug' => $slug,
+        ];
+    }
+
+    private function wikiName(Wiki $wiki): string
+    {
+        $basic = match ($wiki->resource_type) {
+            'talent' => $wiki->getRelationValue('talentBasic'),
+            'group' => $wiki->getRelationValue('groupBasic'),
+            'agency' => $wiki->getRelationValue('agencyBasic'),
+            'song' => $wiki->getRelationValue('songBasic'),
+            default => null,
+        };
+
+        if (! is_object($basic) || ! isset($basic->name)) {
+            return '';
+        }
+
+        return (string) $basic->name;
     }
 
     private function formatDateTime(mixed $dateTime): ?string

--- a/tests/Wiki/Image/Application/UseCase/Query/DraftImageReadModelTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/DraftImageReadModelTest.php
@@ -23,6 +23,12 @@ class DraftImageReadModelTest extends TestCase
             sourceUrl: 'https://example.com/source',
             sourceName: 'Example Source',
             altText: 'Profile image',
+            wiki: [
+                'names' => [
+                    'ko' => 'TWICE',
+                ],
+                'slug' => 'gr-twice',
+            ],
             status: ApprovalStatus::UnderReview->value,
             uploadedAt: '2026-05-01T00:00:00+00:00',
         );
@@ -38,6 +44,12 @@ class DraftImageReadModelTest extends TestCase
             'sourceUrl' => 'https://example.com/source',
             'sourceName' => 'Example Source',
             'altText' => 'Profile image',
+            'wiki' => [
+                'names' => [
+                    'ko' => 'TWICE',
+                ],
+                'slug' => 'gr-twice',
+            ],
             'status' => ApprovalStatus::UnderReview->value,
             'uploadedAt' => '2026-05-01T00:00:00+00:00',
         ], $readModel->toArray());

--- a/tests/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ListDraftImages/ListDraftImagesOutputTest.php
@@ -24,6 +24,12 @@ class ListDraftImagesOutputTest extends TestCase
             sourceUrl: 'https://example.com/source',
             sourceName: 'Example Source',
             altText: 'Profile image',
+            wiki: [
+                'names' => [
+                    'ko' => 'Chaeyoung',
+                ],
+                'slug' => 'tl-chaeyoung',
+            ],
             status: ApprovalStatus::Pending->value,
             uploadedAt: '2026-05-01T00:00:00+00:00',
         );

--- a/tests/Wiki/Image/Infrastructure/Query/ListDraftImagesTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListDraftImagesTest.php
@@ -11,6 +11,7 @@ use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesI
 use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesOutput;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
 use Tests\Helper\CreateDraftImage;
+use Tests\Helper\CreateWiki;
 use Tests\TestCase;
 
 class ListDraftImagesTest extends TestCase
@@ -142,6 +143,20 @@ class ListDraftImagesTest extends TestCase
             'status' => ApprovalStatus::Approved->value,
             'uploaded_at' => '2026-05-01 00:00:00',
         ]);
+        CreateWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f701', 'group', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'slug' => 'gr-twice',
+            'language' => 'ko',
+        ], [
+            'name' => 'TWICE',
+        ]);
+        CreateWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f702', 'group', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'slug' => 'gr-twice',
+            'language' => 'ja',
+        ], [
+            'name' => 'トゥワイス',
+        ]);
 
         $payload = $this->process(new ListDraftImagesInput(
             status: ApprovalStatus::Approved,
@@ -159,6 +174,13 @@ class ListDraftImagesTest extends TestCase
             'sourceUrl' => 'https://example.com/source-image',
             'sourceName' => 'Source Name',
             'altText' => 'Cover image',
+            'wiki' => [
+                'names' => [
+                    'ko' => 'TWICE',
+                    'ja' => 'トゥワイス',
+                ],
+                'slug' => 'gr-twice',
+            ],
             'status' => ApprovalStatus::Approved->value,
             'uploadedAt' => '2026-05-01T00:00:00+00:00',
         ], $payload['images'][0]);

--- a/typespec/services/wiki-private-api/image.tsp
+++ b/typespec/services/wiki-private-api/image.tsp
@@ -79,6 +79,14 @@ union DraftImageStatus {
   "under_review",
 }
 
+@doc("Wiki display information linked to a draft image through its translation set.")
+model DraftImageWikiDisplayInformation {
+  @doc("Display names keyed by language.")
+  names: Record<string>;
+  @doc("Representative slug of the first linked wiki.")
+  slug: string;
+}
+
 @doc("Draft image item returned by the draft image list endpoint.")
 model DraftImageListItem {
   @doc("Draft image identifier.")
@@ -101,6 +109,8 @@ model DraftImageListItem {
   sourceName: string;
   @doc("Alternative text for the image.")
   altText: string;
+  @doc("Wiki display information linked to this image through its translation set.")
+  wiki: DraftImageWikiDisplayInformation;
   @doc("Approval status of the draft image.")
   status: DraftImageStatus;
   @doc("Timestamp when the image was uploaded.")


### PR DESCRIPTION
## 📝 変更内容

- 下書き画像一覧取得 API の各画像レスポンスに `wiki` を追加
- `translationSetIdentifier` が一致する published Wiki から表示情報を取得
- Wiki 名を `language => name` の map として返却
- slug は最初に紐づいた Wiki の代表値として返却
- TypeSpec と OpenAPI を更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

下書き画像一覧で、画像がどの Wiki に紐づくかをフロントエンド側で表示できるようにするため。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `DraftWikiImage` から `translation_set_identifier` 経由で Wiki を取得する relation の妥当性
- N+1 を避けるための eager load 対象
- `wiki.names` と代表 `wiki.slug` のレスポンス形
- TypeSpec / OpenAPI と実装の整合性

## 📖 関連情報

### 関連Issue・タスク

Closes #364

## ⚠️ 注意事項

破壊的変更・マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
