### PR TITLE
Wiki編集APIのpayload変換を修正

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Wiki\Wiki\Command\CreateWiki;
 
+use Application\Http\Action\Wiki\Wiki\Command\Support\WikiCommandPayloadMapper;
 use Application\Http\Context\WikiContext;
 use Application\Http\Exceptions\ConflictHttpException;
 use Application\Http\Exceptions\ForbiddenHttpException;
@@ -22,9 +23,7 @@ use Source\Wiki\Shared\Domain\ValueObject\Slug;
 use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki\CreateWikiOutput;
-use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\Color;
-use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -48,9 +47,8 @@ readonly class CreateWikiAction
         try {
             try {
                 $resourceType = ResourceType::from($request->resourceType());
-                $basicClass = BasicInterface::resolveClass($resourceType);
-                $basic = $basicClass::fromArray($request->basic());
-                $sections = SectionContentCollection::fromArray($request->sections());
+                $basic = WikiCommandPayloadMapper::basic($resourceType, $request->basic());
+                $sections = WikiCommandPayloadMapper::sections($request->sections());
 
                 $input = new CreateWikiInput(
                     $request->publishedWikiIdentifier() !== null ? new WikiIdentifier($request->publishedWikiIdentifier()) : null,

--- a/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Wiki\Wiki\Command\EditWiki;
 
+use Application\Http\Action\Wiki\Wiki\Command\Support\WikiCommandPayloadMapper;
 use Application\Http\Context\WikiContext;
 use Application\Http\Exceptions\ForbiddenHttpException;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
@@ -20,10 +21,8 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\EditWiki\EditWikiOutput;
-use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\Color;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
-use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -47,9 +46,8 @@ readonly class EditWikiAction
         try {
             try {
                 $resourceType = ResourceType::from($request->resourceType());
-                $basicClass = BasicInterface::resolveClass($resourceType);
-                $basic = $basicClass::fromArray($request->basic());
-                $sections = SectionContentCollection::fromArray($request->sections());
+                $basic = WikiCommandPayloadMapper::basic($resourceType, $request->basic());
+                $sections = WikiCommandPayloadMapper::sections($request->sections());
 
                 $input = new EditWikiInput(
                     new DraftWikiIdentifier($request->wikiId()),

--- a/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiRequest.php
@@ -14,6 +14,17 @@ class EditWikiRequest extends FormRequest
     /**
      * @return array<string, mixed>
      */
+    public function validationData(): array
+    {
+        return [
+            ...parent::validationData(),
+            'wikiId' => $this->route('wikiId'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [
@@ -32,7 +43,7 @@ class EditWikiRequest extends FormRequest
 
     public function wikiId(): string
     {
-        return (string) $this->input('wikiId');
+        return (string) $this->route('wikiId');
     }
 
     public function resourceType(): string

--- a/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Wiki\Wiki\Command\MergeWiki;
 
+use Application\Http\Action\Wiki\Wiki\Command\Support\WikiCommandPayloadMapper;
 use Application\Http\Context\WikiContext;
 use Application\Http\Exceptions\ForbiddenHttpException;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
@@ -21,10 +22,8 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\MergeWiki\MergeWikiOutput;
-use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\Color;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
-use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -48,9 +47,8 @@ readonly class MergeWikiAction
         try {
             try {
                 $resourceType = ResourceType::from($request->resourceType());
-                $basicClass = BasicInterface::resolveClass($resourceType);
-                $basic = $basicClass::fromArray($request->basic());
-                $sections = SectionContentCollection::fromArray($request->sections());
+                $basic = WikiCommandPayloadMapper::basic($resourceType, $request->basic());
+                $sections = WikiCommandPayloadMapper::sections($request->sections());
 
                 $input = new MergeWikiInput(
                     new DraftWikiIdentifier($request->wikiId()),

--- a/application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapper.php
+++ b/application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapper.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\Support;
+
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Agency\AgencyBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Song\SongBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\TalentBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\BlockType;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Infrastructure\Repository\SectionContentMapper;
+
+final class WikiCommandPayloadMapper
+{
+    /**
+     * @param array<string, mixed> $basic
+     */
+    public static function basic(ResourceType $resourceType, array $basic): BasicInterface
+    {
+        return match ($resourceType) {
+            ResourceType::AGENCY => AgencyBasic::fromArray(self::agencyBasic($basic)),
+            ResourceType::GROUP => GroupBasic::fromArray(self::groupBasic($basic)),
+            ResourceType::TALENT => TalentBasic::fromArray(self::talentBasic($basic)),
+            ResourceType::SONG => SongBasic::fromArray(self::songBasic($basic)),
+            ResourceType::IMAGE => throw new InvalidArgumentException('IMAGE resource type does not have a Basic.'),
+        };
+    }
+
+    /**
+     * @param array<int, mixed> $sections
+     */
+    public static function sections(array $sections): SectionContentCollection
+    {
+        return SectionContentMapper::collectionFromArray(
+            self::sectionContents($sections, 'sections'),
+        );
+    }
+
+    /**
+     * @param array<int, mixed> $contents
+     * @return array<int, array<string, mixed>>
+     */
+    private static function sectionContents(array $contents, string $path): array
+    {
+        $mapped = [];
+
+        foreach ($contents as $index => $content) {
+            if (! is_array($content)) {
+                throw new InvalidArgumentException(sprintf('Section content must be an object at %s.%s.', $path, $index));
+            }
+
+            $mapped[] = self::sectionContent($content, sprintf('%s.%s', $path, $index));
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param array<string, mixed> $basic
+     * @return array<string, mixed>
+     */
+    private static function groupBasic(array $basic): array
+    {
+        return [
+            'name' => $basic['name'],
+            'normalized_name' => $basic['normalizedName'] ?? '',
+            'agency_identifier' => $basic['agencyIdentifier'] ?? null,
+            'group_type' => $basic['groupType'] ?? null,
+            'status' => $basic['status'] ?? null,
+            'generation' => $basic['generation'] ?? null,
+            'debut_date' => $basic['debutDate'] ?? null,
+            'disband_date' => $basic['disbandDate'] ?? null,
+            'fandom_name' => $basic['fandomName'] ?? '',
+            'official_colors' => $basic['officialColors'] ?? [],
+            'emoji' => $basic['emoji'] ?? '',
+            'representative_symbol' => $basic['representativeSymbol'] ?? '',
+            'main_image_identifier' => $basic['mainImageIdentifier'] ?? null,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $basic
+     * @return array<string, mixed>
+     */
+    private static function talentBasic(array $basic): array
+    {
+        return [
+            'name' => $basic['name'],
+            'normalized_name' => $basic['normalizedName'] ?? '',
+            'real_name' => $basic['realName'] ?? '',
+            'normalized_real_name' => $basic['normalizedRealName'] ?? '',
+            'birthday' => $basic['birthday'] ?? null,
+            'agency_identifier' => $basic['agencyIdentifier'] ?? null,
+            'group_identifiers' => $basic['groupIdentifiers'] ?? [],
+            'emoji' => $basic['emoji'] ?? '',
+            'representative_symbol' => $basic['representativeSymbol'] ?? '',
+            'position' => $basic['position'] ?? '',
+            'mbti' => $basic['mbti'] ?? null,
+            'zodiac_sign' => $basic['zodiacSign'] ?? null,
+            'english_level' => $basic['englishLevel'] ?? null,
+            'height' => $basic['height'] ?? null,
+            'blood_type' => $basic['bloodType'] ?? null,
+            'fandom_name' => $basic['fandomName'] ?? '',
+            'profile_image_identifier' => $basic['profileImageIdentifier'] ?? null,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $basic
+     * @return array<string, mixed>
+     */
+    private static function agencyBasic(array $basic): array
+    {
+        return [
+            'name' => $basic['name'],
+            'normalized_name' => $basic['normalizedName'] ?? '',
+            'ceo' => $basic['ceo'] ?? '',
+            'normalized_ceo' => $basic['normalizedCeo'] ?? '',
+            'founded_in' => $basic['foundedIn'] ?? null,
+            'parent_agency_identifier' => $basic['parentAgencyIdentifier'] ?? null,
+            'status' => $basic['status'] ?? null,
+            'logo_image_identifier' => $basic['logoImageIdentifier'] ?? null,
+            'official_website' => $basic['officialWebsite'] ?? null,
+            'social_links' => $basic['socialLinks'] ?? [],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $basic
+     * @return array<string, mixed>
+     */
+    private static function songBasic(array $basic): array
+    {
+        return [
+            'name' => $basic['name'],
+            'normalized_name' => $basic['normalizedName'] ?? '',
+            'song_type' => $basic['songType'] ?? null,
+            'genres' => $basic['genres'] ?? [],
+            'agency_identifier' => $basic['agencyIdentifier'] ?? null,
+            'group_identifiers' => $basic['groupIdentifiers'] ?? [],
+            'talent_identifiers' => $basic['talentIdentifiers'] ?? [],
+            'release_date' => $basic['releaseDate'] ?? null,
+            'album_name' => $basic['albumName'] ?? null,
+            'cover_image_identifier' => $basic['coverImageIdentifier'] ?? null,
+            'lyricist' => $basic['lyricist'] ?? '',
+            'normalized_lyricist' => $basic['normalizedLyricist'] ?? '',
+            'composer' => $basic['composer'] ?? '',
+            'normalized_composer' => $basic['normalizedComposer'] ?? '',
+            'arranger' => $basic['arranger'] ?? '',
+            'normalized_arranger' => $basic['normalizedArranger'] ?? '',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $content
+     * @return array<string, mixed>
+     */
+    private static function sectionContent(array $content, string $path): array
+    {
+        $type = $content['type'] ?? '';
+
+        if ($type === 'section') {
+            return [
+                'type' => 'section',
+                'title' => $content['title'] ?? '',
+                'display_order' => $content['displayOrder'] ?? 0,
+                'contents' => self::sectionContents($content['contents'] ?? [], $path . '.contents'),
+            ];
+        }
+
+        if ($type === '') {
+            throw new InvalidArgumentException(sprintf(
+                'Section content type is required at %s. keys: %s.',
+                $path,
+                implode(', ', array_keys($content)),
+            ));
+        }
+
+        if (BlockType::tryFrom($type) === null) {
+            throw new InvalidArgumentException('Unknown block type: ' . $type);
+        }
+
+        return [
+            'block_type' => $type,
+            'display_order' => $content['displayOrder'] ?? 0,
+            'content' => $content['content'] ?? '',
+            'image_identifier' => $content['imageIdentifier'] ?? null,
+            'image_identifiers' => $content['imageIdentifiers'] ?? [],
+            'caption' => $content['caption'] ?? null,
+            'alt' => $content['alt'] ?? null,
+            'provider' => $content['provider'] ?? null,
+            'embed_id' => $content['embedId'] ?? '',
+            'source' => $content['source'] ?? null,
+            'list_type' => $content['listType'] ?? 'bullet',
+            'items' => $content['items'] ?? [],
+            'header_cells' => $content['headerCells'] ?? null,
+            'row_cells' => $content['rowCells'] ?? [],
+            'table_width' => $content['tableWidth'] ?? null,
+            'wiki_identifiers' => $content['wikiIdentifiers'] ?? [],
+            'title' => $content['title'] ?? null,
+        ];
+    }
+}

--- a/tests/Application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapperTest.php
+++ b/tests/Application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapperTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Http\Action\Wiki\Wiki\Command\Support;
+
+use Application\Http\Action\Wiki\Wiki\Command\Support\WikiCommandPayloadMapper;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\Wiki\Domain\ValueObject\Block\TextBlock;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\Section;
+
+class WikiCommandPayloadMapperTest extends TestCase
+{
+    public function testSectionsMapsCamelCaseApiPayloadToInternalSectionContents(): void
+    {
+        $sections = WikiCommandPayloadMapper::sections([
+            [
+                'type' => 'section',
+                'title' => 'Overview',
+                'displayOrder' => 1,
+                'contents' => [
+                    [
+                        'type' => 'text',
+                        'displayOrder' => 1,
+                        'content' => 'Hello World',
+                    ],
+                ],
+            ],
+        ]);
+
+        $section = $sections->sorted()[0];
+        $this->assertInstanceOf(Section::class, $section);
+        $this->assertSame(1, $section->displayOrder());
+
+        $block = $section->contents()->sorted()[0];
+        $this->assertInstanceOf(TextBlock::class, $block);
+        $this->assertSame(1, $block->displayOrder());
+        $this->assertSame('Hello World', $block->content());
+    }
+
+    public function testSectionsRejectsMissingContentType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Section content type is required at sections.0. keys: displayOrder, content.');
+
+        WikiCommandPayloadMapper::sections([
+            [
+                'displayOrder' => 1,
+                'content' => 'Hello World',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

- Wiki 作成・編集・マージ API で、API 境界の camelCase payload を内部の snake_case 構造へ変換する `WikiCommandPayloadMapper` を追加
- `basic` と `sections` の生成を mapper 経由に変更
- `EditWikiRequest` で route parameter の `wikiId` を validation / accessor に反映
- sections payload の block は `type` を正として扱い、内部の `block_type` へ変換
- payload 不備時に section content の path と keys が分かる例外メッセージを返すように変更
- mapper の単体テストを追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki draft 保存時に、API payload と backend 内部構造のキー形式が混在し、`BasicInterface::resolveClass()` や `SectionContentCollection::fromArray()` など存在しない API 呼び出し、また `block_type` 欠落による enum 変換エラーが発生していました。

API 境界では camelCase / `type` に統一し、backend 内部の値オブジェクト・repository 向けには snake_case に変換することで、保存 API が正常に use case へ入力を渡せるようにします。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行済み:

- `task test -- tests/Application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapperTest.php`
  - `OK (2600 tests, 8286 assertions)`

## 🔍 レビューのポイント

- API 境界の payload 仕様が camelCase / `type` に統一されているか
- `WikiCommandPayloadMapper` の basic / sections 変換が domain / repository の期待する snake_case 形式と一致しているか
- `EditWikiRequest` の `wikiId` が route parameter 由来になっている点
- Create / Edit / Merge の各 command action で同じ mapper を使う構成が妥当か

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- API 境界の sections block payload は `block_type` / `display_order` ではなく `type` / `displayOrder` を送る前提です。
- マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
