### PR TITLE
Wikiバージョン不整合一覧APIを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Project Codex Instructions
+
+## TypeSpec And OpenAPI
+
+- TypeSpec で OpenAPI の nullable を表現する場合は、`field?: string` だけにせず `field?: string | null` のように `| null` を明示する。
+- Laravel の Request で `nullable` な query/body パラメータを TypeSpec に追加・更新する場合も、OpenAPI 生成結果が null 許容になるよう `| null` を付ける。

--- a/application/Http/Action/Wiki/Wiki/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisAction.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListVersionInconsistentWikis;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class ListVersionInconsistentWikisAction
+{
+    public function __construct(
+        private ListVersionInconsistentWikisInterface $listVersionInconsistentWikis,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ListVersionInconsistentWikisRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ListVersionInconsistentWikisInput(
+                    perPage: $request->perPage(),
+                    resourceType: $request->resourceType() === null ? null : ResourceType::from($request->resourceType()),
+                    sort: $request->sort(),
+                    order: $request->order(),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            $output = new ListVersionInconsistentWikisOutput();
+            $this->listVersionInconsistentWikis->process($input, $output);
+        } catch (UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListVersionInconsistentWikis;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+class ListVersionInconsistentWikisRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'resourceType' => ['nullable', 'string', Rule::in([
+                ResourceType::AGENCY->value,
+                ResourceType::GROUP->value,
+                ResourceType::TALENT->value,
+                ResourceType::SONG->value,
+            ])],
+            'sort' => ['nullable', 'string', Rule::in(['updatedAt', 'name'])],
+            'order' => ['nullable', 'string', Rule::in(['asc', 'desc'])],
+        ];
+    }
+
+    public function perPage(): ?int
+    {
+        $perPage = $this->query('perPage');
+
+        return $perPage === null ? null : (int) $perPage;
+    }
+
+    public function resourceType(): ?string
+    {
+        $resourceType = $this->query('resourceType');
+
+        return $resourceType === null ? null : (string) $resourceType;
+    }
+
+    public function sort(): ?string
+    {
+        $sort = $this->query('sort');
+
+        return $sort === null ? null : (string) $sort;
+    }
+
+    public function order(): ?string
+    {
+        $order = $this->query('order');
+
+        return $order === null ? null : (string) $order;
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -88,6 +88,7 @@ use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyWiki;
@@ -98,6 +99,7 @@ use Source\Wiki\Wiki\Infrastructure\Query\GetSongWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\ListDraftWikis;
+use Source\Wiki\Wiki\Infrastructure\Query\ListVersionInconsistentWikis;
 use Source\Wiki\Wiki\Infrastructure\Query\ListWikis;
 
 class UseCaseServiceProvider extends ServiceProvider
@@ -150,6 +152,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(GetTalentDraftWikiInterface::class, GetTalentDraftWiki::class);
         $this->app->singleton(GetTalentWikiInterface::class, GetTalentWiki::class);
         $this->app->singleton(ListDraftWikisInterface::class, ListDraftWikis::class);
+        $this->app->singleton(ListVersionInconsistentWikisInterface::class, ListVersionInconsistentWikis::class);
         $this->app->singleton(ListWikisInterface::class, ListWikis::class);
     }
 }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1990,6 +1990,61 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/WikiWorkflowRequestBody'
+  /wikis/version-inconsistencies:
+    get:
+      operationId: WikiListOperations_listVersionInconsistentWikis
+      description: List published wikis with version inconsistencies across translation sets.
+      parameters:
+        - name: perPage
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+          explode: false
+        - name: resourceType
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: Response returned when wiki list retrieval succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWikisResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /wikis/{language}:
     get:
       operationId: WikiListOperations_listWikis

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -44,6 +44,7 @@ use Application\Http\Action\Wiki\Wiki\Query\GetSongWiki\GetSongWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki\GetTalentDraftWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentWiki\GetTalentWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\ListDraftWikis\ListDraftWikisAction;
+use Application\Http\Action\Wiki\Wiki\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisAction;
 use Application\Http\Action\Wiki\Wiki\Query\ListWikis\ListWikisAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
@@ -64,6 +65,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
     Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
     Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
 });
+Route::get('/wikis/version-inconsistencies', ListVersionInconsistentWikisAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::get('/wikis/{language}', ListWikisAction::class);
 Route::get('/draft-wikis', ListDraftWikisAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis;
+
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+readonly class ListVersionInconsistentWikisInput implements ListVersionInconsistentWikisInputPort
+{
+    public function __construct(
+        private ?int $perPage = null,
+        private ?ResourceType $resourceType = null,
+        private ?string $sort = null,
+        private ?string $order = null,
+    ) {
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage ?? 10;
+    }
+
+    public function resourceType(): ?ResourceType
+    {
+        return $this->resourceType;
+    }
+
+    public function sort(): string
+    {
+        return $this->sort ?? 'updatedAt';
+    }
+
+    public function order(): string
+    {
+        return $this->order ?? 'desc';
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInputPort.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis;
+
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+interface ListVersionInconsistentWikisInputPort
+{
+    public function perPage(): int;
+
+    public function resourceType(): ?ResourceType;
+
+    public function sort(): string;
+
+    public function order(): string;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis;
+
+interface ListVersionInconsistentWikisInterface
+{
+    public function process(
+        ListVersionInconsistentWikisInputPort $input,
+        ListVersionInconsistentWikisOutputPort $output,
+    ): void;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisOutput.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+
+class ListVersionInconsistentWikisOutput implements ListVersionInconsistentWikisOutputPort
+{
+    /** @var list<WikiListItemReadModel> */
+    private array $wikis = [];
+
+    private ?int $currentPage = null;
+
+    private ?int $lastPage = null;
+
+    private ?int $total = null;
+
+    private ?int $perPage = null;
+
+    /**
+     * @param list<WikiListItemReadModel> $wikis
+     */
+    public function output(array $wikis, int $currentPage, int $lastPage, int $total, int $perPage): void
+    {
+        $this->wikis = $wikis;
+        $this->currentPage = $currentPage;
+        $this->lastPage = $lastPage;
+        $this->total = $total;
+        $this->perPage = $perPage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikis' => array_map(static fn (WikiListItemReadModel $wiki): array => $wiki->toArray(), $this->wikis),
+            'current_page' => $this->currentPage,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'per_page' => $this->perPage,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+
+interface ListVersionInconsistentWikisOutputPort
+{
+    /**
+     * @param list<WikiListItemReadModel> $wikis
+     */
+    public function output(array $wikis, int $currentPage, int $lastPage, int $total, int $perPage): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/ListVersionInconsistentWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListVersionInconsistentWikis.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use Application\Models\Wiki\WikiAgencyBasic;
+use Application\Models\Wiki\WikiGroupBasic;
+use Application\Models\Wiki\WikiSongBasic;
+use Application\Models\Wiki\WikiTalentBasic;
+use DateTimeInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Infrastructure\Support\ImageUrl;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisOutputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+
+readonly class ListVersionInconsistentWikis implements ListVersionInconsistentWikisInterface
+{
+    /** @var array<string, array{relation: string, table: string}> */
+    private const BASIC_TABLES = [
+        ResourceType::TALENT->value => ['relation' => 'talentBasic', 'table' => 'wiki_talent_basics'],
+        ResourceType::GROUP->value => ['relation' => 'groupBasic', 'table' => 'wiki_group_basics'],
+        ResourceType::AGENCY->value => ['relation' => 'agencyBasic', 'table' => 'wiki_agency_basics'],
+        ResourceType::SONG->value => ['relation' => 'songBasic', 'table' => 'wiki_song_basics'],
+    ];
+
+    public function process(
+        ListVersionInconsistentWikisInputPort $input,
+        ListVersionInconsistentWikisOutputPort $output,
+    ): void {
+        $inconsistentSets = DB::table('wikis')
+            ->select('translation_set_identifier', DB::raw('MAX(version) as latest_version'))
+            ->whereIn('resource_type', $this->targetResourceTypes($input->resourceType()))
+            ->groupBy('translation_set_identifier')
+            ->havingRaw(
+                'MIN(version) != MAX(version) OR COUNT(DISTINCT language) < ?',
+                [count(Language::cases())],
+            );
+
+        $query = WikiModel::query()
+            ->select('wikis.*', 'wiki_images.image_path as image_path', 'wiki_images.alt_text as image_alt_text')
+            ->joinSub($inconsistentSets, 'version_inconsistent_sets', function ($join): void {
+                $join->on('version_inconsistent_sets.translation_set_identifier', '=', 'wikis.translation_set_identifier')
+                    ->on('version_inconsistent_sets.latest_version', '=', 'wikis.version');
+            })
+            ->leftJoin('wiki_images', 'wiki_images.id', '=', 'wikis.image_identifier')
+            ->with(['talentBasic', 'groupBasic', 'agencyBasic', 'songBasic'])
+            ->whereIn('wikis.resource_type', $this->targetResourceTypes($input->resourceType()));
+
+        $this->joinBasicTables($query);
+        $this->applySort($query, $input->sort(), $input->order());
+
+        /** @var LengthAwarePaginator<int, WikiModel> $paginator */
+        $paginator = $query->paginate($input->perPage());
+
+        $output->output(
+            array_map(
+                fn (WikiModel $wiki): WikiListItemReadModel => $this->toReadModel($wiki),
+                $paginator->items(),
+            ),
+            $paginator->currentPage(),
+            $paginator->lastPage(),
+            $paginator->total(),
+            $paginator->perPage(),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function targetResourceTypes(?ResourceType $resourceType): array
+    {
+        if ($resourceType !== null) {
+            return [$resourceType->value];
+        }
+
+        return array_keys(self::BASIC_TABLES);
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function joinBasicTables(Builder $query): void
+    {
+        foreach (self::BASIC_TABLES as $basic) {
+            $query->leftJoin($basic['table'], "{$basic['table']}.wiki_id", '=', 'wikis.id');
+        }
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applySort(Builder $query, string $sort, string $order): void
+    {
+        if ($sort === 'name') {
+            $query->orderBy(DB::raw($this->nameSortExpression()), $order)
+                ->orderBy('wikis.updated_at', 'desc');
+
+            return;
+        }
+
+        $query->orderBy('wikis.updated_at', $order);
+    }
+
+    private function nameSortExpression(): string
+    {
+        return 'COALESCE(wiki_talent_basics.name, wiki_group_basics.name, wiki_agency_basics.name, wiki_song_basics.name)';
+    }
+
+    private function toReadModel(WikiModel $wiki): WikiListItemReadModel
+    {
+        $basic = $this->basicModel($wiki);
+
+        return new WikiListItemReadModel(
+            wikiIdentifier: $wiki->id,
+            translationSetIdentifier: $wiki->translation_set_identifier,
+            slug: $wiki->slug,
+            language: $wiki->language,
+            resourceType: $wiki->resource_type,
+            version: $wiki->version,
+            themeColor: $wiki->theme_color,
+            imageIdentifier: $wiki->image_identifier,
+            imageUrl: ImageUrl::fromPath($wiki->getAttribute('image_path')),
+            imageAltText: $wiki->getAttribute('image_alt_text'),
+            name: (string) $basic->getAttribute('name'),
+            normalizedName: (string) $basic->getAttribute('normalized_name'),
+            publishedAt: $this->formatDateTime($wiki->published_at),
+            updatedAt: $this->formatDateTime($wiki->updated_at),
+        );
+    }
+
+    private function basicModel(WikiModel $wiki): Model
+    {
+        $relation = self::BASIC_TABLES[$wiki->resource_type]['relation'] ?? null;
+        if ($relation === null) {
+            throw new InvalidArgumentException("Unsupported wiki resource type: {$wiki->resource_type}");
+        }
+
+        $basic = $wiki->{$relation};
+        if (
+            ! $basic instanceof WikiTalentBasic
+            && ! $basic instanceof WikiGroupBasic
+            && ! $basic instanceof WikiAgencyBasic
+            && ! $basic instanceof WikiSongBasic
+        ) {
+            throw new InvalidArgumentException("Basic not found for Wiki: {$wiki->id}");
+        }
+
+        return $basic;
+    }
+
+    private function formatDateTime(mixed $dateTime): ?string
+    {
+        if ($dateTime === null) {
+            return null;
+        }
+
+        if ($dateTime instanceof DateTimeInterface) {
+            return $dateTime->format(DateTimeInterface::ATOM);
+        }
+
+        return (string) $dateTime;
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisInputTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis;
+
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInput;
+use Tests\TestCase;
+
+class ListVersionInconsistentWikisInputTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $input = new ListVersionInconsistentWikisInput();
+
+        $this->assertSame(10, $input->perPage());
+        $this->assertNull($input->resourceType());
+        $this->assertSame('updatedAt', $input->sort());
+        $this->assertSame('desc', $input->order());
+    }
+
+    public function testAccessors(): void
+    {
+        $input = new ListVersionInconsistentWikisInput(
+            perPage: 20,
+            resourceType: ResourceType::TALENT,
+            sort: 'name',
+            order: 'asc',
+        );
+
+        $this->assertSame(20, $input->perPage());
+        $this->assertSame(ResourceType::TALENT, $input->resourceType());
+        $this->assertSame('name', $input->sort());
+        $this->assertSame('asc', $input->order());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListVersionInconsistentWikis/ListVersionInconsistentWikisOutputTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisOutput;
+use Source\Wiki\Wiki\Application\UseCase\Query\WikiListItemReadModel;
+use Tests\TestCase;
+
+class ListVersionInconsistentWikisOutputTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $item = new WikiListItemReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+            slug: 'tl-chaeyoung',
+            language: 'ko',
+            resourceType: 'talent',
+            version: 2,
+            themeColor: '#FE5F8F',
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f104',
+            imageUrl: 'http://localhost/storage/wiki/example.jpg',
+            imageAltText: 'Chaeyoung profile image',
+            name: 'Chaeyoung',
+            normalizedName: 'chaeyoung',
+            publishedAt: '2026-05-01T00:00:00+00:00',
+            updatedAt: '2026-05-02T00:00:00+00:00',
+        );
+
+        $output = new ListVersionInconsistentWikisOutput();
+        $output->output([$item], 1, 3, 5, 2);
+
+        $this->assertSame([
+            'wikis' => [$item->toArray()],
+            'current_page' => 1,
+            'last_page' => 3,
+            'total' => 5,
+            'per_page' => 2,
+        ], $output->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListVersionInconsistentWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListVersionInconsistentWikisTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisOutput;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class ListVersionInconsistentWikisTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessDoesNotReturnTranslationSetWhenAllLanguagesHaveSameVersion(): void
+    {
+        $translationSetIdentifier = '01965bb2-bcc9-7c6f-8b90-89f7f217a101';
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217a102', $translationSetIdentifier, 'ko', 2);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217a103', $translationSetIdentifier, 'ja', 2);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217a104', $translationSetIdentifier, 'en', 2);
+
+        $payload = $this->process(new ListVersionInconsistentWikisInput())->toArray();
+
+        $this->assertSame(0, $payload['total']);
+        $this->assertSame([], $payload['wikis']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsLatestVersionWikiWhenVersionsDiffer(): void
+    {
+        $translationSetIdentifier = '01965bb2-bcc9-7c6f-8b90-89f7f217b101';
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217b102', $translationSetIdentifier, 'ko', 3);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217b103', $translationSetIdentifier, 'ja', 2);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217b104', $translationSetIdentifier, 'en', 2);
+
+        $payload = $this->process(new ListVersionInconsistentWikisInput())->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame($translationSetIdentifier, $payload['wikis'][0]['translationSetIdentifier']);
+        $this->assertSame('ko', $payload['wikis'][0]['language']);
+        $this->assertSame(3, $payload['wikis'][0]['version']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsTranslationSetWhenPublishedWikiIsMissingForSomeLanguages(): void
+    {
+        $translationSetIdentifier = '01965bb2-bcc9-7c6f-8b90-89f7f217c101';
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217c102', $translationSetIdentifier, 'ko', 1);
+
+        $payload = $this->process(new ListVersionInconsistentWikisInput())->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame($translationSetIdentifier, $payload['wikis'][0]['translationSetIdentifier']);
+        $this->assertSame('ko', $payload['wikis'][0]['language']);
+        $this->assertSame(1, $payload['wikis'][0]['version']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsAllWikisWhenMultipleLanguagesHaveLatestVersion(): void
+    {
+        $translationSetIdentifier = '01965bb2-bcc9-7c6f-8b90-89f7f217d101';
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217d102', $translationSetIdentifier, 'ko', 3);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217d103', $translationSetIdentifier, 'ja', 3);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217d104', $translationSetIdentifier, 'en', 2);
+
+        $payload = $this->process(new ListVersionInconsistentWikisInput())->toArray();
+
+        $this->assertSame(2, $payload['total']);
+        $this->assertEqualsCanonicalizing(['ko', 'ja'], array_column($payload['wikis'], 'language'));
+        $this->assertSame([3, 3], array_column($payload['wikis'], 'version'));
+        $this->assertSame(
+            [$translationSetIdentifier, $translationSetIdentifier],
+            array_column($payload['wikis'], 'translationSetIdentifier'),
+        );
+    }
+
+    private function listVersionInconsistentWikis(): ListVersionInconsistentWikisInterface
+    {
+        return $this->app->make(ListVersionInconsistentWikisInterface::class);
+    }
+
+    private function process(ListVersionInconsistentWikisInput $input): ListVersionInconsistentWikisOutput
+    {
+        $output = new ListVersionInconsistentWikisOutput();
+        $this->listVersionInconsistentWikis()->process($input, $output);
+
+        return $output;
+    }
+
+    private function createWiki(
+        string $wikiId,
+        string $translationSetIdentifier,
+        string $language,
+        int $version,
+    ): void {
+        CreateWiki::create(
+            $wikiId,
+            'talent',
+            [
+                'translation_set_identifier' => $translationSetIdentifier,
+                'slug' => "tl-version-inconsistent-{$language}-{$version}-" . substr($wikiId, -4),
+                'language' => $language,
+                'version' => $version,
+                'published_at' => '2026-04-01 00:00:00',
+            ],
+            [
+                'name' => "Talent {$language} v{$version}",
+                'normalized_name' => "talent {$language} v{$version}",
+            ],
+        );
+
+        DB::table('wikis')
+            ->where('id', $wikiId)
+            ->update([
+                'updated_at' => '2026-05-01 00:00:00',
+                'created_at' => '2026-05-01 00:00:00',
+            ]);
+    }
+}

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -266,6 +266,16 @@ model ListDraftWikisResponse {
 @route("/wikis")
 interface WikiListOperations {
   @get
+  @route("/version-inconsistencies")
+  @doc("List published wikis with version inconsistencies across translation sets.")
+  listVersionInconsistentWikis(
+    @query perPage?: int32,
+    @query resourceType?: string,
+    @query sort?: string,
+    @query order?: string,
+  ): ListWikisResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
   @route("/{language}")
   @doc("List published wikis by language.")
   listWikis(


### PR DESCRIPTION
## 📝 変更内容

- 公開 Wiki のバージョン不整合を `translationSetIdentifier` 単位で一覧取得する `GET /wikis/version-inconsistencies` を追加
- 不整合条件として以下を検出
  - 同一翻訳セット内で `MIN(version) != MAX(version)`
  - 公開対象言語 `ja/ko/en` のいずれかが未公開
- 不整合な翻訳セットごとに、最新 `version` の公開 Wiki をすべて返却
- 既存の Wiki Query パターンに合わせて Action / Request / Input / Output / Interface / Query / DI 登録を追加
- DB Query テストと Input / Output 単体テストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

公開 Wiki は多言語版が `translationSetIdentifier` で紐づいているが、編集・公開タイミングの差により言語間で公開バージョンがずれることがある。

既存の整合性判定は公開 Wiki が 0 件または 1 件の場合を整合ありとして扱うため、他言語の公開 Wiki が存在しない状態も含めて一覧で検出できる専用 API を追加した。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `/wikis/version-inconsistencies` が `/wikis/{language}` より前に定義され、ルート競合を避けられているか
- 不整合抽出条件が Issue 要件どおりになっているか
- 最新 version が複数言語に存在する場合に代表 1 件へ絞らず複数件返す実装になっているか
- 既存 `ListWikis` と同じレスポンス形式・Query 構成に沿っているか

## 📖 関連情報

### 関連Issue・タスク

Closes #387

## ⚠️ 注意事項

DB マイグレーションなし。
TypeSpec / OpenAPI の更新は含めていません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
