### PR TITLE
下書きWiki一覧取得APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisAction.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListDraftWikis;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Illuminate\Http\JsonResponse;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ListDraftWikisAction
+{
+    public function __construct(
+        private ListDraftWikisInterface $listDraftWikis,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ListDraftWikisRequest $request): JsonResponse
+    {
+        try {
+            $input = new ListDraftWikisInput(
+                status: ApprovalStatus::from($request->status()),
+                translationSetIdentifier: $request->translationSetIdentifier() !== null ? new TranslationSetIdentifier($request->translationSetIdentifier()) : null,
+                resourceType: $request->resourceType() !== null ? ResourceType::from($request->resourceType()) : null,
+                perPage: $request->perPage(),
+            );
+            $output = new ListDraftWikisOutput();
+            $this->listDraftWikis->process($input, $output);
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListDraftWikis;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+class ListDraftWikisRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'translationSetIdentifier' => ['nullable', 'uuid'],
+            'status' => ['required', 'string', Rule::in(array_column(ApprovalStatus::cases(), 'value'))],
+            'resourceType' => ['nullable', 'string', Rule::in([
+                ResourceType::AGENCY->value,
+                ResourceType::GROUP->value,
+                ResourceType::TALENT->value,
+                ResourceType::SONG->value,
+            ])],
+        ];
+    }
+
+    public function perPage(): ?int
+    {
+        $perPage = $this->query('perPage');
+
+        return $perPage === null ? null : (int) $perPage;
+    }
+
+    public function translationSetIdentifier(): ?string
+    {
+        $translationSetIdentifier = $this->query('translationSetIdentifier');
+
+        return $translationSetIdentifier === null ? null : (string) $translationSetIdentifier;
+    }
+
+    public function status(): string
+    {
+        return (string) $this->query('status');
+    }
+
+    public function resourceType(): ?string
+    {
+        $resourceType = $this->query('resourceType');
+
+        return $resourceType === null ? null : (string) $resourceType;
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -87,6 +87,7 @@ use Source\Wiki\Wiki\Application\UseCase\Query\GetSongDraftWiki\GetSongDraftWiki
 use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyWiki;
@@ -96,6 +97,7 @@ use Source\Wiki\Wiki\Infrastructure\Query\GetSongDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetSongWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentWiki;
+use Source\Wiki\Wiki\Infrastructure\Query\ListDraftWikis;
 use Source\Wiki\Wiki\Infrastructure\Query\ListWikis;
 
 class UseCaseServiceProvider extends ServiceProvider
@@ -147,6 +149,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(GetSongWikiInterface::class, GetSongWiki::class);
         $this->app->singleton(GetTalentDraftWikiInterface::class, GetTalentDraftWiki::class);
         $this->app->singleton(GetTalentWikiInterface::class, GetTalentWiki::class);
+        $this->app->singleton(ListDraftWikisInterface::class, ListDraftWikis::class);
         $this->app->singleton(ListWikisInterface::class, ListWikis::class);
     }
 }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -56,6 +56,61 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /draft-wikis:
+    get:
+      operationId: DraftWikiListOperations_listDraftWikis
+      description: List draft wikis.
+      parameters:
+        - name: perPage
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+          explode: false
+        - name: translationSetIdentifier
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          explode: false
+        - name: status
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/DraftWikiStatus'
+          explode: false
+        - name: resourceType
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: Response returned when draft wiki list retrieval succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListDraftWikisResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /image/upload:
     post:
       operationId: ImageOperations_uploadImage
@@ -2445,6 +2500,91 @@ components:
           nullable: true
           description: Image identifier shown as the hero image.
       description: Hero image payload for a draft wiki.
+    DraftWikiListItem:
+      type: object
+      required:
+        - wikiIdentifier
+        - publishedWikiIdentifier
+        - translationSetIdentifier
+        - slug
+        - language
+        - resourceType
+        - themeColor
+        - status
+        - name
+        - normalizedName
+        - editedAt
+        - updatedAt
+        - approvedAt
+        - translatedAt
+        - mergedAt
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Draft wiki identifier.
+        publishedWikiIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
+          description: Published wiki identifier linked to this draft.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier.
+        slug:
+          type: string
+          description: Unique slug for the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        themeColor:
+          type: string
+          nullable: true
+          description: Theme color applied to the wiki.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/DraftWikiStatus'
+          description: Approval status of the draft wiki.
+        name:
+          type: string
+          description: Display name of the wiki.
+        normalizedName:
+          type: string
+          description: Normalized name used for search.
+        editedAt:
+          type: string
+          nullable: true
+          description: Timestamp when the draft was edited.
+        updatedAt:
+          type: string
+          nullable: true
+          description: Last updated timestamp.
+        approvedAt:
+          type: string
+          nullable: true
+          description: Timestamp when the draft was approved.
+        translatedAt:
+          type: string
+          nullable: true
+          description: Timestamp when the draft was translated.
+        mergedAt:
+          type: string
+          nullable: true
+          description: Timestamp when the draft was merged.
+      description: Draft wiki list item returned by the draft wiki list endpoint.
+    DraftWikiStatus:
+      type: string
+      enum:
+        - approved
+        - pending
+        - rejected
+        - under_review
+      description: Approval status assigned to a draft wiki.
     DraftWikiSummary:
       type: object
       required:
@@ -2700,6 +2840,37 @@ components:
           format: int32
           description: Number of images per page.
       description: Response body for the draft image list endpoint.
+    ListDraftWikisResponseBody:
+      type: object
+      required:
+        - wikis
+        - current_page
+        - last_page
+        - total
+        - per_page
+      properties:
+        wikis:
+          type: array
+          items:
+            $ref: '#/components/schemas/DraftWikiListItem'
+          description: Draft wikis for the requested page.
+        current_page:
+          type: integer
+          format: int32
+          description: Current page number.
+        last_page:
+          type: integer
+          format: int32
+          description: Last page number.
+        total:
+          type: integer
+          format: int32
+          description: Total number of draft wikis.
+        per_page:
+          type: integer
+          format: int32
+          description: Number of wikis per page.
+      description: Response body for the draft wiki list endpoint.
     ListUploadedImagesResponseBody:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -43,6 +43,7 @@ use Application\Http\Action\Wiki\Wiki\Query\GetSongDraftWiki\GetSongDraftWikiAct
 use Application\Http\Action\Wiki\Wiki\Query\GetSongWiki\GetSongWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki\GetTalentDraftWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentWiki\GetTalentWikiAction;
+use Application\Http\Action\Wiki\Wiki\Query\ListDraftWikis\ListDraftWikisAction;
 use Application\Http\Action\Wiki\Wiki\Query\ListWikis\ListWikisAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
@@ -64,6 +65,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
     Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
 });
 Route::get('/wikis/{language}', ListWikisAction::class);
+Route::get('/draft-wikis', ListDraftWikisAction::class)->middleware('auth.api');
 Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);
 Route::get('/wiki/{language}/agency/{slug}/draft', GetAgencyDraftWikiAction::class);
 Route::get('/wiki/{language}/group/{slug}', GetGroupWikiAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query;
+
+readonly class DraftWikiListItemReadModel
+{
+    public function __construct(
+        private string $wikiIdentifier,
+        private ?string $publishedWikiIdentifier,
+        private string $translationSetIdentifier,
+        private string $slug,
+        private string $language,
+        private string $resourceType,
+        private ?string $themeColor,
+        private string $status,
+        private string $name,
+        private string $normalizedName,
+        private ?string $editedAt,
+        private ?string $updatedAt,
+        private ?string $approvedAt,
+        private ?string $translatedAt,
+        private ?string $mergedAt,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'publishedWikiIdentifier' => $this->publishedWikiIdentifier,
+            'translationSetIdentifier' => $this->translationSetIdentifier,
+            'slug' => $this->slug,
+            'language' => $this->language,
+            'resourceType' => $this->resourceType,
+            'themeColor' => $this->themeColor,
+            'status' => $this->status,
+            'name' => $this->name,
+            'normalizedName' => $this->normalizedName,
+            'editedAt' => $this->editedAt,
+            'updatedAt' => $this->updatedAt,
+            'approvedAt' => $this->approvedAt,
+            'translatedAt' => $this->translatedAt,
+            'mergedAt' => $this->mergedAt,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInput.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
+
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+readonly class ListDraftWikisInput implements ListDraftWikisInputPort
+{
+    public function __construct(
+        private ApprovalStatus $status,
+        private ?TranslationSetIdentifier $translationSetIdentifier = null,
+        private ?ResourceType $resourceType = null,
+        private ?int $perPage = null,
+    ) {
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage ?? 10;
+    }
+
+    public function translationSetIdentifier(): ?TranslationSetIdentifier
+    {
+        return $this->translationSetIdentifier;
+    }
+
+    public function status(): ApprovalStatus
+    {
+        return $this->status;
+    }
+
+    public function resourceType(): ?ResourceType
+    {
+        return $this->resourceType;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
+
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+interface ListDraftWikisInputPort
+{
+    public function perPage(): int;
+
+    public function translationSetIdentifier(): ?TranslationSetIdentifier;
+
+    public function status(): ApprovalStatus;
+
+    public function resourceType(): ?ResourceType;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
+
+interface ListDraftWikisInterface
+{
+    public function process(ListDraftWikisInputPort $input, ListDraftWikisOutputPort $output): void;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisOutput.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiListItemReadModel;
+
+class ListDraftWikisOutput implements ListDraftWikisOutputPort
+{
+    /** @var list<DraftWikiListItemReadModel> */
+    private array $wikis = [];
+
+    private ?int $currentPage = null;
+
+    private ?int $lastPage = null;
+
+    private ?int $total = null;
+
+    private ?int $perPage = null;
+
+    /**
+     * @param list<DraftWikiListItemReadModel> $wikis
+     */
+    public function output(array $wikis, int $currentPage, int $lastPage, int $total, int $perPage): void
+    {
+        $this->wikis = $wikis;
+        $this->currentPage = $currentPage;
+        $this->lastPage = $lastPage;
+        $this->total = $total;
+        $this->perPage = $perPage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikis' => array_map(static fn (DraftWikiListItemReadModel $wiki): array => $wiki->toArray(), $this->wikis),
+            'current_page' => $this->currentPage,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'per_page' => $this->perPage,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiListItemReadModel;
+
+interface ListDraftWikisOutputPort
+{
+    /**
+     * @param list<DraftWikiListItemReadModel> $wikis
+     */
+    public function output(array $wikis, int $currentPage, int $lastPage, int $total, int $perPage): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/ListDraftWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListDraftWikis.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\DraftWiki;
+use Application\Models\Wiki\DraftWikiAgencyBasic;
+use Application\Models\Wiki\DraftWikiGroupBasic;
+use Application\Models\Wiki\DraftWikiSongBasic;
+use Application\Models\Wiki\DraftWikiTalentBasic;
+use DateTimeInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiListItemReadModel;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisOutputPort;
+
+readonly class ListDraftWikis implements ListDraftWikisInterface
+{
+    /** @var array<string, string> */
+    private const BASIC_RELATIONS = [
+        ResourceType::TALENT->value => 'talentBasic',
+        ResourceType::GROUP->value => 'groupBasic',
+        ResourceType::AGENCY->value => 'agencyBasic',
+        ResourceType::SONG->value => 'songBasic',
+    ];
+
+    public function process(ListDraftWikisInputPort $input, ListDraftWikisOutputPort $output): void
+    {
+        $query = DraftWiki::query()
+            ->with(['talentBasic', 'groupBasic', 'agencyBasic', 'songBasic'])
+            ->where('status', $input->status()->value)
+            ->orderBy('edited_at', 'desc')
+            ->orderBy('updated_at', 'desc');
+
+        if ($input->translationSetIdentifier() !== null) {
+            $query->where('translation_set_identifier', (string) $input->translationSetIdentifier());
+        }
+
+        if ($input->resourceType() !== null) {
+            $query->where('resource_type', $input->resourceType()->value);
+        } else {
+            $query->whereIn('resource_type', array_keys(self::BASIC_RELATIONS));
+        }
+
+        /** @var LengthAwarePaginator<int, DraftWiki> $paginator */
+        $paginator = $query->paginate($input->perPage());
+
+        $output->output(
+            array_map(
+                fn (DraftWiki $wiki): DraftWikiListItemReadModel => $this->toReadModel($wiki),
+                $paginator->items(),
+            ),
+            $paginator->currentPage(),
+            $paginator->lastPage(),
+            $paginator->total(),
+            $paginator->perPage(),
+        );
+    }
+
+    private function toReadModel(DraftWiki $wiki): DraftWikiListItemReadModel
+    {
+        $basic = $this->basicModel($wiki);
+
+        return new DraftWikiListItemReadModel(
+            wikiIdentifier: $wiki->id,
+            publishedWikiIdentifier: $wiki->published_wiki_id,
+            translationSetIdentifier: $wiki->translation_set_identifier,
+            slug: $wiki->slug,
+            language: $wiki->language,
+            resourceType: $wiki->resource_type,
+            themeColor: $wiki->theme_color,
+            status: $wiki->status,
+            name: (string) $basic->getAttribute('name'),
+            normalizedName: (string) $basic->getAttribute('normalized_name'),
+            editedAt: $this->formatDateTime($wiki->edited_at),
+            updatedAt: $this->formatDateTime($wiki->updated_at),
+            approvedAt: $this->formatDateTime($wiki->approved_at),
+            translatedAt: $this->formatDateTime($wiki->translated_at),
+            mergedAt: $this->formatDateTime($wiki->merged_at),
+        );
+    }
+
+    private function basicModel(DraftWiki $wiki): Model
+    {
+        $relation = self::BASIC_RELATIONS[$wiki->resource_type] ?? null;
+        if ($relation === null) {
+            throw new InvalidArgumentException("Unsupported draft wiki resource type: {$wiki->resource_type}");
+        }
+
+        $basic = $wiki->{$relation};
+        if (
+            ! $basic instanceof DraftWikiTalentBasic
+            && ! $basic instanceof DraftWikiGroupBasic
+            && ! $basic instanceof DraftWikiAgencyBasic
+            && ! $basic instanceof DraftWikiSongBasic
+        ) {
+            throw new InvalidArgumentException("Basic not found for DraftWiki: {$wiki->id}");
+        }
+
+        return $basic;
+    }
+
+    private function formatDateTime(mixed $dateTime): ?string
+    {
+        if ($dateTime === null) {
+            return null;
+        }
+
+        if ($dateTime instanceof DateTimeInterface) {
+            return $dateTime->format(DateTimeInterface::ATOM);
+        }
+
+        return (string) $dateTime;
+    }
+}

--- a/tests/Helper/CreateDraftWiki.php
+++ b/tests/Helper/CreateDraftWiki.php
@@ -23,9 +23,12 @@ class CreateDraftWiki
      *     approver_id?: ?string,
      *     merger_id?: ?string,
      *     source_editor_id?: ?string,
+     *     edited_at?: ?string,
      *     merged_at?: ?string,
      *     translated_at?: ?string,
      *     approved_at?: ?string,
+     *     created_at?: ?string,
+     *     updated_at?: ?string,
      * } $overrides
      * @param array<string, mixed> $basicOverrides
      */
@@ -45,9 +48,12 @@ class CreateDraftWiki
             'approver_id' => $overrides['approver_id'] ?? null,
             'merger_id' => $overrides['merger_id'] ?? null,
             'source_editor_id' => $overrides['source_editor_id'] ?? null,
+            'edited_at' => $overrides['edited_at'] ?? null,
             'merged_at' => $overrides['merged_at'] ?? null,
             'translated_at' => $overrides['translated_at'] ?? null,
             'approved_at' => $overrides['approved_at'] ?? null,
+            'created_at' => $overrides['created_at'] ?? null,
+            'updated_at' => $overrides['updated_at'] ?? null,
         ]);
 
         match ($resourceType) {

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModelTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query;
+
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiListItemReadModel;
+use Tests\TestCase;
+
+class DraftWikiListItemReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $readModel = new DraftWikiListItemReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            publishedWikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+            slug: 'tl-chaeyoung',
+            language: 'ko',
+            resourceType: 'talent',
+            themeColor: '#FE5F8F',
+            status: ApprovalStatus::UnderReview->value,
+            name: 'Chaeyoung',
+            normalizedName: 'chaeyoung',
+            editedAt: '2026-05-01T00:00:00+00:00',
+            updatedAt: '2026-05-02T00:00:00+00:00',
+            approvedAt: '2026-05-03T00:00:00+00:00',
+            translatedAt: '2026-05-04T00:00:00+00:00',
+            mergedAt: '2026-05-05T00:00:00+00:00',
+        );
+
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'publishedWikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            'translationSetIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+            'slug' => 'tl-chaeyoung',
+            'language' => 'ko',
+            'resourceType' => 'talent',
+            'themeColor' => '#FE5F8F',
+            'status' => ApprovalStatus::UnderReview->value,
+            'name' => 'Chaeyoung',
+            'normalizedName' => 'chaeyoung',
+            'editedAt' => '2026-05-01T00:00:00+00:00',
+            'updatedAt' => '2026-05-02T00:00:00+00:00',
+            'approvedAt' => '2026-05-03T00:00:00+00:00',
+            'translatedAt' => '2026-05-04T00:00:00+00:00',
+            'mergedAt' => '2026-05-05T00:00:00+00:00',
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
+
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInput;
+use Tests\TestCase;
+
+class ListDraftWikisInputTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $input = new ListDraftWikisInput(
+            status: ApprovalStatus::UnderReview,
+        );
+
+        $this->assertSame(10, $input->perPage());
+        $this->assertNull($input->translationSetIdentifier());
+        $this->assertSame(ApprovalStatus::UnderReview, $input->status());
+        $this->assertNull($input->resourceType());
+    }
+
+    public function testAccessors(): void
+    {
+        $input = new ListDraftWikisInput(
+            status: ApprovalStatus::Pending,
+            translationSetIdentifier: new TranslationSetIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f102'),
+            resourceType: ResourceType::TALENT,
+            perPage: 20,
+        );
+
+        $this->assertSame(20, $input->perPage());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f102', (string) $input->translationSetIdentifier());
+        $this->assertSame(ApprovalStatus::Pending, $input->status());
+        $this->assertSame(ResourceType::TALENT, $input->resourceType());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisOutputTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
+
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiListItemReadModel;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisOutput;
+use Tests\TestCase;
+
+class ListDraftWikisOutputTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $item = new DraftWikiListItemReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            publishedWikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+            slug: 'tl-chaeyoung',
+            language: 'ko',
+            resourceType: 'talent',
+            themeColor: '#FE5F8F',
+            status: ApprovalStatus::Pending->value,
+            name: 'Chaeyoung',
+            normalizedName: 'chaeyoung',
+            editedAt: '2026-05-01T00:00:00+00:00',
+            updatedAt: '2026-05-02T00:00:00+00:00',
+            approvedAt: null,
+            translatedAt: null,
+            mergedAt: null,
+        );
+
+        $output = new ListDraftWikisOutput();
+        $output->output([$item], 1, 3, 5, 2);
+
+        $this->assertSame([
+            'wikis' => [$item->toArray()],
+            'current_page' => 1,
+            'last_page' => 3,
+            'total' => 5,
+            'per_page' => 2,
+        ], $output->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisOutput;
+use Tests\Helper\CreateDraftWiki;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class ListDraftWikisTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessFiltersByStatusSortedByEditedAtDesc(): void
+    {
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f101', 'talent', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f901',
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-01 00:00:00',
+        ], [
+            'name' => 'Alpha',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f102', 'group', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f902',
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-03 00:00:00',
+        ], [
+            'name' => 'Beta',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f103', 'agency', [
+            'status' => ApprovalStatus::Pending->value,
+            'edited_at' => '2026-05-04 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f104', 'song', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f903',
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-05 00:00:00',
+        ], [
+            'name' => 'Gamma',
+        ]);
+
+        $payload = $this->process(new ListDraftWikisInput(
+            status: ApprovalStatus::UnderReview,
+        ))->toArray();
+
+        $this->assertSame(1, $payload['current_page']);
+        $this->assertSame(1, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+        $this->assertSame(10, $payload['per_page']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f104',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+        $this->assertSame([
+            ApprovalStatus::UnderReview->value,
+            ApprovalStatus::UnderReview->value,
+            ApprovalStatus::UnderReview->value,
+        ], array_column($payload['wikis'], 'status'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByTranslationSetIdentifierWhenSpecified(): void
+    {
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f201', 'talent', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f202', 'talent', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f402',
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f203', 'talent', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+            'status' => ApprovalStatus::Pending->value,
+            'edited_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftWikisInput(
+            status: ApprovalStatus::UnderReview,
+            translationSetIdentifier: new TranslationSetIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f401'),
+        ))->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+        ], array_column($payload['wikis'], 'translationSetIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByResourceTypeWhenSpecified(): void
+    {
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f301', 'talent', [
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f302', 'group', [
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f303', 'song', [
+            'status' => ApprovalStatus::UnderReview->value,
+            'edited_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftWikisInput(
+            status: ApprovalStatus::UnderReview,
+            resourceType: ResourceType::GROUP,
+        ))->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f302',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+        $this->assertSame([ResourceType::GROUP->value], array_column($payload['wikis'], 'resourceType'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessAppliesPerPage(): void
+    {
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f401', 'talent', [
+            'status' => ApprovalStatus::Pending->value,
+            'edited_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f402', 'talent', [
+            'status' => ApprovalStatus::Pending->value,
+            'edited_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f403', 'talent', [
+            'status' => ApprovalStatus::Pending->value,
+            'edited_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftWikisInput(
+            status: ApprovalStatus::Pending,
+            perPage: 2,
+        ))->toArray();
+
+        $this->assertCount(2, $payload['wikis']);
+        $this->assertSame(2, $payload['per_page']);
+        $this->assertSame(2, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsDraftWikiMetadata(): void
+    {
+        CreateWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f502', 'group', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'slug' => 'gr-twice',
+            'language' => 'ko',
+        ]);
+
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f501', 'group', [
+            'published_wiki_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'slug' => 'gr-twice',
+            'language' => 'ko',
+            'theme_color' => '#ff3366',
+            'status' => ApprovalStatus::Approved->value,
+            'edited_at' => '2026-05-01 00:00:00',
+            'approved_at' => '2026-05-02 00:00:00',
+            'translated_at' => '2026-05-03 00:00:00',
+            'merged_at' => '2026-05-04 00:00:00',
+            'updated_at' => '2026-05-05 00:00:00',
+        ], [
+            'name' => 'TWICE',
+            'normalized_name' => 'twice',
+        ]);
+
+        $payload = $this->process(new ListDraftWikisInput(
+            status: ApprovalStatus::Approved,
+            translationSetIdentifier: new TranslationSetIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f601'),
+        ))->toArray();
+
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f501',
+            'publishedWikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
+            'translationSetIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+            'slug' => 'gr-twice',
+            'language' => 'ko',
+            'resourceType' => 'group',
+            'themeColor' => '#ff3366',
+            'status' => ApprovalStatus::Approved->value,
+            'name' => 'TWICE',
+            'normalizedName' => 'twice',
+            'editedAt' => '2026-05-01T00:00:00+00:00',
+            'updatedAt' => '2026-05-05T00:00:00+00:00',
+            'approvedAt' => '2026-05-02T00:00:00+00:00',
+            'translatedAt' => '2026-05-03T00:00:00+00:00',
+            'mergedAt' => '2026-05-04T00:00:00+00:00',
+        ], $payload['wikis'][0]);
+    }
+
+    private function listDraftWikis(): ListDraftWikisInterface
+    {
+        return $this->app->make(ListDraftWikisInterface::class);
+    }
+
+    private function process(ListDraftWikisInput $input): ListDraftWikisOutput
+    {
+        $output = new ListDraftWikisOutput();
+        $this->listDraftWikis()->process($input, $output);
+
+        return $output;
+    }
+}

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -175,6 +175,48 @@ model WikiListItem {
   updatedAt: string | null;
 }
 
+@doc("Approval status assigned to a draft wiki.")
+union DraftWikiStatus {
+  "approved",
+  "pending",
+  "rejected",
+  "under_review",
+}
+
+@doc("Draft wiki list item returned by the draft wiki list endpoint.")
+model DraftWikiListItem {
+  @doc("Draft wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Published wiki identifier linked to this draft.")
+  publishedWikiIdentifier: Uuid | null;
+  @doc("Translation set identifier.")
+  translationSetIdentifier: Uuid;
+  @doc("Unique slug for the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Theme color applied to the wiki.")
+  themeColor: string | null;
+  @doc("Approval status of the draft wiki.")
+  status: DraftWikiStatus;
+  @doc("Display name of the wiki.")
+  name: string;
+  @doc("Normalized name used for search.")
+  normalizedName: string;
+  @doc("Timestamp when the draft was edited.")
+  editedAt: string | null;
+  @doc("Last updated timestamp.")
+  updatedAt: string | null;
+  @doc("Timestamp when the draft was approved.")
+  approvedAt: string | null;
+  @doc("Timestamp when the draft was translated.")
+  translatedAt: string | null;
+  @doc("Timestamp when the draft was merged.")
+  mergedAt: string | null;
+}
+
 @doc("Response body for the wiki list endpoint.")
 model ListWikisResponseBody {
   @doc("Wiki list for the requested page.")
@@ -189,10 +231,30 @@ model ListWikisResponseBody {
   per_page: int32;
 }
 
+@doc("Response body for the draft wiki list endpoint.")
+model ListDraftWikisResponseBody {
+  @doc("Draft wikis for the requested page.")
+  wikis: DraftWikiListItem[];
+  @doc("Current page number.")
+  current_page: int32;
+  @doc("Last page number.")
+  last_page: int32;
+  @doc("Total number of draft wikis.")
+  total: int32;
+  @doc("Number of wikis per page.")
+  per_page: int32;
+}
+
 @doc("Response returned when wiki list retrieval succeeds.")
 model ListWikisResponse {
   @statusCode statusCode: 200;
   @body body: ListWikisResponseBody;
+}
+
+@doc("Response returned when draft wiki list retrieval succeeds.")
+model ListDraftWikisResponse {
+  @statusCode statusCode: 200;
+  @body body: ListDraftWikisResponseBody;
 }
 
 @route("/wikis")
@@ -208,6 +270,18 @@ interface WikiListOperations {
     @query sort?: string,
     @query order?: string,
   ): ListWikisResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+
+@route("/draft-wikis")
+interface DraftWikiListOperations {
+  @get
+  @doc("List draft wikis.")
+  listDraftWikis(
+    @query perPage?: int32,
+    @query translationSetIdentifier?: Uuid,
+    @query status: DraftWikiStatus,
+    @query resourceType?: string,
+  ): ListDraftWikisResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }
 
 @route("/wiki")


### PR DESCRIPTION
## 📝 変更内容

- `GET /draft-wikis` を追加し、ログイン必須で下書き Wiki 一覧を取得できるようにしました
- `status`, `translationSetIdentifier`, `resourceType`, `perPage` の query parameter に対応しました
- `draft_wikis` 起点の infrastructure query と CQRS 用の input/output/read model を追加しました
- TypeSpec に新規エンドポイントを追加し、Wiki Private API の OpenAPI を再生成しました
- 一覧取得 query、read model、input、output のテストを追加しました

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki 承認・確認画面などで申請中の下書き Wiki を一覧表示するため、既存の下書き画像一覧 API と同じ方針で下書き Wiki 一覧 API を追加しました。status は固定せず、指定された `ApprovalStatus` で絞り込めるようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `GET /draft-wikis` の route が `auth.api` 必須になっていること
- `status`, `translationSetIdentifier`, `resourceType`, `perPage` の validation と query 条件が Issue の要件に合っていること
- response item と pagination の形が既存の下書き画像一覧 API と大きく乖離していないこと
- TypeSpec/OpenAPI の schema が実装レスポンスと一致していること

## 📖 関連情報

### 関連Issue・タスク

Closes #372

## ⚠️ 注意事項

マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
