### PR TITLE
Full AccessテストユーザーSeederを追加

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             SystemPolicySeeder::class,
             SystemRoleSeeder::class,
+            FullAccessTestAccountSeeder::class,
             WikiEditorSampleSeeder::class,
         ]);
     }

--- a/database/seeders/FullAccessTestAccountSeeder.php
+++ b/database/seeders/FullAccessTestAccountSeeder.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use RuntimeException;
+
+class FullAccessTestAccountSeeder extends Seeder
+{
+    private const string ACCOUNT_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217fa01';
+    private const string IDENTITY_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217fa02';
+    private const string PRINCIPAL_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217fa03';
+    private const string PRINCIPAL_GROUP_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217fa04';
+    private const string EMAIL = 'test@example.com';
+
+    public function run(): void
+    {
+        $administratorRoleId = DB::table('roles')
+            ->where('name', 'ADMINISTRATOR')
+            ->value('id');
+
+        if (! is_string($administratorRoleId)) {
+            throw new RuntimeException('ADMINISTRATOR role not found. Please run SystemRoleSeeder first.');
+        }
+
+        $now = now();
+
+        DB::table('accounts')->upsert([
+            [
+                'id' => self::ACCOUNT_ID,
+                'email' => self::EMAIL,
+                'type' => 'individual',
+                'name' => 'Full Access Test Account',
+                'status' => 'active',
+                'category' => 'general',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['id']);
+
+        DB::table('identities')->upsert([
+            [
+                'id' => self::IDENTITY_ID,
+                'username' => 'full-access-test',
+                'email' => self::EMAIL,
+                'language' => 'ja',
+                'profile_image' => null,
+                'password' => Hash::make('password'),
+                'email_verified_at' => $now,
+                'delegation_identifier' => null,
+                'original_identity_identifier' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['id']);
+
+        DB::table('wiki_principals')->upsert([
+            [
+                'id' => self::PRINCIPAL_ID,
+                'identity_id' => self::IDENTITY_ID,
+                'agency_id' => null,
+                'group_ids' => json_encode([], JSON_THROW_ON_ERROR),
+                'talent_ids' => json_encode([], JSON_THROW_ON_ERROR),
+                'delegation_identifier' => null,
+                'enabled' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['id']);
+
+        DB::table('principal_groups')->upsert([
+            [
+                'id' => self::PRINCIPAL_GROUP_ID,
+                'account_id' => self::ACCOUNT_ID,
+                'name' => 'Full Access Test Group',
+                'is_default' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['id']);
+
+        DB::table('principal_group_memberships')->upsert([
+            [
+                'principal_group_id' => self::PRINCIPAL_GROUP_ID,
+                'principal_id' => self::PRINCIPAL_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['principal_group_id', 'principal_id']);
+
+        DB::table('principal_group_role_attachments')->upsert([
+            [
+                'principal_group_id' => self::PRINCIPAL_GROUP_ID,
+                'role_id' => $administratorRoleId,
+            ],
+        ], ['principal_group_id', 'role_id']);
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

Full Access 権限でログインできるテスト用 account / identity / principal を作成する Seeder を追加しました。

- `test@example.com` / `password` でログイン可能な認証済み identity を作成
- 対応する account / wiki principal / principal group を作成
- `FULL_ACCESS` policy を持つ `ADMINISTRATOR` role を principal group に付与
- `DatabaseSeeder` から system policy / role 作成後に実行されるよう追加
- 再実行しても重複しないよう `upsert` で投入

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

開発環境や動作確認で、Wiki の Full Access 権限を持つユーザーとしてすぐログインできるようにするためです。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行済み:

- `php -l database/seeders/FullAccessTestAccountSeeder.php`
- `php -l database/seeders/DatabaseSeeder.php`
- `task phpstan`
- `git diff --check`

## 🔍 レビューのポイント

- `ADMINISTRATOR` role を Full Access role として利用する前提で問題ないか
- 固定 UUID / 固定メールアドレスの seed data として問題ないか
- `DatabaseSeeder` の実行順序が system role 依存として適切か
- `upsert` による再実行可能性が十分か

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

DB マイグレーションはありません。
`db:seed` 実行時に `test@example.com` の account / identity が投入されます。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
