### PR TITLE
fix: 翻訳下書きの編集者と公開版数依存を修正

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2164,7 +2164,6 @@ components:
         - slug
         - language
         - resourceType
-        - version
         - themeColor
         - heroImage
         - basic
@@ -2187,10 +2186,6 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
-        version:
-          type: integer
-          format: int32
-          description: Published version number associated with the draft.
         themeColor:
           type: string
           nullable: true
@@ -2520,7 +2515,6 @@ components:
         - slug
         - language
         - resourceType
-        - version
         - themeColor
         - heroImage
         - basic
@@ -2543,10 +2537,6 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
-        version:
-          type: integer
-          format: int32
-          description: Published version number associated with the draft.
         themeColor:
           type: string
           nullable: true
@@ -3416,7 +3406,6 @@ components:
         - slug
         - language
         - resourceType
-        - version
         - themeColor
         - heroImage
         - basic
@@ -3439,10 +3428,6 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
-        version:
-          type: integer
-          format: int32
-          description: Published version number associated with the draft.
         themeColor:
           type: string
           nullable: true
@@ -3773,7 +3758,6 @@ components:
         - slug
         - language
         - resourceType
-        - version
         - themeColor
         - heroImage
         - basic
@@ -3796,10 +3780,6 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
-        version:
-          type: integer
-          format: int32
-          description: Published version number associated with the draft.
         themeColor:
           type: string
           nullable: true

--- a/src/Wiki/Principal/Application/Service/ContributionPointServiceInterface.php
+++ b/src/Wiki/Principal/Application/Service/ContributionPointServiceInterface.php
@@ -13,7 +13,7 @@ interface ContributionPointServiceInterface
     /**
      * Grant contribution points to principals when a wiki is published.
      *
-     * @param PrincipalIdentifier|null $editorIdentifier null for translation articles
+     * @param PrincipalIdentifier|null $editorIdentifier the user who edited or translated
      * @param PrincipalIdentifier $approverIdentifier the user who approved
      * @param PrincipalIdentifier|null $mergerIdentifier the user who merged
      * @param ResourceType $resourceType agency, talent, group, or song

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
@@ -85,7 +85,7 @@ readonly class TranslateWiki implements TranslateWikiInterface
             $translatedData = $this->translationService->translateWiki($wiki, $language);
 
             $wikiDraft = $this->draftWikiFactory->create(
-                editorIdentifier: null,
+                editorIdentifier: $input->principalIdentifier(),
                 language: $language,
                 basic: $translatedData->translatedBasic(),
                 slug: $wiki->slug(),

--- a/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
@@ -11,7 +11,6 @@ readonly class DraftWikiReadModel
     private string $slug;
     private string $language;
     private string $resourceType;
-    private int $version;
     private ?string $themeColor;
     /** @var array<string, mixed> */
     private array $heroImage;
@@ -30,7 +29,6 @@ readonly class DraftWikiReadModel
         string $slug,
         string $language,
         string $resourceType,
-        int $version,
         ?string $themeColor,
         array $heroImage,
         array|WikiBasicReadModel $basic,
@@ -41,7 +39,6 @@ readonly class DraftWikiReadModel
         $this->slug = $slug;
         $this->language = $language;
         $this->resourceType = $resourceType;
-        $this->version = $version;
         $this->themeColor = $themeColor;
         $this->heroImage = $heroImage;
         $this->basic = is_array($basic) ? match ($resourceType) {
@@ -77,11 +74,6 @@ readonly class DraftWikiReadModel
     public function resourceType(): string
     {
         return $this->resourceType;
-    }
-
-    public function version(): int
-    {
-        return $this->version;
     }
 
     public function themeColor(): ?string
@@ -123,7 +115,6 @@ readonly class DraftWikiReadModel
             'slug' => $this->slug,
             'language' => $this->language,
             'resourceType' => $this->resourceType,
-            'version' => $this->version,
             'themeColor' => $this->themeColor,
             'heroImage' => $this->heroImage,
             'basic' => $this->basic->toArray(),

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
@@ -44,7 +44,6 @@ readonly class GetAgencyDraftWiki implements GetAgencyDraftWikiInterface
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::AGENCY->value,
-            version: $model->publishedWiki->version,
             themeColor: $model->theme_color,
             heroImage: [
                 'imageIdentifier' => $model->image_identifier,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
@@ -46,7 +46,6 @@ readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::GROUP->value,
-            version: $model->publishedWiki->version,
             themeColor: $model->theme_color,
             heroImage: [
                 'imageIdentifier' => $model->image_identifier,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
@@ -47,7 +47,6 @@ readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::SONG->value,
-            version: $model->publishedWiki->version,
             themeColor: $model->theme_color,
             heroImage: [
                 'imageIdentifier' => $model->image_identifier,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
@@ -48,7 +48,6 @@ readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
             slug: $model->slug,
             language: $model->language,
             resourceType: ResourceType::TALENT->value,
-            version: $model->publishedWiki->version,
             themeColor: $model->theme_color,
             heroImage: [
                 'imageIdentifier' => $model->image_identifier,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
@@ -149,6 +149,7 @@ class TranslateWikiTest extends TestCase
             $jaTranslatedSections,
             null,
             ApprovalStatus::Pending,
+            $principalIdentifier,
         );
 
         $enDraftWiki = new DraftWiki(
@@ -162,12 +163,13 @@ class TranslateWikiTest extends TestCase
             $enTranslatedSections,
             null,
             ApprovalStatus::Pending,
+            $principalIdentifier,
         );
 
         $draftWikiFactory = Mockery::mock(DraftWikiFactoryInterface::class);
         $draftWikiFactory->shouldReceive('create')
             ->with(
-                Mockery::on(fn ($arg) => $arg === null),
+                $principalIdentifier,
                 Language::JAPANESE,
                 $jaTranslatedBasic,
                 $testData->slug,
@@ -177,7 +179,7 @@ class TranslateWikiTest extends TestCase
             ->andReturn($jaDraftWiki);
         $draftWikiFactory->shouldReceive('create')
             ->with(
-                Mockery::on(fn ($arg) => $arg === null),
+                $principalIdentifier,
                 Language::ENGLISH,
                 $enTranslatedBasic,
                 $testData->slug,
@@ -198,6 +200,8 @@ class TranslateWikiTest extends TestCase
         $result = $output->toArray();
 
         $this->assertCount(2, $result['draftWikis']);
+        $this->assertSame($principalIdentifier, $jaDraftWiki->editorIdentifier());
+        $this->assertSame($principalIdentifier, $enDraftWiki->editorIdentifier());
         $this->assertNull($jaDraftWiki->publishedWikiIdentifier());
         $this->assertSame($enPublishedWikiIdentifier, $enDraftWiki->publishedWikiIdentifier());
     }

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
@@ -18,7 +18,6 @@ class DraftWikiReadModelTest extends TestCase
             slug: 'gr-twice',
             language: 'ko',
             resourceType: 'group',
-            version: 1,
             themeColor: '#FE5F8F',
             heroImage: [
                 'imageIdentifier' => null,
@@ -54,7 +53,6 @@ class DraftWikiReadModelTest extends TestCase
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());
-        $this->assertSame(1, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
         $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
         $this->assertInstanceOf(GroupWikiBasicReadModel::class, $readModel->basic());
@@ -66,7 +64,6 @@ class DraftWikiReadModelTest extends TestCase
             'slug' => 'gr-twice',
             'language' => 'ko',
             'resourceType' => 'group',
-            'version' => 1,
             'themeColor' => '#FE5F8F',
             'heroImage' => [
                 'imageIdentifier' => null,

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWikiTest.php
@@ -93,7 +93,6 @@ class GetAgencyDraftWikiTest extends TestCase
         $this->assertSame('ag-jyp-entertainment', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('agency', $readModel->resourceType());
-        $this->assertSame(3, $readModel->version());
         $this->assertSame('#1A1A1A', $readModel->themeColor());
         $this->assertSame([
             'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f404',

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
@@ -29,7 +29,6 @@ class GetGroupDraftWikiTest extends TestCase
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());
-        $this->assertSame(1, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
         $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
         $this->assertInstanceOf(GroupWikiBasicReadModel::class, $readModel->basic());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
@@ -132,7 +132,6 @@ class GetSongDraftWikiTest extends TestCase
         $this->assertSame('sg-signal', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('song', $readModel->resourceType());
-        $this->assertSame(1, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
         $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
         $this->assertInstanceOf(SongWikiBasicReadModel::class, $readModel->basic());

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
@@ -12,6 +12,7 @@ use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\TalentWikiBasicReadModel;
+use Tests\Helper\CreateDraftWiki;
 use Tests\TestCase;
 
 class GetTalentDraftWikiTest extends TestCase
@@ -29,7 +30,6 @@ class GetTalentDraftWikiTest extends TestCase
         $this->assertSame('tl-chaeyoung', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('talent', $readModel->resourceType());
-        $this->assertSame(1, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
         $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
         $this->assertInstanceOf(TalentWikiBasicReadModel::class, $readModel->basic());
@@ -39,6 +39,37 @@ class GetTalentDraftWikiTest extends TestCase
         $this->assertSame('TWICE', $readModel->basic()['groups'][0]['name']);
         $this->assertSame('girl_group', $readModel->basic()['groups'][0]['groupType']);
         $this->assertSame('overview', $readModel->sections()[0]['id']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsTranslatedDraftTalentWikiWithoutPublishedWiki(): void
+    {
+        CreateDraftWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'talent',
+            [
+                'published_wiki_id' => null,
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f202',
+                'slug' => 'tl-momo',
+                'language' => 'ja',
+                'theme_color' => '#FE5F8F',
+            ],
+            [
+                'name' => 'モモ',
+                'normalized_name' => 'momo',
+                'real_name' => '平井もも',
+                'normalized_real_name' => 'hirai momo',
+            ],
+        );
+
+        $useCase = $this->app->make(GetTalentDraftWikiInterface::class);
+        $readModel = $useCase->process(new GetTalentDraftWikiInput(new Slug('tl-momo'), Language::JAPANESE));
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f201', $readModel->wikiIdentifier());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f202', $readModel->translationSetIdentifier());
+        $this->assertSame('tl-momo', $readModel->slug());
+        $this->assertSame('ja', $readModel->language());
+        $this->assertSame('モモ', $readModel->basic()['name']);
     }
 
     #[Group('useDb')]

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -87,8 +87,6 @@ model DraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
-  @doc("Published version number associated with the draft.")
-  version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")
@@ -205,8 +203,6 @@ model TalentDraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
-  @doc("Published version number associated with the draft.")
-  version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")
@@ -361,8 +357,6 @@ model SongDraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
-  @doc("Published version number associated with the draft.")
-  version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")
@@ -431,8 +425,6 @@ model AgencyDraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
-  @doc("Published version number associated with the draft.")
-  version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")


### PR DESCRIPTION
## 📝 変更内容

- 翻訳Wiki作成時の下書き編集者に、翻訳実行者の `principalIdentifier` を設定するよう修正
- 下書きWiki詳細の ReadModel / Query / TypeSpec / OpenAPI から公開Wiki版数 `version` を削除
- 公開Wikiに紐づかない翻訳下書きでも下書き詳細を取得できるテストを追加
- 関連する既存テストの期待値を更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

翻訳下書きは翻訳実行者が編集者として扱われるべきですが、従来は `editorIdentifier` が `null` で作成されていました。

また、下書き詳細レスポンスが公開Wikiの `version` に依存していたため、公開Wikiに未紐づけの翻訳下書きで詳細取得できない可能性がありました。下書き詳細の責務から公開版数を外し、公開Wiki未紐づけの下書きも扱えるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- 翻訳Wiki作成時に `DraftWikiFactory::create()` へ渡す編集者が翻訳実行者になっていること
- 下書き詳細 ReadModel から `version` を削除しても既存の取得処理に不要な公開Wiki依存が残っていないこと
- TypeSpec / OpenAPI から `version` が削除されていること
- 公開Wiki未紐づけの翻訳下書き取得ケースがテストで担保されていること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

下書きWiki詳細レスポンスから `version` フィールドを削除しています。フロントエンドなど API 利用側で同フィールドを参照している場合は追従が必要です。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
