### PR TITLE
principal meで実効policyを返す

### DIFF
--- a/application/Models/Wiki/Principal.php
+++ b/application/Models/Wiki/Principal.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Application\Models\Wiki;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -17,6 +19,7 @@ use Illuminate\Support\Carbon;
  * @property bool $enabled
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
+ * @property-read Collection<int, PrincipalGroupMembership> $memberships
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',
@@ -41,5 +44,13 @@ class Principal extends Model
             'talent_ids' => 'array',
             'enabled' => 'boolean',
         ];
+    }
+
+    /**
+     * @return HasMany<PrincipalGroupMembership, $this>
+     */
+    public function memberships(): HasMany
+    {
+        return $this->hasMany(PrincipalGroupMembership::class, 'principal_id', 'id');
     }
 }

--- a/application/Models/Wiki/PrincipalGroupMembership.php
+++ b/application/Models/Wiki/PrincipalGroupMembership.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Models\Wiki;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 
 /**
@@ -12,6 +13,7 @@ use Illuminate\Support\Carbon;
  * @property string $principal_id
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
+ * @property-read PrincipalGroup|null $principalGroup
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'principal_group_id',
@@ -37,5 +39,13 @@ class PrincipalGroupMembership extends Model
     {
         return $query->where('principal_group_id', $this->principal_group_id)
             ->where('principal_id', $this->principal_id);
+    }
+
+    /**
+     * @return BelongsTo<PrincipalGroup, $this>
+     */
+    public function principalGroup(): BelongsTo
+    {
+        return $this->belongsTo(PrincipalGroup::class, 'principal_group_id', 'id');
     }
 }

--- a/application/Models/Wiki/PrincipalGroupRoleAttachment.php
+++ b/application/Models/Wiki/PrincipalGroupRoleAttachment.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Application\Models\Wiki;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property string $principal_group_id
  * @property string $role_id
+ * @property-read Role|null $role
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'principal_group_id',
@@ -22,4 +24,12 @@ class PrincipalGroupRoleAttachment extends Model
 
     #[\Override]
     public $timestamps = false;
+
+    /**
+     * @return BelongsTo<Role, $this>
+     */
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class, 'role_id', 'id');
+    }
 }

--- a/application/Models/Wiki/RolePolicyAttachment.php
+++ b/application/Models/Wiki/RolePolicyAttachment.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Application\Models\Wiki;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property string $role_id
  * @property string $policy_id
+ * @property-read Policy|null $policy
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'role_id',
@@ -22,4 +24,12 @@ class RolePolicyAttachment extends Model
 
     #[\Override]
     public $timestamps = false;
+
+    /**
+     * @return BelongsTo<Policy, $this>
+     */
+    public function policy(): BelongsTo
+    {
+        return $this->belongsTo(Policy::class, 'policy_id', 'id');
+    }
 }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2221,6 +2221,30 @@ components:
           type: string
           description: Current workflow status of the draft wiki.
       description: Summary of a draft wiki.
+    EffectivePolicySummary:
+      type: object
+      required:
+        - policyIdentifier
+        - name
+        - isSystemPolicy
+        - statements
+      properties:
+        policyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Policy identifier.
+        name:
+          type: string
+          description: Policy name.
+        isSystemPolicy:
+          type: boolean
+          description: Whether this is a system policy.
+        statements:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyStatement'
+          description: Statements that define the effective policy.
+      description: Effective policy summary returned for the current principal.
     GroupDraftWikiBasic:
       type: object
       required:
@@ -2549,7 +2573,9 @@ components:
           type: string
           description: Operator used for the comparison.
         value:
-          type: string
+          anyOf:
+            - type: string
+            - type: boolean
           description: Value to compare against.
       description: Single condition clause in a policy.
     PolicyStatement:
@@ -2573,8 +2599,10 @@ components:
             type: string
           description: Resource types covered by this statement.
         condition:
+          type: object
           allOf:
             - $ref: '#/components/schemas/PolicyCondition'
+          nullable: true
           description: Optional condition attached to the statement.
       description: Statement that grants or denies actions on resource types.
     PolicySummary:
@@ -2638,6 +2666,7 @@ components:
         - identityIdentifier
         - isDelegatedPrincipal
         - isEnabled
+        - policies
       properties:
         principalIdentifier:
           allOf:
@@ -2653,6 +2682,11 @@ components:
         isEnabled:
           type: boolean
           description: Whether the principal is enabled.
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/EffectivePolicySummary'
+          description: Effective policies granted to the principal through principal groups and roles.
       description: Summary of a principal.
     PublishWikiRequestBody:
       type: object

--- a/src/Wiki/Principal/Application/UseCase/Query/PrincipalReadModel.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/PrincipalReadModel.php
@@ -6,16 +6,20 @@ namespace Source\Wiki\Principal\Application\UseCase\Query;
 
 readonly class PrincipalReadModel
 {
+    /**
+     * @param array<int, array<string, mixed>> $policies
+     */
     public function __construct(
         private string $principalIdentifier,
         private string $identityIdentifier,
         private bool $isDelegatedPrincipal,
         private bool $isEnabled,
+        private array $policies,
     ) {
     }
 
     /**
-     * @return array{principalIdentifier: string, identityIdentifier: string, isDelegatedPrincipal: bool, isEnabled: bool}
+     * @return array{principalIdentifier: string, identityIdentifier: string, isDelegatedPrincipal: bool, isEnabled: bool, policies: array<int, array<string, mixed>>}
      */
     public function toArray(): array
     {
@@ -24,6 +28,7 @@ readonly class PrincipalReadModel
             'identityIdentifier' => $this->identityIdentifier,
             'isDelegatedPrincipal' => $this->isDelegatedPrincipal,
             'isEnabled' => $this->isEnabled,
+            'policies' => $this->policies,
         ];
     }
 }

--- a/src/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipal.php
+++ b/src/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipal.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Infrastructure\Query;
 
+use Application\Models\Wiki\Policy as PolicyModel;
 use Application\Models\Wiki\Principal as PrincipalModel;
 use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInputPort;
 use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
@@ -18,6 +19,7 @@ readonly class GetCurrentPrincipal implements GetCurrentPrincipalInterface
     public function process(GetCurrentPrincipalInputPort $input): PrincipalReadModel
     {
         $principal = PrincipalModel::query()
+            ->with('memberships.principalGroup.roleAttachments.role.policyAttachments.policy')
             ->where('identity_id', (string) $input->identityIdentifier())
             ->first();
 
@@ -35,6 +37,94 @@ readonly class GetCurrentPrincipal implements GetCurrentPrincipalInterface
             identityIdentifier: $principal->identity_id,
             isDelegatedPrincipal: $principal->delegation_identifier !== null,
             isEnabled: $principal->enabled,
+            policies: $this->effectivePolicies($principal),
         );
+    }
+
+    /**
+     * @return array<int, array{policyIdentifier: string, name: string, isSystemPolicy: bool, statements: array<int, array<string, mixed>>}>
+     */
+    private function effectivePolicies(PrincipalModel $principal): array
+    {
+        $policies = [];
+
+        foreach ($principal->memberships as $membership) {
+            $principalGroup = $membership->principalGroup;
+            if ($principalGroup === null) {
+                continue;
+            }
+
+            foreach ($principalGroup->roleAttachments as $roleAttachment) {
+                $role = $roleAttachment->role;
+                if ($role === null) {
+                    continue;
+                }
+
+                foreach ($role->policyAttachments as $policyAttachment) {
+                    $policy = $policyAttachment->policy;
+                    if ($policy === null) {
+                        continue;
+                    }
+
+                    $policies[$policy->id] = $policy;
+                }
+            }
+        }
+
+        ksort($policies);
+
+        return array_map(
+            fn (PolicyModel $policy) => $this->toPolicyArray($policy),
+            array_values($policies)
+        );
+    }
+
+    /**
+     * @return array{policyIdentifier: string, name: string, isSystemPolicy: bool, statements: array<int, array<string, mixed>>}
+     */
+    private function toPolicyArray(PolicyModel $policy): array
+    {
+        return [
+            'policyIdentifier' => $policy->id,
+            'name' => $policy->name,
+            'isSystemPolicy' => $policy->is_system_policy,
+            'statements' => array_map($this->toStatementArray(...), $policy->statements),
+        ];
+    }
+
+    /**
+     * @param array{effect: string, actions: array<string>, resource_types: array<string>, condition?: array<array{key: string, operator: string, value: string|bool}>|null} $statement
+     * @return array{effect: string, actions: array<string>, resourceTypes: array<string>, condition: array{clauses: array<int, array{field: string, operator: string, value: string|bool}>}|null}
+     */
+    private function toStatementArray(array $statement): array
+    {
+        return [
+            'effect' => $statement['effect'],
+            'actions' => $statement['actions'],
+            'resourceTypes' => $statement['resource_types'],
+            'condition' => $this->toConditionArray($statement['condition'] ?? null),
+        ];
+    }
+
+    /**
+     * @param array<array{key: string, operator: string, value: string|bool}>|null $condition
+     * @return array{clauses: array<int, array{field: string, operator: string, value: string|bool}>}|null
+     */
+    private function toConditionArray(?array $condition): ?array
+    {
+        if ($condition === null) {
+            return null;
+        }
+
+        return [
+            'clauses' => array_map(
+                static fn (array $clause) => [
+                    'field' => $clause['key'],
+                    'operator' => $clause['operator'],
+                    'value' => $clause['value'],
+                ],
+                $condition
+            ),
+        ];
     }
 }

--- a/tests/Wiki/Principal/Application/UseCase/Query/PrincipalReadModelTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Query/PrincipalReadModelTest.php
@@ -16,6 +16,21 @@ class PrincipalReadModelTest extends TestCase
             identityIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
             isDelegatedPrincipal: true,
             isEnabled: false,
+            policies: [
+                [
+                    'policyIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+                    'name' => 'Wiki Editor',
+                    'isSystemPolicy' => true,
+                    'statements' => [
+                        [
+                            'effect' => 'allow',
+                            'actions' => ['edit'],
+                            'resourceTypes' => ['group'],
+                            'condition' => null,
+                        ],
+                    ],
+                ],
+            ],
         );
 
         $this->assertSame([
@@ -23,6 +38,21 @@ class PrincipalReadModelTest extends TestCase
             'identityIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
             'isDelegatedPrincipal' => true,
             'isEnabled' => false,
+            'policies' => [
+                [
+                    'policyIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+                    'name' => 'Wiki Editor',
+                    'isSystemPolicy' => true,
+                    'statements' => [
+                        [
+                            'effect' => 'allow',
+                            'actions' => ['edit'],
+                            'resourceTypes' => ['group'],
+                            'condition' => null,
+                        ],
+                    ],
+                ],
+            ],
         ], $readModel->toArray());
     }
 }

--- a/tests/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipalTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Query/GetCurrentPrincipalTest.php
@@ -5,15 +5,25 @@ declare(strict_types=1);
 namespace Tests\Wiki\Principal\Infrastructure\Query;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Facades\DB;
 use JsonException;
 use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInput;
 use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\CreateAccount;
 use Tests\Helper\CreateIdentity;
+use Tests\Helper\CreatePolicy;
 use Tests\Helper\CreatePrincipal;
+use Tests\Helper\CreatePrincipalGroup;
+use Tests\Helper\CreatePrincipalGroupMembership;
+use Tests\Helper\CreateRole;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -41,6 +51,146 @@ class GetCurrentPrincipalTest extends TestCase
         $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
         $this->assertFalse($result['isDelegatedPrincipal']);
         $this->assertTrue($result['isEnabled']);
+        $this->assertSame([], $result['policies']);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws JsonException
+     */
+    #[Group('useDb')]
+    public function testProcessReturnsEffectivePoliciesThroughPrincipalGroupAndRole(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        CreateIdentity::create($identityIdentifier);
+
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        CreatePrincipal::create($principalIdentifier, $identityIdentifier);
+
+        $policyIdentifier = new PolicyIdentifier(StrTestHelper::generateUuid());
+        CreatePolicy::create($policyIdentifier, [
+            'name' => 'Wiki Editor',
+            'is_system_policy' => true,
+            'statements' => [
+                [
+                    'effect' => 'allow',
+                    'actions' => ['edit'],
+                    'resource_types' => ['group'],
+                    'condition' => [
+                        [
+                            'key' => 'resource:groupId',
+                            'operator' => 'in',
+                            'value' => '${principal.wikiGroupIds}',
+                        ],
+                    ],
+                ],
+                [
+                    'effect' => 'deny',
+                    'actions' => ['rollback'],
+                    'resource_types' => ['group'],
+                    'condition' => null,
+                ],
+            ],
+        ]);
+
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        CreateRole::create($roleIdentifier, ['policies' => [(string) $policyIdentifier]]);
+
+        $principalGroupIdentifier = $this->createPrincipalGroupWithMember($principalIdentifier);
+        $this->attachRoleToPrincipalGroup($principalGroupIdentifier, $roleIdentifier);
+
+        $useCase = $this->app->make(GetCurrentPrincipalInterface::class);
+        $readModel = $useCase->process(new GetCurrentPrincipalInput($identityIdentifier));
+
+        $result = $readModel->toArray();
+        $this->assertSame([
+            [
+                'policyIdentifier' => (string) $policyIdentifier,
+                'name' => 'Wiki Editor',
+                'isSystemPolicy' => true,
+                'statements' => [
+                    [
+                        'effect' => 'allow',
+                        'actions' => ['edit'],
+                        'resourceTypes' => ['group'],
+                        'condition' => [
+                            'clauses' => [
+                                [
+                                    'field' => 'resource:groupId',
+                                    'operator' => 'in',
+                                    'value' => '${principal.wikiGroupIds}',
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'effect' => 'deny',
+                        'actions' => ['rollback'],
+                        'resourceTypes' => ['group'],
+                        'condition' => null,
+                    ],
+                ],
+            ],
+        ], $result['policies']);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws JsonException
+     */
+    #[Group('useDb')]
+    public function testProcessDoesNotDuplicatePolicyAttachedThroughMultipleRoles(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        CreateIdentity::create($identityIdentifier);
+
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        CreatePrincipal::create($principalIdentifier, $identityIdentifier);
+
+        $policyIdentifier = new PolicyIdentifier(StrTestHelper::generateUuid());
+        CreatePolicy::create($policyIdentifier);
+
+        $roleIdentifier1 = new RoleIdentifier(StrTestHelper::generateUuid());
+        $roleIdentifier2 = new RoleIdentifier(StrTestHelper::generateUuid());
+        CreateRole::create($roleIdentifier1, ['policies' => [(string) $policyIdentifier]]);
+        CreateRole::create($roleIdentifier2, ['policies' => [(string) $policyIdentifier]]);
+
+        $principalGroupIdentifier = $this->createPrincipalGroupWithMember($principalIdentifier);
+        $this->attachRoleToPrincipalGroup($principalGroupIdentifier, $roleIdentifier1);
+        $this->attachRoleToPrincipalGroup($principalGroupIdentifier, $roleIdentifier2);
+
+        $useCase = $this->app->make(GetCurrentPrincipalInterface::class);
+        $readModel = $useCase->process(new GetCurrentPrincipalInput($identityIdentifier));
+
+        $result = $readModel->toArray();
+        $this->assertCount(1, $result['policies']);
+        $this->assertSame((string) $policyIdentifier, $result['policies'][0]['policyIdentifier']);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws JsonException
+     */
+    #[Group('useDb')]
+    public function testProcessReturnsEmptyPoliciesWhenPrincipalHasNoPolicies(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        CreateIdentity::create($identityIdentifier);
+
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        CreatePrincipal::create($principalIdentifier, $identityIdentifier);
+
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        CreateRole::create($roleIdentifier);
+
+        $principalGroupIdentifier = $this->createPrincipalGroupWithMember($principalIdentifier);
+        $this->attachRoleToPrincipalGroup($principalGroupIdentifier, $roleIdentifier);
+
+        $useCase = $this->app->make(GetCurrentPrincipalInterface::class);
+        $readModel = $useCase->process(new GetCurrentPrincipalInput($identityIdentifier));
+
+        $result = $readModel->toArray();
+        $this->assertSame([], $result['policies']);
     }
 
     /**
@@ -55,5 +205,27 @@ class GetCurrentPrincipalTest extends TestCase
 
         $useCase = $this->app->make(GetCurrentPrincipalInterface::class);
         $useCase->process(new GetCurrentPrincipalInput($identityIdentifier));
+    }
+
+    private function createPrincipalGroupWithMember(PrincipalIdentifier $principalIdentifier): PrincipalGroupIdentifier
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $accountIdentifier);
+
+        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        CreatePrincipalGroup::create($principalGroupIdentifier, $accountIdentifier);
+        CreatePrincipalGroupMembership::create((string) $principalGroupIdentifier, (string) $principalIdentifier);
+
+        return $principalGroupIdentifier;
+    }
+
+    private function attachRoleToPrincipalGroup(
+        PrincipalGroupIdentifier $principalGroupIdentifier,
+        RoleIdentifier $roleIdentifier
+    ): void {
+        DB::table('principal_group_role_attachments')->insert([
+            'principal_group_id' => (string) $principalGroupIdentifier,
+            'role_id' => (string) $roleIdentifier,
+        ]);
     }
 }

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -433,6 +433,8 @@ model PrincipalSummary {
   isDelegatedPrincipal: boolean;
   @doc("Whether the principal is enabled.")
   isEnabled: boolean;
+  @doc("Effective policies granted to the principal through principal groups and roles.")
+  policies: EffectivePolicySummary[];
 }
 
 @doc("Summary of a principal group.")
@@ -475,6 +477,18 @@ model PolicySummary {
   createdAt: string;
 }
 
+@doc("Effective policy summary returned for the current principal.")
+model EffectivePolicySummary {
+  @doc("Policy identifier.")
+  policyIdentifier: Uuid;
+  @doc("Policy name.")
+  name: string;
+  @doc("Whether this is a system policy.")
+  isSystemPolicy: boolean;
+  @doc("Statements that define the effective policy.")
+  statements: PolicyStatement[];
+}
+
 @doc("Summary of an official certification request.")
 model OfficialCertificationSummary {
   @doc("Certification identifier.")
@@ -494,7 +508,7 @@ model PolicyConditionClause {
   @doc("Operator used for the comparison.")
   operator: string;
   @doc("Value to compare against.")
-  value: string;
+  value: string | boolean;
 }
 
 @doc("Conditional constraints for a policy statement.")
@@ -512,5 +526,5 @@ model PolicyStatement {
   @doc("Resource types covered by this statement.")
   resourceTypes: string[];
   @doc("Optional condition attached to the statement.")
-  condition?: PolicyCondition;
+  condition?: PolicyCondition | null;
 }


### PR DESCRIPTION
## 📝 変更内容

`GET /principal/me` のレスポンスに、認証中 principal の実効 policy 一覧を追加しました。

- principal group / role / policy を辿る Eloquent relation を追加
- `GetCurrentPrincipal` で relation を eager load し、実効 policy を集約
- 同一 policy が複数 role 経由で到達する場合は `policyIdentifier` で重複排除
- `statements.resource_types` を API レスポンス用に `resourceTypes` へ変換
- `PrincipalSummary` に `policies` を追加し、TypeSpec / OpenAPI を更新
- policy 返却、重複排除、policy なしケースのテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

フロントエンドで現在のユーザーが持つ Wiki 権限を判定できるようにするため、role ではなく最終的な policy statement を `GET /principal/me` から取得できるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- principal group -> role -> policy の relation eager load が既存モデル構造に合っているか
- `policyIdentifier` による重複排除で問題ないか
- `statements` のレスポンス変換、特に `resourceTypes` と `condition` の形が API 契約として適切か
- `PrincipalSummary` に `policies` を必須項目として追加して問題ないか

## 📖 関連情報

### 関連Issue・タスク

Closes #366

## ⚠️ 注意事項

破壊的な DB マイグレーションはありません。
`PrincipalSummary` のレスポンス項目に `policies` が追加されます。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
