### PR TITLE
Draft Wiki Detailで翻訳セットIDを返す

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1875,6 +1875,7 @@ components:
       type: object
       required:
         - wikiIdentifier
+        - translationSetIdentifier
         - slug
         - language
         - resourceType
@@ -1887,6 +1888,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Draft wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
         slug:
           type: string
           description: Unique slug of the wiki.
@@ -2147,6 +2152,7 @@ components:
       type: object
       required:
         - wikiIdentifier
+        - translationSetIdentifier
         - slug
         - language
         - resourceType
@@ -2159,6 +2165,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Draft wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
         slug:
           type: string
           description: Unique slug of the wiki.
@@ -2918,6 +2928,7 @@ components:
       type: object
       required:
         - wikiIdentifier
+        - translationSetIdentifier
         - slug
         - language
         - resourceType
@@ -2930,6 +2941,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Draft wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
         slug:
           type: string
           description: Unique slug of the wiki.
@@ -3181,6 +3196,7 @@ components:
       type: object
       required:
         - wikiIdentifier
+        - translationSetIdentifier
         - slug
         - language
         - resourceType
@@ -3193,6 +3209,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Draft wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
         slug:
           type: string
           description: Unique slug of the wiki.

--- a/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
@@ -7,6 +7,7 @@ namespace Source\Wiki\Wiki\Application\UseCase\Query;
 readonly class DraftWikiReadModel
 {
     private string $wikiIdentifier;
+    private string $translationSetIdentifier;
     private string $slug;
     private string $language;
     private string $resourceType;
@@ -25,6 +26,7 @@ readonly class DraftWikiReadModel
      */
     public function __construct(
         string $wikiIdentifier,
+        string $translationSetIdentifier,
         string $slug,
         string $language,
         string $resourceType,
@@ -35,6 +37,7 @@ readonly class DraftWikiReadModel
         array $sections,
     ) {
         $this->wikiIdentifier = $wikiIdentifier;
+        $this->translationSetIdentifier = $translationSetIdentifier;
         $this->slug = $slug;
         $this->language = $language;
         $this->resourceType = $resourceType;
@@ -54,6 +57,11 @@ readonly class DraftWikiReadModel
     public function wikiIdentifier(): string
     {
         return $this->wikiIdentifier;
+    }
+
+    public function translationSetIdentifier(): string
+    {
+        return $this->translationSetIdentifier;
     }
 
     public function slug(): string
@@ -111,6 +119,7 @@ readonly class DraftWikiReadModel
     {
         return [
             'wikiIdentifier' => $this->wikiIdentifier,
+            'translationSetIdentifier' => $this->translationSetIdentifier,
             'slug' => $this->slug,
             'language' => $this->language,
             'resourceType' => $this->resourceType,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
@@ -36,6 +36,7 @@ readonly class GetAgencyDraftWiki implements GetAgencyDraftWikiInterface
 
         return new DraftWikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::AGENCY->value,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
@@ -38,6 +38,7 @@ readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
 
         return new DraftWikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::GROUP->value,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
@@ -39,6 +39,7 @@ readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
 
         return new DraftWikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::SONG->value,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
@@ -40,6 +40,7 @@ readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
 
         return new DraftWikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::TALENT->value,

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
@@ -14,6 +14,7 @@ class DraftWikiReadModelTest extends TestCase
     {
         $readModel = new DraftWikiReadModel(
             wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f003',
             slug: 'gr-twice',
             language: 'ko',
             resourceType: 'group',
@@ -48,6 +49,7 @@ class DraftWikiReadModelTest extends TestCase
         );
 
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f003', $readModel->translationSetIdentifier());
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());
@@ -59,6 +61,7 @@ class DraftWikiReadModelTest extends TestCase
         $this->assertSame('overview', $readModel->sections()[0]['id']);
         $this->assertSame([
             'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'translationSetIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f003',
             'slug' => 'gr-twice',
             'language' => 'ko',
             'resourceType' => 'group',

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWikiTest.php
@@ -35,6 +35,7 @@ class GetAgencyDraftWikiTest extends TestCase
             'agency',
             [
                 'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f405',
                 'slug' => 'ag-jyp-entertainment',
                 'language' => 'ko',
                 'theme_color' => '#1A1A1A',
@@ -68,6 +69,7 @@ class GetAgencyDraftWikiTest extends TestCase
         $readModel = $useCase->process(new GetAgencyDraftWikiInput(new Slug('ag-jyp-entertainment'), Language::KOREAN));
 
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f402', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f405', $readModel->translationSetIdentifier());
         $this->assertSame('ag-jyp-entertainment', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('agency', $readModel->resourceType());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
@@ -25,6 +25,7 @@ class GetGroupDraftWikiTest extends TestCase
         $readModel = $useCase->process(new GetGroupDraftWikiInput(new Slug('gr-twice'), Language::KOREAN));
 
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f003', $readModel->translationSetIdentifier());
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
@@ -93,6 +93,7 @@ class GetSongDraftWikiTest extends TestCase
             'song',
             [
                 'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f302',
                 'slug' => 'sg-signal',
                 'language' => 'ko',
                 'theme_color' => '#FE5F8F',
@@ -127,6 +128,7 @@ class GetSongDraftWikiTest extends TestCase
         $readModel = $useCase->process(new GetSongDraftWikiInput(new Slug('sg-signal'), Language::KOREAN));
 
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f301', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f302', $readModel->translationSetIdentifier());
         $this->assertSame('sg-signal', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('song', $readModel->resourceType());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
@@ -25,6 +25,7 @@ class GetTalentDraftWikiTest extends TestCase
         $readModel = $useCase->process(new GetTalentDraftWikiInput(new Slug('tl-chaeyoung'), Language::KOREAN));
 
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f172', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f173', $readModel->translationSetIdentifier());
         $this->assertSame('tl-chaeyoung', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('talent', $readModel->resourceType());

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -77,6 +77,8 @@ model GroupDraftWikiBasic {
 model DraftWikiDetail {
   @doc("Draft wiki identifier.")
   wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
   @doc("Unique slug of the wiki.")
   slug: string;
   @doc("Language of the wiki.")
@@ -173,6 +175,8 @@ model TalentDraftWikiBasic {
 model TalentDraftWikiDetail {
   @doc("Draft wiki identifier.")
   wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
   @doc("Unique slug of the wiki.")
   slug: string;
   @doc("Language of the wiki.")
@@ -309,6 +313,8 @@ model SongDraftWikiBasic {
 model SongDraftWikiDetail {
   @doc("Draft wiki identifier.")
   wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
   @doc("Unique slug of the wiki.")
   slug: string;
   @doc("Language of the wiki.")
@@ -355,6 +361,8 @@ model AgencyDraftWikiBasic {
 model AgencyDraftWikiDetail {
   @doc("Draft wiki identifier.")
   wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
   @doc("Unique slug of the wiki.")
   slug: string;
   @doc("Language of the wiki.")


### PR DESCRIPTION
## 📝 変更内容

Draft wiki detail API のレスポンスに `translationSetIdentifier` を追加しました。

- `DraftWikiReadModel` に `translationSetIdentifier` を追加
- group / talent / song / agency の draft detail query で `draft_wikis.translation_set_identifier` を返却
- TypeSpec と OpenAPI を更新
- 各 draft detail query のテストで `translationSetIdentifier` の返却を検証

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

draft wiki detail API の利用側で、画像アップロード等に必要な翻訳セットIDを detail レスポンスから取得できるようにするため。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行済み:

- `task openapi-generate`
- `task test filter=DraftWikiReadModelTest`
- `task test filter=GetGroupDraftWikiTest`
- `task test filter=GetTalentDraftWikiTest`
- `task test filter=GetSongDraftWikiTest`
- `task test filter=GetAgencyDraftWikiTest`
- `task phpstan`

## 🔍 レビューのポイント

- 4種類の draft detail API すべてで `translationSetIdentifier` が返っていること
- TypeSpec / OpenAPI のレスポンス定義が実装と一致していること
- 既存の `wikiIdentifier` と別フィールドとして扱えていること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
