### PR TITLE
fix: 翻訳Draft公開時のversion追いつき判定を追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/ApproveWiki/ApproveWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/ApproveWiki/ApproveWikiAction.php
@@ -20,6 +20,7 @@ use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\Exception\ExistsApprovedDraftWikiException;
+use Source\Wiki\Wiki\Application\Exception\InconsistentVersionException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWikiInterface;
@@ -92,6 +93,11 @@ readonly class ApproveWikiAction
                 $this->logger->error((string) $e);
 
                 throw new ConflictHttpException(detail: error_message('exists_approved_draft_wiki', $language), previous: $e);
+            } catch (InconsistentVersionException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('inconsistent_version', $language), previous: $e);
             } catch (PrincipalNotFoundException $e) {
                 DB::rollBack();
                 $this->logger->error((string) $e);

--- a/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWiki.php
@@ -16,6 +16,7 @@ use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
 use Source\Wiki\Shared\Domain\ValueObject\HistoryActionType;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\ExistsApprovedDraftWikiException;
+use Source\Wiki\Wiki\Application\Exception\InconsistentVersionException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
@@ -48,6 +49,7 @@ readonly class ApproveWiki implements ApproveWikiInterface
      * @throws DisallowedException
      * @throws DuplicateSlugException
      * @throws PrincipalNotFoundException
+     * @throws InconsistentVersionException
      */
     public function process(ApproveWikiInputPort $input, ApproveWikiOutputPort $output): void
     {
@@ -93,6 +95,10 @@ readonly class ApproveWiki implements ApproveWikiInterface
         // 同じ翻訳セットの別版で、承認済みだが公開されていないDraftWikiが存在するかチェック
         if ($this->wikiService->existsApprovedDraftWiki($wiki->translationSetIdentifier(), $wiki->wikiIdentifier())) {
             throw new ExistsApprovedDraftWikiException();
+        }
+
+        if (! $this->wikiService->canApproveDraftWiki($wiki)) {
+            throw new InconsistentVersionException();
         }
 
         $previousStatus = $wiki->status();

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWiki.php
@@ -88,10 +88,8 @@ readonly class PublishWiki implements PublishWikiInterface
             throw new DisallowedException();
         }
 
-        // 同じ翻訳セットの公開Wikiのバージョンが揃っているかチェック
-        if (! $this->wikiService->hasConsistentVersions(
-            $wiki->translationSetIdentifier(),
-        )) {
+        $publishVersion = $this->wikiService->resolvePublishVersion($wiki);
+        if ($publishVersion === null) {
             throw new InconsistentVersionException();
         }
 
@@ -106,7 +104,7 @@ readonly class PublishWiki implements PublishWikiInterface
             $this->wikiSnapshotRepository->save($snapshot);
 
             $publishedWiki->setBasic($wiki->basic());
-            $publishedWiki->updateVersion();
+            $publishedWiki->setVersion($publishVersion);
         } else {
             $publishedWiki = $this->wikiFactory->create(
                 $wiki->translationSetIdentifier(),
@@ -114,6 +112,7 @@ readonly class PublishWiki implements PublishWikiInterface
                 $wiki->language(),
                 $wiki->resourceType(),
                 $wiki->basic(),
+                $publishVersion,
             );
         }
         $publishedWiki->setSections($wiki->sections());

--- a/src/Wiki/Wiki/Domain/Entity/Wiki.php
+++ b/src/Wiki/Wiki/Domain/Entity/Wiki.php
@@ -107,6 +107,11 @@ class Wiki
         $this->version = Version::nextVersion($this->version);
     }
 
+    public function setVersion(Version $version): void
+    {
+        $this->version = $version;
+    }
+
     public function hasSameVersion(Version $version): bool
     {
         return $this->version->value() === $version->value();

--- a/src/Wiki/Wiki/Domain/Factory/WikiFactoryInterface.php
+++ b/src/Wiki/Wiki/Domain/Factory/WikiFactoryInterface.php
@@ -8,6 +8,7 @@ use Source\Shared\Domain\ValueObject\Language;
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Shared\Domain\ValueObject\Version;
 use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\BasicInterface;
 
@@ -19,5 +20,6 @@ interface WikiFactoryInterface
         Language $language,
         ResourceType $resourceType,
         BasicInterface $basic,
+        ?Version $version = null,
     ): Wiki;
 }

--- a/src/Wiki/Wiki/Domain/Service/WikiService.php
+++ b/src/Wiki/Wiki/Domain/Service/WikiService.php
@@ -6,6 +6,9 @@ namespace Source\Wiki\Wiki\Domain\Service;
 
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\Version;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\Entity\Wiki;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
@@ -55,5 +58,96 @@ readonly class WikiService implements WikiServiceInterface
         }
 
         return false;
+    }
+
+    public function canApproveDraftWiki(DraftWiki $draftWiki): bool
+    {
+        return $this->resolvePublishVersion($draftWiki) !== null;
+    }
+
+    public function resolvePublishVersion(DraftWiki $draftWiki): ?Version
+    {
+        $publishedWikis = $this->wikiRepository->findByTranslationSetIdentifier(
+            $draftWiki->translationSetIdentifier(),
+        );
+
+        if ($publishedWikis === []) {
+            return new Version(1);
+        }
+
+        $latestVersion = $this->latestVersion($publishedWikis);
+        $targetWiki = $this->targetPublishedWiki($publishedWikis, $draftWiki);
+        $isTranslationDraft = $draftWiki->translatedAt() !== null;
+
+        if (! $isTranslationDraft) {
+            if (! $this->hasSameVersions($publishedWikis)) {
+                return null;
+            }
+
+            return $targetWiki ? Version::nextVersion($targetWiki->version()) : $latestVersion;
+        }
+
+        if ($targetWiki === null) {
+            return $latestVersion;
+        }
+
+        if ($targetWiki->isVersionGreaterThan($latestVersion) || $targetWiki->hasSameVersion($latestVersion)) {
+            return null;
+        }
+
+        return $latestVersion;
+    }
+
+    /**
+     * @param Wiki[] $wikis
+     */
+    private function hasSameVersions(array $wikis): bool
+    {
+        if (count($wikis) <= 1) {
+            return true;
+        }
+
+        $firstVersion = $wikis[0]->version();
+
+        return array_all($wikis, fn (Wiki $wiki) => $wiki->hasSameVersion($firstVersion));
+    }
+
+    /**
+     * @param Wiki[] $wikis
+     */
+    private function latestVersion(array $wikis): Version
+    {
+        $latest = $wikis[0]->version();
+
+        foreach ($wikis as $wiki) {
+            if ($wiki->isVersionGreaterThan($latest)) {
+                $latest = $wiki->version();
+            }
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @param Wiki[] $wikis
+     */
+    private function targetPublishedWiki(array $wikis, DraftWiki $draftWiki): ?Wiki
+    {
+        foreach ($wikis as $wiki) {
+            if (
+                $draftWiki->publishedWikiIdentifier() !== null
+                && (string) $wiki->wikiIdentifier() === (string) $draftWiki->publishedWikiIdentifier()
+            ) {
+                return $wiki;
+            }
+        }
+
+        foreach ($wikis as $wiki) {
+            if ($wiki->language() === $draftWiki->language()) {
+                return $wiki;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Wiki/Wiki/Domain/Service/WikiServiceInterface.php
+++ b/src/Wiki/Wiki/Domain/Service/WikiServiceInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Domain\Service;
 
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\Version;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 
 interface WikiServiceInterface
@@ -30,4 +32,8 @@ interface WikiServiceInterface
         TranslationSetIdentifier $translationSetIdentifier,
         DraftWikiIdentifier $excludeWikiIdentifier,
     ): bool;
+
+    public function canApproveDraftWiki(DraftWiki $draftWiki): bool;
+
+    public function resolvePublishVersion(DraftWiki $draftWiki): ?Version;
 }

--- a/src/Wiki/Wiki/Infrastructure/Factory/WikiFactory.php
+++ b/src/Wiki/Wiki/Infrastructure/Factory/WikiFactory.php
@@ -29,6 +29,7 @@ readonly class WikiFactory implements WikiFactoryInterface
         Language $language,
         ResourceType $resourceType,
         BasicInterface $basic,
+        ?Version $version = null,
     ): Wiki {
         return new Wiki(
             new WikiIdentifier($this->generator->generate()),
@@ -39,7 +40,7 @@ readonly class WikiFactory implements WikiFactoryInterface
             $basic,
             new SectionContentCollection([], allowBlocks: false),
             null,
-            new Version(1),
+            $version ?? new Version(1),
         );
     }
 }

--- a/tests/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiTest.php
@@ -23,6 +23,7 @@ use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Shared\Domain\ValueObject\Slug;
 use Source\Wiki\Wiki\Application\Exception\ExistsApprovedDraftWikiException;
+use Source\Wiki\Wiki\Application\Exception\InconsistentVersionException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWikiInput;
@@ -131,6 +132,10 @@ class ApproveWikiTest extends TestCase
             ->once()
             ->with($dummyApproveWiki->translationSetIdentifier, $dummyApproveWiki->wikiIdentifier)
             ->andReturn(false);
+        $wikiService->shouldReceive('canApproveDraftWiki')
+            ->once()
+            ->with($dummyApproveWiki->draftWiki)
+            ->andReturn(true);
 
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
         $wikiHistoryFactory->shouldReceive('create')
@@ -500,6 +505,82 @@ class ApproveWikiTest extends TestCase
         $this->app->instance(WikiHistoryFactoryInterface::class, $wikiHistoryFactory);
 
         $this->expectException(ExistsApprovedDraftWikiException::class);
+        $approveWiki = $this->app->make(ApproveWikiInterface::class);
+        $approveWiki->process($input, new ApproveWikiOutput());
+    }
+
+    /**
+     * 異常系：version整合性上承認できないDraftWikiの場合、例外がスローされること.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws InvalidStatusException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testInconsistentVersions(): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+
+        $dummyApproveWiki = $this->createDummyApproveWiki(
+            operatorIdentifier: $principalIdentifier,
+        );
+
+        $input = new ApproveWikiInput(
+            $dummyApproveWiki->wikiIdentifier,
+            $principalIdentifier,
+            $dummyApproveWiki->resourceType,
+            $dummyApproveWiki->agencyIdentifier,
+            $dummyApproveWiki->groupIdentifiers,
+            $dummyApproveWiki->talentIdentifiers,
+        );
+
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->once()->andReturn(true);
+        $this->app->instance(PolicyEvaluatorInterface::class, $policyEvaluator);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findById')
+            ->with($principalIdentifier)
+            ->once()
+            ->andReturn($principal);
+
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+        $draftWikiRepository->shouldReceive('findById')
+            ->once()
+            ->with($dummyApproveWiki->wikiIdentifier)
+            ->andReturn($dummyApproveWiki->draftWiki);
+        $draftWikiRepository->shouldNotReceive('save');
+
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('existsBySlugExcludingTranslationSetIdentifier')
+            ->once()
+            ->with($dummyApproveWiki->slug, $dummyApproveWiki->translationSetIdentifier)
+            ->andReturn(false);
+
+        $wikiService = Mockery::mock(WikiServiceInterface::class);
+        $wikiService->shouldReceive('existsApprovedDraftWiki')
+            ->once()
+            ->with($dummyApproveWiki->translationSetIdentifier, $dummyApproveWiki->wikiIdentifier)
+            ->andReturn(false);
+        $wikiService->shouldReceive('canApproveDraftWiki')
+            ->once()
+            ->with($dummyApproveWiki->draftWiki)
+            ->andReturn(false);
+
+        $wikiHistoryRepository = Mockery::mock(WikiHistoryRepositoryInterface::class);
+        $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
+
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
+        $this->app->instance(WikiServiceInterface::class, $wikiService);
+        $this->app->instance(WikiHistoryRepositoryInterface::class, $wikiHistoryRepository);
+        $this->app->instance(WikiHistoryFactoryInterface::class, $wikiHistoryFactory);
+
+        $this->expectException(InconsistentVersionException::class);
         $approveWiki = $this->app->make(ApproveWikiInterface::class);
         $approveWiki->process($input, new ApproveWikiOutput());
     }

--- a/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiTest.php
@@ -137,10 +137,10 @@ class PublishWikiTest extends TestCase
             ->andReturn(null);
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(true);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn(Version::nextVersion($dummyPublishWiki->publishedVersion));
 
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
         $wikiHistoryFactory->shouldReceive('create')
@@ -236,10 +236,10 @@ class PublishWikiTest extends TestCase
             ->andReturn(null);
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(true);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn(Version::nextVersion($dummyPublishWiki->publishedVersion));
 
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
         $wikiHistoryFactory->shouldReceive('create')
@@ -350,14 +350,15 @@ class PublishWikiTest extends TestCase
                 $dummyPublishWiki->language,
                 $dummyPublishWiki->resourceType,
                 $dummyPublishWiki->basic,
+                $dummyPublishWiki->version,
             )
             ->andReturn($dummyPublishWiki->createdWiki);
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(true);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn($dummyPublishWiki->version);
 
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
         $wikiHistoryFactory->shouldReceive('create')
@@ -392,6 +393,100 @@ class PublishWikiTest extends TestCase
         $result = $output->toArray();
         $this->assertSame($dummyPublishWiki->language->value, $result['language']);
         $this->assertSame($dummyPublishWiki->version->value(), $result['version']);
+    }
+
+    public function testProcessForNewTranslatedLanguageUsesResolvedLatestVersion(): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+
+        $dummyPublishWiki = $this->createDummyPublishWiki(
+            hasPublishedWiki: false,
+            operatorIdentifier: new PrincipalIdentifier((string) $principalIdentifier),
+            translatedAt: new DateTimeImmutable('2024-01-01 00:00:00'),
+            createdVersion: new Version(2),
+        );
+
+        $input = new PublishWikiInput(
+            $dummyPublishWiki->wikiIdentifier,
+            $principalIdentifier,
+            $dummyPublishWiki->resourceType,
+        );
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findById')
+            ->with($principalIdentifier)
+            ->once()
+            ->andReturn($principal);
+
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('save')
+            ->once()
+            ->with($dummyPublishWiki->createdWiki)
+            ->andReturn(null);
+
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+        $draftWikiRepository->shouldReceive('findById')
+            ->once()
+            ->with($dummyPublishWiki->wikiIdentifier)
+            ->andReturn($dummyPublishWiki->draftWiki);
+        $draftWikiRepository->shouldReceive('delete')
+            ->once()
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn(null);
+
+        $wikiFactory = Mockery::mock(WikiFactoryInterface::class);
+        $wikiFactory->shouldReceive('create')
+            ->once()
+            ->with(
+                $dummyPublishWiki->translationSetIdentifier,
+                $dummyPublishWiki->slug,
+                $dummyPublishWiki->language,
+                $dummyPublishWiki->resourceType,
+                $dummyPublishWiki->basic,
+                $dummyPublishWiki->version,
+            )
+            ->andReturn($dummyPublishWiki->createdWiki);
+
+        $wikiService = Mockery::mock(WikiServiceInterface::class);
+        $wikiService->shouldReceive('resolvePublishVersion')
+            ->once()
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn($dummyPublishWiki->version);
+
+        $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
+        $wikiHistoryFactory->shouldReceive('create')
+            ->once()
+            ->andReturn($dummyPublishWiki->history);
+
+        $wikiHistoryRepository = Mockery::mock(WikiHistoryRepositoryInterface::class);
+        $wikiHistoryRepository->shouldReceive('save')
+            ->once()
+            ->with($dummyPublishWiki->history)
+            ->andReturn(null);
+
+        $wikiSnapshotFactory = Mockery::mock(WikiSnapshotFactoryInterface::class);
+        $wikiSnapshotFactory->shouldNotReceive('create');
+
+        $wikiSnapshotRepository = Mockery::mock(WikiSnapshotRepositoryInterface::class);
+        $wikiSnapshotRepository->shouldNotReceive('save');
+
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
+        $this->app->instance(WikiFactoryInterface::class, $wikiFactory);
+        $this->app->instance(WikiServiceInterface::class, $wikiService);
+        $this->app->instance(WikiHistoryRepositoryInterface::class, $wikiHistoryRepository);
+        $this->app->instance(WikiHistoryFactoryInterface::class, $wikiHistoryFactory);
+        $this->app->instance(WikiSnapshotFactoryInterface::class, $wikiSnapshotFactory);
+        $this->app->instance(WikiSnapshotRepositoryInterface::class, $wikiSnapshotRepository);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+
+        $publishWiki = $this->app->make(PublishWikiInterface::class);
+        $output = new PublishWikiOutput();
+        $publishWiki->process($input, $output);
+        $result = $output->toArray();
+
+        $this->assertSame(2, $result['version']);
     }
 
     /**
@@ -582,10 +677,10 @@ class PublishWikiTest extends TestCase
         $draftWikiRepository->shouldNotReceive('delete');
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(false);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn(null);
 
         $wikiHistoryRepository = Mockery::mock(WikiHistoryRepositoryInterface::class);
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
@@ -644,10 +739,10 @@ class PublishWikiTest extends TestCase
         $draftWikiRepository->shouldNotReceive('delete');
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(true);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn(Version::nextVersion($dummyPublishWiki->publishedVersion));
 
         $wikiHistoryRepository = Mockery::mock(WikiHistoryRepositoryInterface::class);
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
@@ -775,14 +870,15 @@ class PublishWikiTest extends TestCase
                 $dummyPublishWiki->language,
                 $dummyPublishWiki->resourceType,
                 $dummyPublishWiki->basic,
+                $dummyPublishWiki->version,
             )
             ->andReturn($dummyPublishWiki->createdWiki);
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(true);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn($dummyPublishWiki->version);
 
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
         $wikiHistoryFactory->shouldReceive('create')
@@ -870,14 +966,15 @@ class PublishWikiTest extends TestCase
                 $dummyPublishWiki->language,
                 $dummyPublishWiki->resourceType,
                 $dummyPublishWiki->basic,
+                $dummyPublishWiki->version,
             )
             ->andReturn($dummyPublishWiki->createdWiki);
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(true);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn($dummyPublishWiki->version);
 
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
         $wikiHistoryFactory->shouldReceive('create')
@@ -986,10 +1083,10 @@ class PublishWikiTest extends TestCase
             ->andReturn(null);
 
         $wikiService = Mockery::mock(WikiServiceInterface::class);
-        $wikiService->shouldReceive('hasConsistentVersions')
+        $wikiService->shouldReceive('resolvePublishVersion')
             ->once()
-            ->with($dummyPublishWiki->translationSetIdentifier)
-            ->andReturn(true);
+            ->with($dummyPublishWiki->draftWiki)
+            ->andReturn(Version::nextVersion($dummyPublishWiki->publishedVersion));
 
         $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
         $wikiHistoryFactory->shouldReceive('create')
@@ -1063,6 +1160,9 @@ class PublishWikiTest extends TestCase
         ?PrincipalIdentifier $operatorIdentifier = null,
         ?PrincipalIdentifier $approverIdentifier = null,
         ?PrincipalIdentifier $mergerIdentifier = null,
+        ?DateTimeImmutable $translatedAt = null,
+        ?Version $createdVersion = null,
+        ?Version $publishedVersion = null,
     ): PublishWikiTestData {
         $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
         $publishedWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
@@ -1104,6 +1204,7 @@ class PublishWikiTest extends TestCase
             $editorIdentifier,
             $approverIdentifier,
             $mergerIdentifier,
+            translatedAt: $translatedAt,
         );
 
         // 公開済みのWikiエンティティ（既存データを想定）
@@ -1122,7 +1223,7 @@ class PublishWikiTest extends TestCase
             representativeSymbol: new RepresentativeSymbol(''),
         );
         $exSections = new SectionContentCollection();
-        $publishedVersion = new Version(1);
+        $publishedVersion ??= new Version(1);
         $publishedWiki = new Wiki(
             $publishedWikiIdentifier,
             $translationSetIdentifier,
@@ -1136,7 +1237,7 @@ class PublishWikiTest extends TestCase
         );
 
         // 新規作成用のWiki
-        $version = new Version(1);
+        $version = $createdVersion ?? new Version(1);
         $createdWiki = new Wiki(
             $publishedWikiIdentifier,
             $translationSetIdentifier,

--- a/tests/Wiki/Wiki/Domain/Entity/WikiTest.php
+++ b/tests/Wiki/Wiki/Domain/Entity/WikiTest.php
@@ -145,6 +145,25 @@ class WikiTest extends TestCase
     }
 
     /**
+     * 正常系：setVersionが指定したバージョンに更新すること.
+     *
+     * @return void
+     */
+    public function testSetVersion(): void
+    {
+        $data = $this->createDummyWiki();
+        $wiki = $data->wiki;
+
+        $this->assertSame(1, $wiki->version()->value());
+
+        $version = new Version(3);
+        $wiki->setVersion($version);
+
+        $this->assertSame($version, $wiki->version());
+        $this->assertSame(3, $wiki->version()->value());
+    }
+
+    /**
      * 正常系：hasSameVersionが正しく動作すること.
      *
      * @return void

--- a/tests/Wiki/Wiki/Domain/Service/WikiServiceTest.php
+++ b/tests/Wiki/Wiki/Domain/Service/WikiServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Wiki\Wiki\Domain\Service;
 
+use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
 use Source\Shared\Domain\ValueObject\Language;
@@ -407,6 +408,164 @@ class WikiServiceTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testResolvePublishVersionAllowsTranslatedDraftToCatchUpExistingLanguage(): void
+    {
+        $translationSetIdentifier = new TranslationSetIdentifier(StrTestHelper::generateUuid());
+        $koreanWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+        $koreanWiki = $this->createDummyWiki(
+            $translationSetIdentifier,
+            Language::KOREAN,
+            new Version(1),
+            $koreanWikiIdentifier,
+        );
+        $japaneseWiki = $this->createDummyWiki($translationSetIdentifier, Language::JAPANESE, new Version(1));
+        $englishWiki = $this->createDummyWiki($translationSetIdentifier, Language::ENGLISH, new Version(2));
+        $draftWiki = $this->createDummyDraftWiki(
+            $translationSetIdentifier,
+            Language::KOREAN,
+            ApprovalStatus::UnderReview,
+            publishedWikiIdentifier: $koreanWikiIdentifier,
+            translatedAt: new DateTimeImmutable('2024-01-01 00:00:00'),
+        );
+
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('findByTranslationSetIdentifier')
+            ->twice()
+            ->with($translationSetIdentifier)
+            ->andReturn([$koreanWiki, $japaneseWiki, $englishWiki]);
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+
+        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $wikiService = $this->app->make(WikiServiceInterface::class);
+
+        $this->assertTrue($wikiService->canApproveDraftWiki($draftWiki));
+        $this->assertSame(2, $wikiService->resolvePublishVersion($draftWiki)?->value());
+    }
+
+    public function testResolvePublishVersionRejectsNormalDraftWhenVersionsAreInconsistent(): void
+    {
+        $translationSetIdentifier = new TranslationSetIdentifier(StrTestHelper::generateUuid());
+        $koreanWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+        $koreanWiki = $this->createDummyWiki(
+            $translationSetIdentifier,
+            Language::KOREAN,
+            new Version(1),
+            $koreanWikiIdentifier,
+        );
+        $englishWiki = $this->createDummyWiki($translationSetIdentifier, Language::ENGLISH, new Version(2));
+        $draftWiki = $this->createDummyDraftWiki(
+            $translationSetIdentifier,
+            Language::KOREAN,
+            ApprovalStatus::UnderReview,
+            publishedWikiIdentifier: $koreanWikiIdentifier,
+        );
+
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('findByTranslationSetIdentifier')
+            ->once()
+            ->with($translationSetIdentifier)
+            ->andReturn([$koreanWiki, $englishWiki]);
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+
+        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $wikiService = $this->app->make(WikiServiceInterface::class);
+
+        $this->assertNull($wikiService->resolvePublishVersion($draftWiki));
+    }
+
+    public function testResolvePublishVersionRejectsTranslatedDraftForLatestLanguage(): void
+    {
+        $translationSetIdentifier = new TranslationSetIdentifier(StrTestHelper::generateUuid());
+        $englishWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+        $japaneseWiki = $this->createDummyWiki($translationSetIdentifier, Language::JAPANESE, new Version(2));
+        $englishWiki = $this->createDummyWiki(
+            $translationSetIdentifier,
+            Language::ENGLISH,
+            new Version(2),
+            $englishWikiIdentifier,
+        );
+        $draftWiki = $this->createDummyDraftWiki(
+            $translationSetIdentifier,
+            Language::ENGLISH,
+            ApprovalStatus::UnderReview,
+            publishedWikiIdentifier: $englishWikiIdentifier,
+            translatedAt: new DateTimeImmutable('2024-01-01 00:00:00'),
+        );
+
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('findByTranslationSetIdentifier')
+            ->once()
+            ->with($translationSetIdentifier)
+            ->andReturn([$japaneseWiki, $englishWiki]);
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+
+        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $wikiService = $this->app->make(WikiServiceInterface::class);
+
+        $this->assertNull($wikiService->resolvePublishVersion($draftWiki));
+    }
+
+    public function testResolvePublishVersionUsesLatestVersionForNewTranslatedLanguage(): void
+    {
+        $translationSetIdentifier = new TranslationSetIdentifier(StrTestHelper::generateUuid());
+        $japaneseWiki = $this->createDummyWiki($translationSetIdentifier, Language::JAPANESE, new Version(2));
+        $englishWiki = $this->createDummyWiki($translationSetIdentifier, Language::ENGLISH, new Version(2));
+        $draftWiki = $this->createDummyDraftWiki(
+            $translationSetIdentifier,
+            Language::KOREAN,
+            ApprovalStatus::UnderReview,
+            translatedAt: new DateTimeImmutable('2024-01-01 00:00:00'),
+        );
+
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('findByTranslationSetIdentifier')
+            ->once()
+            ->with($translationSetIdentifier)
+            ->andReturn([$japaneseWiki, $englishWiki]);
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+
+        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $wikiService = $this->app->make(WikiServiceInterface::class);
+
+        $this->assertSame(2, $wikiService->resolvePublishVersion($draftWiki)?->value());
+    }
+
+    public function testResolvePublishVersionAllowsNormalDraftWhenVersionsAreConsistent(): void
+    {
+        $translationSetIdentifier = new TranslationSetIdentifier(StrTestHelper::generateUuid());
+        $koreanWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+        $koreanWiki = $this->createDummyWiki(
+            $translationSetIdentifier,
+            Language::KOREAN,
+            new Version(2),
+            $koreanWikiIdentifier,
+        );
+        $englishWiki = $this->createDummyWiki($translationSetIdentifier, Language::ENGLISH, new Version(2));
+        $draftWiki = $this->createDummyDraftWiki(
+            $translationSetIdentifier,
+            Language::KOREAN,
+            ApprovalStatus::UnderReview,
+            publishedWikiIdentifier: $koreanWikiIdentifier,
+        );
+
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('findByTranslationSetIdentifier')
+            ->once()
+            ->with($translationSetIdentifier)
+            ->andReturn([$koreanWiki, $englishWiki]);
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+
+        $this->app->instance(WikiRepositoryInterface::class, $wikiRepository);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $wikiService = $this->app->make(WikiServiceInterface::class);
+
+        $this->assertSame(3, $wikiService->resolvePublishVersion($draftWiki)?->value());
+    }
+
     /**
      * ダミーの公開Wikiを作成するヘルパーメソッド
      *
@@ -419,9 +578,10 @@ class WikiServiceTest extends TestCase
         TranslationSetIdentifier $translationSetIdentifier,
         Language $language,
         Version $version,
+        ?WikiIdentifier $wikiIdentifier = null,
     ): Wiki {
         return new Wiki(
-            new WikiIdentifier(StrTestHelper::generateUuid()),
+            $wikiIdentifier ?? new WikiIdentifier(StrTestHelper::generateUuid()),
             $translationSetIdentifier,
             new Slug('gr-twice'),
             $language,
@@ -460,10 +620,12 @@ class WikiServiceTest extends TestCase
         Language $language,
         ApprovalStatus $status,
         ?DraftWikiIdentifier $wikiIdentifier = null,
+        ?WikiIdentifier $publishedWikiIdentifier = null,
+        ?DateTimeImmutable $translatedAt = null,
     ): DraftWiki {
         return new DraftWiki(
             $wikiIdentifier ?? new DraftWikiIdentifier(StrTestHelper::generateUuid()),
-            null,
+            $publishedWikiIdentifier,
             $translationSetIdentifier,
             new Slug('gr-twice'),
             $language,
@@ -486,6 +648,7 @@ class WikiServiceTest extends TestCase
             new Color('#FF5733'),
             $status,
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            translatedAt: $translatedAt,
         );
     }
 }

--- a/tests/Wiki/Wiki/Infrastructure/Factory/WikiFactoryTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Factory/WikiFactoryTest.php
@@ -10,6 +10,7 @@ use Source\Shared\Domain\ValueObject\Language;
 use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Shared\Domain\ValueObject\Version;
 use Source\Wiki\Wiki\Domain\Factory\WikiFactoryInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
@@ -79,5 +80,40 @@ class WikiFactoryTest extends TestCase
         $this->assertNull($wiki->mergedAt());
         $this->assertNull($wiki->translatedAt());
         $this->assertNull($wiki->approvedAt());
+    }
+
+    /**
+     * 正常系: 指定したバージョンでWiki Entityが作成されること.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
+    public function testCreateWithVersion(): void
+    {
+        $translationSetIdentifier = new TranslationSetIdentifier(StrTestHelper::generateUuid());
+        $slug = new Slug('gr-twice');
+        $language = Language::KOREAN;
+        $resourceType = ResourceType::GROUP;
+        $basic = new GroupBasic(
+            name: new Name('TWICE'),
+            normalizedName: 'twice',
+            agencyIdentifier: null,
+            groupType: null,
+            status: null,
+            generation: null,
+            debutDate: null,
+            disbandDate: null,
+            fandomName: new FandomName('ONCE'),
+            officialColors: [],
+            emoji: new Emoji(''),
+            representativeSymbol: new RepresentativeSymbol(''),
+        );
+        $version = new Version(2);
+
+        $wikiFactory = $this->app->make(WikiFactoryInterface::class);
+        $wiki = $wikiFactory->create($translationSetIdentifier, $slug, $language, $resourceType, $basic, $version);
+
+        $this->assertSame($version, $wiki->version());
+        $this->assertSame(2, $wiki->version()->value());
     }
 }


### PR DESCRIPTION
## 📝 変更内容

翻訳Draftの公開時に、公開済みWikiの最新versionへ追いつくためのversion解決ロジックを追加しました。

- DraftWikiの承認時にversion整合性を確認し、不整合時はConflictを返すように変更
- PublishWikiで公開versionを `WikiService::resolvePublishVersion()` から決定するように変更
- 翻訳Draftの場合、対象言語が最新version未満なら最新versionへ追いつけるように変更
- 通常Draftの場合は翻訳セット内の公開Wiki version が揃っている場合のみ次versionを発行
- 新規公開Wiki作成時に任意のversionを指定できるようFactoryを拡張
- version解決、承認、公開、Factory、Entityのテストを追加・更新

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

翻訳Draftを公開する際、翻訳セット内で公開済みWikiのversionが一致していないと公開できず、古いversionの翻訳Draftを最新versionへ追いつかせることができませんでした。

翻訳Draftと通常Draftでversion決定ルールを分け、翻訳Draftは最新versionへの追いつきを許可しつつ、通常Draftは従来どおり不整合状態での公開を防ぐようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `WikiService::resolvePublishVersion()` のversion決定条件が、翻訳Draftと通常Draftの業務ルールに合っているか
- 翻訳Draftで既存言語・新規言語を公開する場合のversionが期待どおりか
- 承認時点でversion不整合をConflictとして扱うことが適切か
- `WikiFactory::create()` に任意versionを渡す変更の影響範囲が問題ないか

## 📖 関連情報

### 関連Issue・タスク

Closes #394

## ⚠️ 注意事項

マイグレーションや破壊的変更はありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した