### PR TITLE
下書きWiki一覧で自身の下書きを絞り込めるようにする

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisAction.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Wiki\Wiki\Query\ListDraftWikis;
 
+use Application\Http\Context\ActorContext;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
 use Illuminate\Http\JsonResponse;
 use Psr\Log\LoggerInterface;
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInput;
+use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInput;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
@@ -20,6 +26,8 @@ readonly class ListDraftWikisAction
 {
     public function __construct(
         private ListDraftWikisInterface $listDraftWikis,
+        private GetCurrentPrincipalInterface $getCurrentPrincipal,
+        private ActorContext $actorContext,
         private LoggerInterface $logger,
     ) {
     }
@@ -34,10 +42,15 @@ readonly class ListDraftWikisAction
                 status: ApprovalStatus::from($request->status()),
                 translationSetIdentifier: $request->translationSetIdentifier() !== null ? new TranslationSetIdentifier($request->translationSetIdentifier()) : null,
                 resourceType: $request->resourceType() !== null ? ResourceType::from($request->resourceType()) : null,
+                editorIdentifier: $request->onlyMine() ? $this->currentPrincipalIdentifier() : null,
                 perPage: $request->perPage(),
             );
             $output = new ListDraftWikisOutput();
             $this->listDraftWikis->process($input, $output);
+        } catch (NotFoundHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
         } catch (Throwable $e) {
             $this->logger->error((string) $e);
 
@@ -45,5 +58,19 @@ readonly class ListDraftWikisAction
         }
 
         return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+
+    private function currentPrincipalIdentifier(): PrincipalIdentifier
+    {
+        try {
+            $principal = $this->getCurrentPrincipal->process(new GetCurrentPrincipalInput($this->actorContext->identityIdentifier));
+        } catch (PrincipalNotFoundException $e) {
+            throw new NotFoundHttpException(detail: error_message('principal_not_found', $this->actorContext->language->value), previous: $e);
+        }
+
+        /** @var array{principalIdentifier: string} $payload */
+        $payload = $principal->toArray();
+
+        return new PrincipalIdentifier($payload['principalIdentifier']);
     }
 }

--- a/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListDraftWikis/ListDraftWikisRequest.php
@@ -20,6 +20,7 @@ class ListDraftWikisRequest extends FormRequest
             'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
             'translationSetIdentifier' => ['nullable', 'uuid'],
             'status' => ['required', 'string', Rule::in(array_column(ApprovalStatus::cases(), 'value'))],
+            'onlyMine' => ['nullable', 'boolean'],
             'resourceType' => ['nullable', 'string', Rule::in([
                 ResourceType::AGENCY->value,
                 ResourceType::GROUP->value,
@@ -46,6 +47,11 @@ class ListDraftWikisRequest extends FormRequest
     public function status(): string
     {
         return (string) $this->query('status');
+    }
+
+    public function onlyMine(): bool
+    {
+        return $this->boolean('onlyMine');
     }
 
     public function resourceType(): ?string

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -86,6 +86,12 @@ paths:
           schema:
             type: string
           explode: false
+        - name: onlyMine
+          in: query
+          required: false
+          schema:
+            type: boolean
+          explode: false
       responses:
         '200':
           description: Response returned when draft wiki list retrieval succeeds.
@@ -95,6 +101,12 @@ paths:
                 $ref: '#/components/schemas/ListDraftWikisResponseBody'
         '401':
           description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
           content:
             application/json:
               schema:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -65,7 +65,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
     Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
 });
 Route::get('/wikis/{language}', ListWikisAction::class);
-Route::get('/draft-wikis', ListDraftWikisAction::class)->middleware('auth.api');
+Route::get('/draft-wikis', ListDraftWikisAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);
 Route::get('/wiki/{language}/agency/{slug}/draft', GetAgencyDraftWikiAction::class);
 Route::get('/wiki/{language}/group/{slug}', GetGroupWikiAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInput.php
@@ -6,6 +6,7 @@ namespace Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
 
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 
 readonly class ListDraftWikisInput implements ListDraftWikisInputPort
@@ -14,6 +15,7 @@ readonly class ListDraftWikisInput implements ListDraftWikisInputPort
         private ApprovalStatus $status,
         private ?TranslationSetIdentifier $translationSetIdentifier = null,
         private ?ResourceType $resourceType = null,
+        private ?PrincipalIdentifier $editorIdentifier = null,
         private ?int $perPage = null,
     ) {
     }
@@ -36,5 +38,10 @@ readonly class ListDraftWikisInput implements ListDraftWikisInputPort
     public function resourceType(): ?ResourceType
     {
         return $this->resourceType;
+    }
+
+    public function editorIdentifier(): ?PrincipalIdentifier
+    {
+        return $this->editorIdentifier;
     }
 }

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputPort.php
@@ -6,6 +6,7 @@ namespace Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
 
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 
 interface ListDraftWikisInputPort
@@ -17,4 +18,6 @@ interface ListDraftWikisInputPort
     public function status(): ApprovalStatus;
 
     public function resourceType(): ?ResourceType;
+
+    public function editorIdentifier(): ?PrincipalIdentifier;
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/ListDraftWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListDraftWikis.php
@@ -41,6 +41,10 @@ readonly class ListDraftWikis implements ListDraftWikisInterface
             $query->where('translation_set_identifier', (string) $input->translationSetIdentifier());
         }
 
+        if ($input->editorIdentifier() !== null) {
+            $query->where('editor_id', (string) $input->editorIdentifier());
+        }
+
         if ($input->resourceType() !== null) {
             $query->where('resource_type', $input->resourceType()->value);
         } else {

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListDraftWikis/ListDraftWikisInputTest.php
@@ -6,6 +6,7 @@ namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis;
 
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInput;
 use Tests\TestCase;
@@ -22,6 +23,7 @@ class ListDraftWikisInputTest extends TestCase
         $this->assertNull($input->translationSetIdentifier());
         $this->assertSame(ApprovalStatus::UnderReview, $input->status());
         $this->assertNull($input->resourceType());
+        $this->assertNull($input->editorIdentifier());
     }
 
     public function testAccessors(): void
@@ -30,6 +32,7 @@ class ListDraftWikisInputTest extends TestCase
             status: ApprovalStatus::Pending,
             translationSetIdentifier: new TranslationSetIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f102'),
             resourceType: ResourceType::TALENT,
+            editorIdentifier: new PrincipalIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f103'),
             perPage: 20,
         );
 
@@ -37,5 +40,6 @@ class ListDraftWikisInputTest extends TestCase
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f102', (string) $input->translationSetIdentifier());
         $this->assertSame(ApprovalStatus::Pending, $input->status());
         $this->assertSame(ResourceType::TALENT, $input->resourceType());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f103', (string) $input->editorIdentifier());
     }
 }

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
@@ -7,6 +7,7 @@ namespace Tests\Wiki\Wiki\Infrastructure\Query;
 use PHPUnit\Framework\Attributes\Group;
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInput;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
@@ -152,6 +153,36 @@ class ListDraftWikisTest extends TestCase
         $this->assertSame(2, $payload['per_page']);
         $this->assertSame(2, $payload['last_page']);
         $this->assertSame(3, $payload['total']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByEditorIdentifierWhenSpecified(): void
+    {
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f601', 'talent', [
+            'status' => ApprovalStatus::UnderReview->value,
+            'editor_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f701',
+            'edited_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f602', 'talent', [
+            'status' => ApprovalStatus::UnderReview->value,
+            'editor_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f702',
+            'edited_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f603', 'talent', [
+            'status' => ApprovalStatus::Pending->value,
+            'editor_id' => '01965bb2-bcc9-7c6f-8b90-89f7f217f701',
+            'edited_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListDraftWikisInput(
+            status: ApprovalStatus::UnderReview,
+            editorIdentifier: new PrincipalIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f701'),
+        ))->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f601',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
     }
 
     #[Group('useDb')]

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -281,7 +281,8 @@ interface DraftWikiListOperations {
     @query translationSetIdentifier?: Uuid,
     @query status: DraftWikiStatus,
     @query resourceType?: string,
-  ): ListDraftWikisResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+    @query onlyMine?: boolean,
+  ): ListDraftWikisResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }
 
 @route("/wiki")


### PR DESCRIPTION
## 📝 変更内容

- `GET /draft-wikis` に `onlyMine` query parameter を追加しました
- `onlyMine=true` の場合、ログイン中 identity から current principal を取得し、`draft_wikis.editor_id` で絞り込むようにしました
- `/draft-wikis` に `resolve.actor` middleware を追加しました
- TypeSpec に `onlyMine` と 404 response を追加し、OpenAPI を再生成しました
- `editorIdentifier` による query 絞り込みと input DTO のテストを追加しました

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

下書き Wiki 一覧 API で「自身が編集した下書き」を取得できるようにするため、クライアントから editorIdentifier を直接受け取るのではなく、`onlyMine` フラグが有効な場合にログイン情報から principalIdentifier を解決して絞り込むようにしました。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `onlyMine=true` のときだけ current principal を解決して `editor_id` 条件が適用されること
- request から `editorIdentifier` を直接受け取らないこと
- `/draft-wikis` に `resolve.actor` が追加され、ActorContext を利用できること
- TypeSpec/OpenAPI が実装と一致していること

## 📖 関連情報

### 関連Issue・タスク

Relates to #372

## ⚠️ 注意事項

マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
