### PR TITLE
fix: Wiki/Principalレスポンスのスキーマ不整合を修正

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1185,6 +1185,46 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateWikiRequestBody'
+  /wiki/{language}/agency/{slug}:
+    get:
+      operationId: WikiOperations_getAgencyWiki
+      description: Fetch the published agency wiki.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when an agency published wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgencyWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /wiki/{language}/agency/{slug}/draft:
     get:
       operationId: WikiOperations_getAgencyDraftWiki
@@ -1207,6 +1247,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgencyDraftWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /wiki/{language}/group/{slug}:
+    get:
+      operationId: WikiOperations_getGroupWiki
+      description: Fetch the published group wiki.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when a group published wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WikiDetail'
         '404':
           description: The server cannot find the requested resource.
           content:
@@ -1265,6 +1345,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /wiki/{language}/song/{slug}:
+    get:
+      operationId: WikiOperations_getSongWiki
+      description: Fetch the published song wiki.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when a song published wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SongWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /wiki/{language}/song/{slug}/draft:
     get:
       operationId: WikiOperations_getSongDraftWiki
@@ -1287,6 +1407,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SongDraftWikiDetail'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /wiki/{language}/talent/{slug}:
+    get:
+      operationId: WikiOperations_getTalentWiki
+      description: Fetch the published talent wiki.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Response returned when a talent published wiki is fetched.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TalentWikiDetail'
         '404':
           description: The server cannot find the requested resource.
           content:
@@ -1921,6 +2081,58 @@ components:
           items: {}
           description: Section content payloads.
       description: Detailed agency draft wiki payload used by the editor.
+    AgencyWikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - translationSetIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - themeColor
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number.
+        themeColor:
+          type: string
+          nullable: true
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload.
+        basic:
+          allOf:
+            - $ref: '#/components/schemas/AgencyDraftWikiBasic'
+          description: Basic agency wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed published agency wiki payload.
     AttachPolicyToRoleRequestBody:
       type: object
       required:
@@ -3121,6 +3333,58 @@ components:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Profile image identifier of the talent.
       description: Summary of a published talent linked from a song draft wiki.
+    SongWikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - translationSetIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - themeColor
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number.
+        themeColor:
+          type: string
+          nullable: true
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload.
+        basic:
+          allOf:
+            - $ref: '#/components/schemas/SongDraftWikiBasic'
+          description: Basic song wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed published song wiki payload.
     TalentDraftWikiBasic:
       type: object
       required:
@@ -3311,6 +3575,58 @@ components:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Main image identifier of the group.
       description: Summary of a published group linked from a talent draft wiki.
+    TalentWikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - translationSetIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - themeColor
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number.
+        themeColor:
+          type: string
+          nullable: true
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload.
+        basic:
+          allOf:
+            - $ref: '#/components/schemas/TalentDraftWikiBasic'
+          description: Basic talent wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed published talent wiki payload.
     TranslateWikiResponseBody:
       type: object
       required:
@@ -3492,10 +3808,63 @@ components:
             $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Associated talent identifiers.
       description: Association targets that link a wiki to related agencies, groups, or talents.
+    WikiDetail:
+      type: object
+      required:
+        - wikiIdentifier
+        - translationSetIdentifier
+        - slug
+        - language
+        - resourceType
+        - version
+        - themeColor
+        - heroImage
+        - basic
+        - sections
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
+        slug:
+          type: string
+          description: Unique slug of the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        version:
+          type: integer
+          format: int32
+          description: Published version number.
+        themeColor:
+          type: string
+          nullable: true
+          description: Theme color applied to the wiki.
+        heroImage:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiHeroImage'
+          description: Hero image payload.
+        basic:
+          allOf:
+            - $ref: '#/components/schemas/GroupDraftWikiBasic'
+          description: Basic wiki content payload.
+        sections:
+          type: array
+          items: {}
+          description: Section content payloads.
+      description: Detailed published group wiki payload.
     WikiListItem:
       type: object
       required:
         - wikiIdentifier
+        - translationSetIdentifier
         - slug
         - language
         - resourceType
@@ -3510,6 +3879,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Wiki identifier.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
         slug:
           type: string
           description: Unique slug for the wiki.

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -891,7 +891,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PrincipalSummary'
+                $ref: '#/components/schemas/CreatedPrincipalSummary'
         '409':
           description: The request conflicts with the current state of the server.
           content:
@@ -2271,6 +2271,29 @@ components:
       allOf:
         - $ref: '#/components/schemas/WikiAssociationTargets'
       description: Request body for creating a wiki draft.
+    CreatedPrincipalSummary:
+      type: object
+      required:
+        - principalIdentifier
+        - identityIdentifier
+        - isDelegatedPrincipal
+        - isEnabled
+      properties:
+        principalIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Principal identifier.
+        identityIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Identity identifier linked to the principal.
+        isDelegatedPrincipal:
+          type: boolean
+          description: Whether the principal is delegated.
+        isEnabled:
+          type: boolean
+          description: Whether the principal is enabled.
+      description: Summary of a newly created principal.
     DraftImageListItem:
       type: object
       required:

--- a/src/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModel.php
@@ -8,6 +8,7 @@ readonly class WikiListItemReadModel
 {
     public function __construct(
         private string $wikiIdentifier,
+        private string $translationSetIdentifier,
         private string $slug,
         private string $language,
         private string $resourceType,
@@ -37,6 +38,7 @@ readonly class WikiListItemReadModel
     {
         return [
             'wikiIdentifier' => $this->wikiIdentifier,
+            'translationSetIdentifier' => $this->translationSetIdentifier,
             'slug' => $this->slug,
             'language' => $this->language,
             'resourceType' => $this->resourceType,

--- a/src/Wiki/Wiki/Application/UseCase/Query/WikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/WikiReadModel.php
@@ -7,6 +7,7 @@ namespace Source\Wiki\Wiki\Application\UseCase\Query;
 readonly class WikiReadModel
 {
     private string $wikiIdentifier;
+    private string $translationSetIdentifier;
     private string $slug;
     private string $language;
     private string $resourceType;
@@ -25,6 +26,7 @@ readonly class WikiReadModel
      */
     public function __construct(
         string $wikiIdentifier,
+        string $translationSetIdentifier,
         string $slug,
         string $language,
         string $resourceType,
@@ -35,6 +37,7 @@ readonly class WikiReadModel
         array $sections,
     ) {
         $this->wikiIdentifier = $wikiIdentifier;
+        $this->translationSetIdentifier = $translationSetIdentifier;
         $this->slug = $slug;
         $this->language = $language;
         $this->resourceType = $resourceType;
@@ -54,6 +57,11 @@ readonly class WikiReadModel
     public function wikiIdentifier(): string
     {
         return $this->wikiIdentifier;
+    }
+
+    public function translationSetIdentifier(): string
+    {
+        return $this->translationSetIdentifier;
     }
 
     public function slug(): string
@@ -111,6 +119,7 @@ readonly class WikiReadModel
     {
         return [
             'wikiIdentifier' => $this->wikiIdentifier,
+            'translationSetIdentifier' => $this->translationSetIdentifier,
             'slug' => $this->slug,
             'language' => $this->language,
             'resourceType' => $this->resourceType,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
@@ -36,6 +36,7 @@ readonly class GetAgencyWiki implements GetAgencyWikiInterface
 
         return new WikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::AGENCY->value,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
@@ -36,6 +36,7 @@ readonly class GetGroupWiki implements GetGroupWikiInterface
 
         return new WikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::GROUP->value,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
@@ -38,6 +38,7 @@ readonly class GetSongWiki implements GetSongWikiInterface
 
         return new WikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::SONG->value,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
@@ -39,6 +39,7 @@ readonly class GetTalentWiki implements GetTalentWikiInterface
 
         return new WikiReadModel(
             wikiIdentifier: $model->id,
+            translationSetIdentifier: $model->translation_set_identifier,
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::TALENT->value,

--- a/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
@@ -130,6 +130,7 @@ readonly class ListWikis implements ListWikisInterface
 
         return new WikiListItemReadModel(
             wikiIdentifier: $wiki->id,
+            translationSetIdentifier: $wiki->translation_set_identifier,
             slug: $wiki->slug,
             language: $wiki->language,
             resourceType: $wiki->resource_type,

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListWikis/ListWikisOutputTest.php
@@ -14,6 +14,7 @@ class ListWikisOutputTest extends TestCase
     {
         $item = new WikiListItemReadModel(
             wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
             slug: 'tl-chaeyoung',
             language: 'ko',
             resourceType: 'talent',

--- a/tests/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModelTest.php
@@ -13,6 +13,7 @@ class WikiListItemReadModelTest extends TestCase
     {
         $readModel = new WikiListItemReadModel(
             wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
             slug: 'tl-chaeyoung',
             language: 'ko',
             resourceType: 'talent',
@@ -26,6 +27,7 @@ class WikiListItemReadModelTest extends TestCase
 
         $this->assertSame([
             'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'translationSetIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
             'slug' => 'tl-chaeyoung',
             'language' => 'ko',
             'resourceType' => 'talent',

--- a/tests/Wiki/Wiki/Application/UseCase/Query/WikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/WikiReadModelTest.php
@@ -14,6 +14,7 @@ class WikiReadModelTest extends TestCase
     {
         $readModel = new WikiReadModel(
             wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f003',
             slug: 'gr-twice',
             language: 'ko',
             resourceType: 'group',
@@ -48,6 +49,7 @@ class WikiReadModelTest extends TestCase
         );
 
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f003', $readModel->translationSetIdentifier());
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());
@@ -59,6 +61,7 @@ class WikiReadModelTest extends TestCase
         $this->assertSame('overview', $readModel->sections()[0]['id']);
         $this->assertSame([
             'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'translationSetIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f003',
             'slug' => 'gr-twice',
             'language' => 'ko',
             'resourceType' => 'group',

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyWikiTest.php
@@ -26,6 +26,7 @@ class GetAgencyWikiTest extends TestCase
             [
                 'slug' => 'ag-jyp-entertainment',
                 'language' => 'ko',
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f405',
                 'version' => 3,
                 'theme_color' => '#1A1A1A',
                 'sections' => json_encode([
@@ -59,6 +60,7 @@ class GetAgencyWikiTest extends TestCase
 
         $this->assertInstanceOf(WikiReadModel::class, $readModel);
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f401', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f405', $readModel->translationSetIdentifier());
         $this->assertSame('ag-jyp-entertainment', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('agency', $readModel->resourceType());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
@@ -24,6 +24,7 @@ class GetGroupWikiTest extends TestCase
             '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
             'group',
             [
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f003',
                 'slug' => 'gr-twice',
                 'language' => 'ko',
                 'version' => 2,
@@ -55,6 +56,7 @@ class GetGroupWikiTest extends TestCase
 
         $this->assertInstanceOf(WikiReadModel::class, $readModel);
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f003', $readModel->translationSetIdentifier());
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetSongWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetSongWikiTest.php
@@ -67,6 +67,7 @@ class GetSongWikiTest extends TestCase
             [
                 'slug' => 'sg-signal',
                 'language' => 'ko',
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f203',
                 'version' => 5,
                 'theme_color' => '#FE5F8F',
                 'sections' => json_encode([
@@ -101,6 +102,7 @@ class GetSongWikiTest extends TestCase
 
         $this->assertInstanceOf(WikiReadModel::class, $readModel);
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f201', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f203', $readModel->translationSetIdentifier());
         $this->assertSame('sg-signal', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('song', $readModel->resourceType());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetTalentWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetTalentWikiTest.php
@@ -45,6 +45,7 @@ class GetTalentWikiTest extends TestCase
             [
                 'slug' => 'tl-chaeyoung',
                 'language' => 'ko',
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
                 'version' => 4,
                 'theme_color' => '#FE5F8F',
                 'sections' => json_encode([
@@ -78,6 +79,7 @@ class GetTalentWikiTest extends TestCase
 
         $this->assertInstanceOf(WikiReadModel::class, $readModel);
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f101', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f103', $readModel->translationSetIdentifier());
         $this->assertSame('tl-chaeyoung', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('talent', $readModel->resourceType());

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListWikisTest.php
@@ -34,6 +34,8 @@ class ListWikisTest extends TestCase
             '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
             '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
         ], array_column($payload['wikis'], 'wikiIdentifier'));
+        $this->assertArrayHasKey('translationSetIdentifier', $payload['wikis'][0]);
+        $this->assertIsString($payload['wikis'][0]['translationSetIdentifier']);
         $this->assertArrayNotHasKey('sections', $payload['wikis'][0]);
     }
 

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -97,6 +97,30 @@ model DraftWikiDetail {
   sections: unknown[];
 }
 
+@doc("Detailed published group wiki payload.")
+model WikiDetail {
+  @doc("Published wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor: string | null;
+  @doc("Hero image payload.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic wiki content payload.")
+  basic: GroupDraftWikiBasic;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
 @doc("Summary of a published group linked from a talent draft wiki.")
 model TalentDraftWikiGroupSummary {
   @doc("Published group wiki identifier.")
@@ -188,6 +212,30 @@ model TalentDraftWikiDetail {
   @doc("Theme color applied to the wiki.")
   themeColor?: string;
   @doc("Hero image payload for the editor.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic talent wiki content payload.")
+  basic: TalentDraftWikiBasic;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
+@doc("Detailed published talent wiki payload.")
+model TalentWikiDetail {
+  @doc("Published wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor: string | null;
+  @doc("Hero image payload.")
   heroImage: DraftWikiHeroImage;
   @doc("Basic talent wiki content payload.")
   basic: TalentDraftWikiBasic;
@@ -333,6 +381,30 @@ model SongDraftWikiDetail {
   sections: unknown[];
 }
 
+@doc("Detailed published song wiki payload.")
+model SongWikiDetail {
+  @doc("Published wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor: string | null;
+  @doc("Hero image payload.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic song wiki content payload.")
+  basic: SongDraftWikiBasic;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
 @doc("Basic payload for an agency draft wiki.")
 model AgencyDraftWikiBasic {
   @doc("Display name of the agency.")
@@ -374,6 +446,30 @@ model AgencyDraftWikiDetail {
   @doc("Theme color applied to the wiki.")
   themeColor?: string;
   @doc("Hero image payload for the editor.")
+  heroImage: DraftWikiHeroImage;
+  @doc("Basic agency wiki content payload.")
+  basic: AgencyDraftWikiBasic;
+  @doc("Section content payloads.")
+  sections: unknown[];
+}
+
+@doc("Detailed published agency wiki payload.")
+model AgencyWikiDetail {
+  @doc("Published wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
+  @doc("Unique slug of the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Published version number.")
+  version: int32;
+  @doc("Theme color applied to the wiki.")
+  themeColor: string | null;
+  @doc("Hero image payload.")
   heroImage: DraftWikiHeroImage;
   @doc("Basic agency wiki content payload.")
   basic: AgencyDraftWikiBasic;

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -541,6 +541,18 @@ model PrincipalSummary {
   policies: EffectivePolicySummary[];
 }
 
+@doc("Summary of a newly created principal.")
+model CreatedPrincipalSummary {
+  @doc("Principal identifier.")
+  principalIdentifier: Uuid;
+  @doc("Identity identifier linked to the principal.")
+  identityIdentifier: Uuid;
+  @doc("Whether the principal is delegated.")
+  isDelegatedPrincipal: boolean;
+  @doc("Whether the principal is enabled.")
+  isEnabled: boolean;
+}
+
 @doc("Summary of a principal group.")
 model PrincipalGroupSummary {
   @doc("Principal group identifier.")

--- a/typespec/services/wiki-private-api/principal.tsp
+++ b/typespec/services/wiki-private-api/principal.tsp
@@ -60,7 +60,7 @@ model CreatePolicyRequestBody {
 @doc("Response returned when a principal is created.")
 model CreatePrincipalResponse {
   @statusCode statusCode: 201;
-  @body body: PrincipalSummary;
+  @body body: CreatedPrincipalSummary;
 }
 
 @doc("Response returned for the authenticated identity's principal.")

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -77,10 +77,22 @@ model GetGroupDraftWikiResponse {
   @body body: DraftWikiDetail;
 }
 
+@doc("Response returned when a group published wiki is fetched.")
+model GetGroupWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: WikiDetail;
+}
+
 @doc("Response returned when a talent draft wiki is fetched.")
 model GetTalentDraftWikiResponse {
   @statusCode statusCode: 200;
   @body body: TalentDraftWikiDetail;
+}
+
+@doc("Response returned when a talent published wiki is fetched.")
+model GetTalentWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: TalentWikiDetail;
 }
 
 @doc("Response returned when a song draft wiki is fetched.")
@@ -89,10 +101,22 @@ model GetSongDraftWikiResponse {
   @body body: SongDraftWikiDetail;
 }
 
+@doc("Response returned when a song published wiki is fetched.")
+model GetSongWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: SongWikiDetail;
+}
+
 @doc("Response returned when an agency draft wiki is fetched.")
 model GetAgencyDraftWikiResponse {
   @statusCode statusCode: 200;
   @body body: AgencyDraftWikiDetail;
+}
+
+@doc("Response returned when an agency published wiki is fetched.")
+model GetAgencyWikiResponse {
+  @statusCode statusCode: 200;
+  @body body: AgencyWikiDetail;
 }
 
 @doc("Response returned when a wiki is published.")
@@ -129,6 +153,8 @@ model RollbackWikiResponse {
 model WikiListItem {
   @doc("Wiki identifier.")
   wikiIdentifier: Uuid;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
   @doc("Unique slug for the wiki.")
   slug: string;
   @doc("Language of the wiki.")
@@ -265,12 +291,28 @@ interface WikiOperations {
   ): TranslateWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @get
+  @route("/{language}/group/{slug}")
+  @doc("Fetch the published group wiki.")
+  getGroupWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetGroupWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
   @route("/{language}/group/{slug}/draft")
   @doc("Fetch the group draft wiki used by the editor.")
   getGroupDraftWiki(
     @path language: string,
     @path slug: string,
   ): GetGroupDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/{language}/talent/{slug}")
+  @doc("Fetch the published talent wiki.")
+  getTalentWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetTalentWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @get
   @route("/{language}/talent/{slug}/draft")
@@ -281,12 +323,28 @@ interface WikiOperations {
   ): GetTalentDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @get
+  @route("/{language}/song/{slug}")
+  @doc("Fetch the published song wiki.")
+  getSongWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetSongWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
   @route("/{language}/song/{slug}/draft")
   @doc("Fetch the song draft wiki used by the editor.")
   getSongDraftWiki(
     @path language: string,
     @path slug: string,
   ): GetSongDraftWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/{language}/agency/{slug}")
+  @doc("Fetch the published agency wiki.")
+  getAgencyWiki(
+    @path language: string,
+    @path slug: string,
+  ): GetAgencyWikiResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @get
   @route("/{language}/agency/{slug}/draft")


### PR DESCRIPTION
## 📝 変更内容

- 公開Wiki詳細レスポンスに `translationSetIdentifier` を追加
  - group / talent / song / agency の各詳細取得で `wikis.translation_set_identifier` を返却
- 公開Wiki一覧レスポンスの item に `translationSetIdentifier` を追加
- `principal/create` の OpenAPI schema を実装レスポンスに合わせて修正
  - create response 用の `CreatedPrincipalSummary` を追加
  - `/principal/me` 用の `PrincipalSummary` とは分離し、create response では `policies` を必須にしない
- TypeSpec に公開Wiki詳細APIとレスポンス差分を定義
- OpenAPI を再生成
- 関連する ReadModel / Query テストを更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

フロントエンドが公開Wiki詳細レスポンス直下の `translationSetIdentifier` を必須として扱っている一方、バックエンドの公開Wiki詳細・一覧レスポンスでは返却されていなかったため、一覧クリック経由でWiki詳細を表示した際にスキーマ検証エラーが発生していた。

また、`principal/create` の生成スキーマが `/principal/me` と同じ `PrincipalSummary` を参照していたため、実際の create response には存在しない `policies` が必須扱いになっていた。create response と current principal response の契約を分離し、実装レスポンスと生成スキーマを一致させる。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行済み:

- `task test -- tests/...`
  - このリポジトリでは対象ファイル指定に絞られず全 PHPUnit が実行された
  - `OK (2598 tests, 8279 assertions)`
- `task openapi-generate`
  - TypeSpec から OpenAPI を再生成済み

## 🔍 レビューのポイント

- 公開詳細レスポンスと公開一覧レスポンスの両方で `translationSetIdentifier` が直下に含まれること
- TypeSpec / OpenAPI の公開Wiki詳細API定義が実装済みルートと一致していること
- `/principal/create` の 201 response が `CreatedPrincipalSummary` を参照し、`policies` を要求しないこと
- `/principal/me` の `PrincipalSummary` では引き続き `policies` が返る契約になっていること
- draft detail 側の既存レスポンス契約に影響していないこと

## ⚠️ 注意事項

破壊的変更、マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
