### PR TITLE
fix: Wiki下書き作成とレスポンススキーマを修正

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
@@ -6,7 +6,6 @@ namespace Application\Http\Action\Wiki\Wiki\Command\CreateWiki;
 
 use Application\Http\Action\Wiki\Wiki\Command\Support\WikiCommandPayloadMapper;
 use Application\Http\Context\WikiContext;
-use Application\Http\Exceptions\ConflictHttpException;
 use Application\Http\Exceptions\ForbiddenHttpException;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
 use Application\Http\Exceptions\UnprocessableEntityHttpException;
@@ -15,7 +14,6 @@ use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Source\Shared\Domain\ValueObject\Language;
-use Source\Wiki\Shared\Application\Exception\DuplicateSlugException;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
@@ -82,11 +80,6 @@ readonly class CreateWikiAction
                 $this->logger->error((string) $e);
 
                 throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
-            } catch (DuplicateSlugException $e) {
-                DB::rollBack();
-                $this->logger->error((string) $e);
-
-                throw new ConflictHttpException(detail: error_message('duplicate_slug', $language), previous: $e);
             } catch (PrincipalNotFoundException $e) {
                 DB::rollBack();
                 $this->logger->error((string) $e);
@@ -98,7 +91,7 @@ readonly class CreateWikiAction
 
                 throw $e;
             }
-        } catch (ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+        } catch (ForbiddenHttpException|UnprocessableEntityHttpException $e) {
             $this->logger->error((string) $e);
 
             return response()->json($e->toProblemDetails(), $e->getHttpStatus());

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2059,6 +2059,9 @@ components:
         - normalizedName
         - ceo
         - normalizedCeo
+        - foundedIn
+        - parentAgencyIdentifier
+        - status
         - officialWebsite
         - socialLinks
       properties:
@@ -2077,13 +2080,17 @@ components:
         foundedIn:
           type: string
           format: date
+          nullable: true
           description: Date when the agency was founded.
         parentAgencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Parent agency identifier.
         status:
           type: string
+          nullable: true
           description: Current activity status of the agency.
         officialWebsite:
           type: string
@@ -2103,6 +2110,7 @@ components:
         - language
         - resourceType
         - version
+        - themeColor
         - heroImage
         - basic
         - sections
@@ -2130,6 +2138,7 @@ components:
           description: Published version number associated with the draft.
         themeColor:
           type: string
+          nullable: true
           description: Theme color applied to the wiki.
         heroImage:
           allOf:
@@ -2457,6 +2466,7 @@ components:
         - language
         - resourceType
         - version
+        - themeColor
         - heroImage
         - basic
         - sections
@@ -2484,6 +2494,7 @@ components:
           description: Published version number associated with the draft.
         themeColor:
           type: string
+          nullable: true
           description: Theme color applied to the wiki.
         heroImage:
           allOf:
@@ -2502,6 +2513,8 @@ components:
       type: object
       required:
         - imageIdentifier
+        - src
+        - alt
       properties:
         imageIdentifier:
           type: string
@@ -2509,6 +2522,14 @@ components:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           nullable: true
           description: Image identifier shown as the hero image.
+        src:
+          type: string
+          nullable: true
+          description: Resolved hero image URL.
+        alt:
+          type: string
+          nullable: true
+          description: Hero image alternative text.
       description: Hero image payload for a draft wiki.
     DraftWikiListItem:
       type: object
@@ -2662,8 +2683,12 @@ components:
       required:
         - name
         - normalizedName
+        - agencyIdentifier
         - groupType
+        - status
         - generation
+        - debutDate
+        - disbandDate
         - fandomName
         - officialColors
         - emoji
@@ -2686,6 +2711,7 @@ components:
           description: Group type.
         status:
           type: string
+          nullable: true
           description: Current activity status of the group.
         generation:
           type: string
@@ -2693,6 +2719,7 @@ components:
         debutDate:
           type: string
           format: date
+          nullable: true
           description: Debut date of the group.
         disbandDate:
           type: string
@@ -3260,6 +3287,8 @@ components:
         - normalizedName
         - songType
         - genres
+        - agencyIdentifier
+        - releaseDate
         - albumName
         - lyricist
         - normalizedLyricist
@@ -3278,6 +3307,7 @@ components:
           description: Normalized name of the song.
         songType:
           type: string
+          nullable: true
           description: Song type.
         genres:
           type: array
@@ -3285,15 +3315,19 @@ components:
             type: string
           description: Genres associated with the song.
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         releaseDate:
           type: string
           format: date
+          nullable: true
           description: Release date of the song.
         albumName:
           type: string
+          nullable: true
           description: Album name.
         lyricist:
           type: string
@@ -3333,6 +3367,7 @@ components:
         - language
         - resourceType
         - version
+        - themeColor
         - heroImage
         - basic
         - sections
@@ -3360,6 +3395,7 @@ components:
           description: Published version number associated with the draft.
         themeColor:
           type: string
+          nullable: true
           description: Theme color applied to the wiki.
         heroImage:
           allOf:
@@ -3382,6 +3418,12 @@ components:
         - language
         - name
         - normalizedName
+        - agencyIdentifier
+        - groupType
+        - status
+        - generation
+        - debutDate
+        - disbandDate
         - fandomName
         - officialColors
         - emoji
@@ -3404,25 +3446,32 @@ components:
           type: string
           description: Normalized name of the group.
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         groupType:
           type: string
+          nullable: true
           description: Group type.
         status:
           type: string
+          nullable: true
           description: Current activity status of the group.
         generation:
           type: string
+          nullable: true
           description: Generation label of the group.
         debutDate:
           type: string
           format: date
+          nullable: true
           description: Debut date of the group.
         disbandDate:
           type: string
           format: date
+          nullable: true
           description: Disband date of the group.
         fandomName:
           type: string
@@ -3449,9 +3498,16 @@ components:
         - normalizedName
         - realName
         - normalizedRealName
+        - birthday
+        - agencyIdentifier
         - emoji
         - representativeSymbol
         - position
+        - mbti
+        - zodiacSign
+        - englishLevel
+        - height
+        - bloodType
         - fandomName
       properties:
         wikiIdentifier:
@@ -3479,10 +3535,13 @@ components:
         birthday:
           type: string
           format: date
+          nullable: true
           description: Birthday of the talent.
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         emoji:
           type: string
@@ -3495,19 +3554,26 @@ components:
           description: Position of the talent.
         mbti:
           type: string
+          nullable: true
           description: MBTI of the talent.
         zodiacSign:
           type: string
+          nullable: true
           description: Zodiac sign of the talent.
         englishLevel:
           type: string
+          nullable: true
           description: English proficiency level of the talent.
         height:
-          type: integer
-          format: int32
+          anyOf:
+            - type: integer
+              format: int32
+            - type: string
+          nullable: true
           description: Height of the talent in centimeters.
         bloodType:
           type: string
+          nullable: true
           description: Blood type of the talent.
         fandomName:
           type: string
@@ -3572,9 +3638,16 @@ components:
         - normalizedName
         - realName
         - normalizedRealName
+        - birthday
+        - agencyIdentifier
         - emoji
         - representativeSymbol
         - position
+        - mbti
+        - zodiacSign
+        - englishLevel
+        - height
+        - bloodType
         - fandomName
         - groups
       properties:
@@ -3593,10 +3666,13 @@ components:
         birthday:
           type: string
           format: date
+          nullable: true
           description: Birthday of the talent.
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         emoji:
           type: string
@@ -3609,19 +3685,26 @@ components:
           description: Position of the talent.
         mbti:
           type: string
+          nullable: true
           description: MBTI of the talent.
         zodiacSign:
           type: string
+          nullable: true
           description: Zodiac sign of the talent.
         englishLevel:
           type: string
+          nullable: true
           description: English proficiency level of the talent.
         height:
-          type: integer
-          format: int32
+          anyOf:
+            - type: integer
+              format: int32
+            - type: string
+          nullable: true
           description: Height of the talent in centimeters.
         bloodType:
           type: string
+          nullable: true
           description: Blood type of the talent.
         fandomName:
           type: string
@@ -3641,6 +3724,7 @@ components:
         - language
         - resourceType
         - version
+        - themeColor
         - heroImage
         - basic
         - sections
@@ -3668,6 +3752,7 @@ components:
           description: Published version number associated with the draft.
         themeColor:
           type: string
+          nullable: true
           description: Theme color applied to the wiki.
         heroImage:
           allOf:
@@ -3690,6 +3775,12 @@ components:
         - language
         - name
         - normalizedName
+        - agencyIdentifier
+        - groupType
+        - status
+        - generation
+        - debutDate
+        - disbandDate
         - fandomName
         - officialColors
         - emoji
@@ -3712,25 +3803,32 @@ components:
           type: string
           description: Normalized name of the group.
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         groupType:
           type: string
+          nullable: true
           description: Group type.
         status:
           type: string
+          nullable: true
           description: Current activity status of the group.
         generation:
           type: string
+          nullable: true
           description: Generation label of the group.
         debutDate:
           type: string
           format: date
+          nullable: true
           description: Debut date of the group.
         disbandDate:
           type: string
           format: date
+          nullable: true
           description: Disband date of the group.
         fandomName:
           type: string

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWiki.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki;
 
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
-use Source\Wiki\Shared\Application\Exception\DuplicateSlugException;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\Action;
@@ -33,7 +32,6 @@ readonly class CreateWiki implements CreateWikiInterface
      * @return void
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
-     * @throws DuplicateSlugException
      */
     public function process(CreateWikiInputPort $input, CreateWikiOutputPort $output): void
     {
@@ -59,22 +57,20 @@ readonly class CreateWiki implements CreateWikiInterface
             throw new DisallowedException();
         }
 
-        if ($this->wikiRepository->existsBySlug($input->slug())) {
-            throw new DuplicateSlugException();
-        }
+        $publishedWiki = $input->publishedWikiIdentifier() !== null
+            ? $this->wikiRepository->findById($input->publishedWikiIdentifier())
+            : null;
 
         $wiki = $this->wikiFactory->create(
             $input->principalIdentifier(),
             $input->language(),
             $input->basic(),
             $input->slug(),
+            $publishedWiki?->translationSetIdentifier(),
         );
 
-        if ($input->publishedWikiIdentifier()) {
-            $publishedWiki = $this->wikiRepository->findById($input->publishedWikiIdentifier());
-            if ($publishedWiki) {
-                $wiki->setPublishedWikiIdentifier($publishedWiki->wikiIdentifier());
-            }
+        if ($publishedWiki !== null) {
+            $wiki->setPublishedWikiIdentifier($publishedWiki->wikiIdentifier());
         }
 
         $wiki->setSections($input->sections());

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Wiki\Application\UseCase\Command\CreateWiki;
 
-use Source\Wiki\Shared\Application\Exception\DuplicateSlugException;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 
@@ -16,7 +15,6 @@ interface CreateWikiInterface
      * @return void
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
-     * @throws DuplicateSlugException
      */
     public function process(CreateWikiInputPort $input, CreateWikiOutputPort $output): void;
 }

--- a/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiTest.php
@@ -12,7 +12,6 @@ use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
-use Source\Wiki\Shared\Application\Exception\DuplicateSlugException;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
@@ -65,7 +64,6 @@ class CreateWikiTest extends TestCase
      * @return void
      * @throws BindingResolutionException
      * @throws DisallowedException
-     * @throws DuplicateSlugException
      */
     public function testWhenNotFoundPrincipal(): void
     {
@@ -112,7 +110,6 @@ class CreateWikiTest extends TestCase
      * @return void
      * @throws BindingResolutionException
      * @throws PrincipalNotFoundException
-     * @throws DuplicateSlugException
      */
     public function testDisallowed(): void
     {
@@ -161,72 +158,12 @@ class CreateWikiTest extends TestCase
     }
 
     /**
-     * 異常系：指定したSlugが既に存在する場合、例外がスローされること.
-     *
-     * @return void
-     * @throws BindingResolutionException
-     * @throws DisallowedException
-     * @throws PrincipalNotFoundException
-     */
-    public function testDuplicateSlug(): void
-    {
-        $testData = $this->createDummyCreateWiki();
-
-        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
-
-        $input = new CreateWikiInput(
-            $testData->publishedWikiIdentifier,
-            $testData->language,
-            $testData->resourceType,
-            $testData->basic,
-            $testData->sections,
-            $testData->themeColor,
-            $testData->slug,
-            $principalIdentifier,
-            $testData->agencyIdentifier,
-            $testData->groupIdentifiers,
-            $testData->talentIdentifiers,
-        );
-
-        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $principalRepository->shouldReceive('findById')
-            ->with($principalIdentifier)
-            ->once()
-            ->andReturn($principal);
-
-        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
-        $policyEvaluator->shouldReceive('evaluate')
-            ->once()
-            ->andReturn(true);
-
-        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
-        $wikiRepository->shouldReceive('existsBySlug')
-            ->once()
-            ->with($testData->slug)
-            ->andReturn(true);
-
-        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
-        $draftWikiRepository->shouldNotReceive('save');
-
-        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PolicyEvaluatorInterface::class, $policyEvaluator);
-        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
-        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
-
-        $this->expectException(DuplicateSlugException::class);
-        $useCase = $this->app->make(CreateWikiInterface::class);
-        $useCase->process($input, new CreateWikiOutput());
-    }
-
-    /**
      * 正常系：正しくDraftWiki Entityが作成されること.
      *
      * @return void
      * @throws BindingResolutionException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
-     * @throws DuplicateSlugException
      */
     public function testProcess(): void
     {
@@ -263,14 +200,16 @@ class CreateWikiTest extends TestCase
         $wikiFactory = Mockery::mock(DraftWikiFactoryInterface::class);
         $wikiFactory->shouldReceive('create')
             ->once()
-            ->with($principalIdentifier, $testData->language, $testData->basic, $testData->slug)
+            ->with(
+                $principalIdentifier,
+                $testData->language,
+                $testData->basic,
+                $testData->slug,
+                $testData->translationSetIdentifier,
+            )
             ->andReturn($testData->draftWiki);
 
         $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
-        $wikiRepository->shouldReceive('existsBySlug')
-            ->once()
-            ->with($testData->slug)
-            ->andReturn(false);
         $wikiRepository->shouldReceive('findById')
             ->once()
             ->with($testData->publishedWikiIdentifier)

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -41,6 +41,10 @@ model PublishedWikiSummary {
 model DraftWikiHeroImage {
   @doc("Image identifier shown as the hero image.")
   imageIdentifier: Uuid | null;
+  @doc("Resolved hero image URL.")
+  src: string | null;
+  @doc("Hero image alternative text.")
+  alt: string | null;
 }
 
 @doc("Basic payload for a group draft wiki.")
@@ -50,17 +54,17 @@ model GroupDraftWikiBasic {
   @doc("Normalized name of the group.")
   normalizedName: string;
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid | null;
+  agencyIdentifier: Uuid | null;
   @doc("Group type.")
   groupType: string;
   @doc("Current activity status of the group.")
-  status?: string;
+  status: string | null;
   @doc("Generation label of the group.")
   generation: string;
   @doc("Debut date of the group.")
-  debutDate?: plainDate;
+  debutDate: plainDate | null;
   @doc("Disband date of the group.")
-  disbandDate?: plainDate | null;
+  disbandDate: plainDate | null;
   @doc("Fandom name of the group.")
   fandomName: string;
   @doc("Official colors of the group.")
@@ -86,7 +90,7 @@ model DraftWikiDetail {
   @doc("Published version number associated with the draft.")
   version: int32;
   @doc("Theme color applied to the wiki.")
-  themeColor?: string;
+  themeColor: string | null;
   @doc("Hero image payload for the editor.")
   heroImage: DraftWikiHeroImage;
   @doc("Basic wiki content payload.")
@@ -132,17 +136,17 @@ model TalentDraftWikiGroupSummary {
   @doc("Normalized name of the group.")
   normalizedName: string;
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier: Uuid | null;
   @doc("Group type.")
-  groupType?: string;
+  groupType: string | null;
   @doc("Current activity status of the group.")
-  status?: string;
+  status: string | null;
   @doc("Generation label of the group.")
-  generation?: string;
+  generation: string | null;
   @doc("Debut date of the group.")
-  debutDate?: plainDate;
+  debutDate: plainDate | null;
   @doc("Disband date of the group.")
-  disbandDate?: plainDate;
+  disbandDate: plainDate | null;
   @doc("Fandom name of the group.")
   fandomName: string;
   @doc("Official color palette of the group.")
@@ -164,9 +168,9 @@ model TalentDraftWikiBasic {
   @doc("Normalized real name of the talent.")
   normalizedRealName: string;
   @doc("Birthday of the talent.")
-  birthday?: plainDate;
+  birthday: plainDate | null;
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier: Uuid | null;
   @doc("Emoji representing the talent.")
   emoji: string;
   @doc("Representative symbol of the talent.")
@@ -174,15 +178,15 @@ model TalentDraftWikiBasic {
   @doc("Position of the talent.")
   position: string;
   @doc("MBTI of the talent.")
-  mbti?: string;
+  mbti: string | null;
   @doc("Zodiac sign of the talent.")
-  zodiacSign?: string;
+  zodiacSign: string | null;
   @doc("English proficiency level of the talent.")
-  englishLevel?: string;
+  englishLevel: string | null;
   @doc("Height of the talent in centimeters.")
-  height?: int32;
+  height: int32 | string | null;
   @doc("Blood type of the talent.")
-  bloodType?: string;
+  bloodType: string | null;
   @doc("Fandom name of the talent.")
   fandomName: string;
   @doc("Related published groups linked to the talent.")
@@ -204,7 +208,7 @@ model TalentDraftWikiDetail {
   @doc("Published version number associated with the draft.")
   version: int32;
   @doc("Theme color applied to the wiki.")
-  themeColor?: string;
+  themeColor: string | null;
   @doc("Hero image payload for the editor.")
   heroImage: DraftWikiHeroImage;
   @doc("Basic talent wiki content payload.")
@@ -250,17 +254,17 @@ model SongDraftWikiGroupSummary {
   @doc("Normalized name of the group.")
   normalizedName: string;
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier: Uuid | null;
   @doc("Group type.")
-  groupType?: string;
+  groupType: string | null;
   @doc("Current activity status of the group.")
-  status?: string;
+  status: string | null;
   @doc("Generation label of the group.")
-  generation?: string;
+  generation: string | null;
   @doc("Debut date of the group.")
-  debutDate?: plainDate;
+  debutDate: plainDate | null;
   @doc("Disband date of the group.")
-  disbandDate?: plainDate;
+  disbandDate: plainDate | null;
   @doc("Fandom name of the group.")
   fandomName: string;
   @doc("Official color palette of the group.")
@@ -288,9 +292,9 @@ model SongDraftWikiTalentSummary {
   @doc("Normalized real name of the talent.")
   normalizedRealName: string;
   @doc("Birthday of the talent.")
-  birthday?: plainDate;
+  birthday: plainDate | null;
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier: Uuid | null;
   @doc("Emoji representing the talent.")
   emoji: string;
   @doc("Representative symbol of the talent.")
@@ -298,15 +302,15 @@ model SongDraftWikiTalentSummary {
   @doc("Position of the talent.")
   position: string;
   @doc("MBTI of the talent.")
-  mbti?: string;
+  mbti: string | null;
   @doc("Zodiac sign of the talent.")
-  zodiacSign?: string;
+  zodiacSign: string | null;
   @doc("English proficiency level of the talent.")
-  englishLevel?: string;
+  englishLevel: string | null;
   @doc("Height of the talent in centimeters.")
-  height?: int32;
+  height: int32 | string | null;
   @doc("Blood type of the talent.")
-  bloodType?: string;
+  bloodType: string | null;
   @doc("Fandom name of the talent.")
   fandomName: string;
 }
@@ -318,15 +322,15 @@ model SongDraftWikiBasic {
   @doc("Normalized name of the song.")
   normalizedName: string;
   @doc("Song type.")
-  songType: string;
+  songType: string | null;
   @doc("Genres associated with the song.")
   genres: string[];
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier: Uuid | null;
   @doc("Release date of the song.")
-  releaseDate?: plainDate;
+  releaseDate: plainDate | null;
   @doc("Album name.")
-  albumName: string;
+  albumName: string | null;
   @doc("Lyricist name.")
   lyricist: string;
   @doc("Normalized lyricist name.")
@@ -360,7 +364,7 @@ model SongDraftWikiDetail {
   @doc("Published version number associated with the draft.")
   version: int32;
   @doc("Theme color applied to the wiki.")
-  themeColor?: string;
+  themeColor: string | null;
   @doc("Hero image payload for the editor.")
   heroImage: DraftWikiHeroImage;
   @doc("Basic song wiki content payload.")
@@ -404,11 +408,11 @@ model AgencyDraftWikiBasic {
   @doc("Normalized chief executive officer name.")
   normalizedCeo: string;
   @doc("Date when the agency was founded.")
-  foundedIn?: plainDate;
+  foundedIn: plainDate | null;
   @doc("Parent agency identifier.")
-  parentAgencyIdentifier?: Uuid;
+  parentAgencyIdentifier: Uuid | null;
   @doc("Current activity status of the agency.")
-  status?: string;
+  status: string | null;
   @doc("Official website of the agency.")
   officialWebsite: string;
   @doc("Social links of the agency.")
@@ -430,7 +434,7 @@ model AgencyDraftWikiDetail {
   @doc("Published version number associated with the draft.")
   version: int32;
   @doc("Theme color applied to the wiki.")
-  themeColor?: string;
+  themeColor: string | null;
   @doc("Hero image payload for the editor.")
   heroImage: DraftWikiHeroImage;
   @doc("Basic agency wiki content payload.")


### PR DESCRIPTION
## 📝 変更内容

Wiki下書き作成時の workflow と Draft Wiki read model の schema を修正しました。

主な変更は以下です。

- CreateWiki で slug 重複チェックを行わないように変更
- 既存公開Wikiを元に下書きを作成する場合、公開Wikiの `translationSetIdentifier` を下書きへ引き継ぐように修正
- CreateWiki API から `DuplicateSlugException` の conflict ハンドリングを削除
- Draft Wiki の実レスポンスに合わせて TypeSpec を修正
  - `themeColor` を `string | null` に変更
  - read model で常に返る nullable 項目を `?:` ではなく `| null` に変更
  - `DraftWikiHeroImage` に `src` / `alt` を追加
  - talent/song の `height` を `int32 | string | null` に変更
- TypeSpec 変更に合わせて OpenAPI を再生成
- CreateWiki のテストを更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

CreateWiki の段階では slug 重複を確定判定する必要がなく、承認時に既存公開Wikiと同じ `translationSetIdentifier` を除外して判定する方針に合わせる必要がありました。

また、既存公開Wikiから下書きを作成した際に `translationSetIdentifier` を引き継いでいなかったため、Approve 時に同一Wikiの更新であっても別翻訳セットの slug 重複として扱われる問題がありました。

加えて、Draft Wiki の frontend schema 生成元である TypeSpec が backend の read model 実レスポンスより strict になっており、`themeColor: null` や talent/song の nullable 項目で schema validation が失敗し得る状態だったため、実レスポンスに合わせて修正しました。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行内容:

- `task test -- tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiTest.php tests/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiTest.php`
  - 実際には全体 PHPUnit が走り、`2606 tests, 8289 assertions` で通過
- `task openapi-generate`
- `git diff --check`

## 🔍 レビューのポイント

- CreateWiki で slug 重複チェックを削除しても、Approve 側の重複判定で期待する制御になっているか
- 既存公開Wikiを元にした下書き作成時に `translationSetIdentifier` を引き継ぐ挙動が妥当か
- TypeSpec の nullable 定義が `DraftWikiReadModel` / basic read model の `toArray()` と整合しているか
- 再生成された OpenAPI の差分が frontend schema 生成に適した内容になっているか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

DBマイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
