### PR TITLE
fix: 翻訳Wikiの公開Wiki紐づけ先を言語ごとに修正

### DIFF
--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
@@ -70,6 +70,14 @@ readonly class TranslateWiki implements TranslateWikiInterface
         }
 
         $languages = Language::allExcept($wiki->language());
+        $publishedWikiIdentifierMap = [];
+        $publishedWikis = $this->wikiRepository->findByTranslationSetIdentifierAndLanguages(
+            $wiki->translationSetIdentifier(),
+            $languages,
+        );
+        foreach ($publishedWikis as $publishedWiki) {
+            $publishedWikiIdentifierMap[$publishedWiki->language()->value] = $publishedWiki->wikiIdentifier();
+        }
 
         $wikiDrafts = [];
         $translatedAt = new DateTimeImmutable();
@@ -87,7 +95,10 @@ readonly class TranslateWiki implements TranslateWikiInterface
             $wikiDraft->setSections($translatedData->translatedSections());
             $wikiDraft->setThemeColor($wiki->themeColor());
             $wikiDraft->setImageIdentifier($wiki->imageIdentifier());
-            $wikiDraft->setPublishedWikiIdentifier($input->wikiIdentifier());
+            $publishedWikiIdentifier = $publishedWikiIdentifierMap[$language->value] ?? null;
+            if ($publishedWikiIdentifier !== null) {
+                $wikiDraft->setPublishedWikiIdentifier($publishedWikiIdentifier);
+            }
             $wikiDraft->setSourceEditorIdentifier($wiki->editorIdentifier());
             $wikiDraft->setTranslatedAt($translatedAt);
 

--- a/src/Wiki/Wiki/Domain/Repository/WikiRepositoryInterface.php
+++ b/src/Wiki/Wiki/Domain/Repository/WikiRepositoryInterface.php
@@ -31,6 +31,15 @@ interface WikiRepositoryInterface
     public function findByTranslationSetIdentifier(TranslationSetIdentifier $translationSetIdentifier): array;
 
     /**
+     * @param Language[] $languages
+     * @return Wiki[]
+     */
+    public function findByTranslationSetIdentifierAndLanguages(
+        TranslationSetIdentifier $translationSetIdentifier,
+        array $languages,
+    ): array;
+
+    /**
      * @return Wiki[]
      */
     public function findByResourceType(ResourceType $resourceType, int $limit = 20, int $offset = 0): array;

--- a/src/Wiki/Wiki/Infrastructure/Repository/WikiRepository.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/WikiRepository.php
@@ -90,6 +90,27 @@ readonly class WikiRepository implements WikiRepositoryInterface
     }
 
     /**
+     * @param Language[] $languages
+     * @return Wiki[]
+     */
+    public function findByTranslationSetIdentifierAndLanguages(
+        TranslationSetIdentifier $translationSetIdentifier,
+        array $languages,
+    ): array {
+        if ($languages === []) {
+            return [];
+        }
+
+        $models = WikiModel::query()
+            ->with(['talentBasic.groups', 'groupBasic', 'agencyBasic', 'songBasic.groups', 'songBasic.talents'])
+            ->where('translation_set_identifier', (string) $translationSetIdentifier)
+            ->whereIn('language', array_map(static fn (Language $language): string => $language->value, $languages))
+            ->get();
+
+        return $models->map(fn (WikiModel $model) => $this->toDomainEntity($model))->toArray();
+    }
+
+    /**
      * @return Wiki[]
      */
     public function findByResourceType(ResourceType $resourceType, int $limit = 20, int $offset = 0): array

--- a/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
@@ -80,6 +80,20 @@ class TranslateWikiTest extends TestCase
             $principalIdentifier,
             ResourceType::TALENT,
         );
+        $enPublishedWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+        $enPublishedWiki = new Wiki(
+            $enPublishedWikiIdentifier,
+            $testData->translationSetIdentifier,
+            $testData->slug,
+            Language::ENGLISH,
+            ResourceType::TALENT,
+            $this->createTalentBasic('Test Wiki'),
+            new SectionContentCollection(),
+            null,
+            new Version(1),
+            null,
+            $testData->editorIdentifier,
+        );
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $principalRepository->shouldReceive('findById')
@@ -92,6 +106,10 @@ class TranslateWikiTest extends TestCase
             ->with($testData->wikiIdentifier)
             ->once()
             ->andReturn($testData->wiki);
+        $wikiRepository->shouldReceive('findByTranslationSetIdentifierAndLanguages')
+            ->with($testData->translationSetIdentifier, [Language::JAPANESE, Language::ENGLISH])
+            ->once()
+            ->andReturn([$enPublishedWiki]);
 
         $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
         $draftWikiRepository->shouldReceive('save')
@@ -180,6 +198,8 @@ class TranslateWikiTest extends TestCase
         $result = $output->toArray();
 
         $this->assertCount(2, $result['draftWikis']);
+        $this->assertNull($jaDraftWiki->publishedWikiIdentifier());
+        $this->assertSame($enPublishedWikiIdentifier, $enDraftWiki->publishedWikiIdentifier());
     }
 
     /**

--- a/tests/Wiki/Wiki/Infrastructure/Repository/WikiRepositoryTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Repository/WikiRepositoryTest.php
@@ -645,6 +645,55 @@ class WikiRepositoryTest extends TestCase
     }
 
     /**
+     * 正常系：TranslationSetIdentifierと言語でWikiが取得できること.
+     *
+     * @throws BindingResolutionException
+     */
+    #[Group('useDb')]
+    public function testFindByTranslationSetIdentifierAndLanguages(): void
+    {
+        $translationSetId = StrTestHelper::generateUuid();
+        $wikiId1 = StrTestHelper::generateUuid();
+        $wikiId2 = StrTestHelper::generateUuid();
+        $excludedLanguageWikiId = StrTestHelper::generateUuid();
+        $otherTranslationSetWikiId = StrTestHelper::generateUuid();
+
+        CreateWiki::create($wikiId1, 'group', [
+            'translation_set_identifier' => $translationSetId,
+            'slug' => 'gr-twice-ja',
+            'language' => Language::JAPANESE->value,
+        ]);
+        CreateWiki::create($wikiId2, 'group', [
+            'translation_set_identifier' => $translationSetId,
+            'slug' => 'gr-twice-en',
+            'language' => Language::ENGLISH->value,
+        ]);
+        CreateWiki::create($excludedLanguageWikiId, 'group', [
+            'translation_set_identifier' => $translationSetId,
+            'slug' => 'gr-twice-ko',
+            'language' => Language::KOREAN->value,
+        ]);
+        CreateWiki::create($otherTranslationSetWikiId, 'group', [
+            'translation_set_identifier' => StrTestHelper::generateUuid(),
+            'slug' => 'gr-other-translation-set-ja',
+            'language' => Language::JAPANESE->value,
+        ]);
+
+        $repository = $this->app->make(WikiRepositoryInterface::class);
+        $wikis = $repository->findByTranslationSetIdentifierAndLanguages(
+            new TranslationSetIdentifier($translationSetId),
+            [Language::JAPANESE, Language::ENGLISH],
+        );
+
+        $this->assertCount(2, $wikis);
+        $wikiIds = array_map(static fn (Wiki $wiki): string => (string) $wiki->wikiIdentifier(), $wikis);
+        $this->assertContains($wikiId1, $wikiIds);
+        $this->assertContains($wikiId2, $wikiIds);
+        $this->assertNotContains($excludedLanguageWikiId, $wikiIds);
+        $this->assertNotContains($otherTranslationSetWikiId, $wikiIds);
+    }
+
+    /**
      * 正常系：ResourceTypeでWikiが取得できること.
      *
      * @throws BindingResolutionException


### PR DESCRIPTION
## 📝 変更内容

- `TranslateWiki` の翻訳 Draft 作成時に、翻訳元 Wiki ID を無条件で `publishedWikiIdentifier` に設定していた処理を修正
- 翻訳セット内の公開 Wiki を翻訳対象言語で絞って取得する `findByTranslationSetIdentifierAndLanguages()` を追加
- 翻訳先言語の公開 Wiki が存在する場合のみ、その Wiki ID を Draft の `publishedWikiIdentifier` に設定
- 翻訳先言語の公開 Wiki が存在しない場合は、Draft を未紐づけのまま作成
- UseCase と Repository のテストを追加・更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

翻訳 Draft 作成時に翻訳元 Wiki の `WikiIdentifier` をそのまま設定していたため、翻訳先言語の Draft が別言語の公開 Wiki に紐づく問題がありました。

翻訳先言語に対応する公開 Wiki が既に存在する場合はその Wiki に紐づけ、存在しない場合は新規公開できる Draft として扱えるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- 翻訳先言語に対応する公開 Wiki がある場合のみ `publishedWikiIdentifier` が設定されること
- 翻訳先言語の公開 Wiki がない場合に、翻訳元 Wiki ID や別言語 Wiki ID が流用されないこと
- Repository が ID などのプリミティブではなく `Wiki[]` を返す設計を維持していること

## 📖 関連情報

### 関連Issue・タスク

Closes #385

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
