### PR TITLE
add: Wiki関連プロフィール取得APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/ListRelatedProfiles/ListRelatedProfilesAction.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListRelatedProfiles/ListRelatedProfilesAction.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListRelatedProfiles;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class ListRelatedProfilesAction
+{
+    public function __construct(
+        private ListRelatedProfilesInterface $listRelatedProfiles,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ListRelatedProfilesRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ListRelatedProfilesInput(
+                    slug: new Slug($request->slug()),
+                    language: Language::from($request->language()),
+                    resourceType: ResourceType::from($request->resourceType()),
+                );
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $output = new ListRelatedProfilesOutput();
+                $this->listRelatedProfiles->process($input, $output);
+            } catch (WikiNotFoundException $e) {
+                throw new NotFoundHttpException(detail: 'Wiki not found.', previous: $e);
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+        } catch (NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Query/ListRelatedProfiles/ListRelatedProfilesRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListRelatedProfiles/ListRelatedProfilesRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Query\ListRelatedProfiles;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+
+class ListRelatedProfilesRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validationData(): array
+    {
+        return [
+            ...parent::validationData(),
+            'language' => $this->route('language'),
+            'slug' => $this->route('slug'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', 'string', 'in:ja,ko,en'],
+            'slug' => ['required', 'string'],
+            'resourceType' => ['required', 'string', Rule::in([
+                ResourceType::AGENCY->value,
+                ResourceType::GROUP->value,
+                ResourceType::TALENT->value,
+                ResourceType::SONG->value,
+            ])],
+        ];
+    }
+
+    public function language(): string
+    {
+        return (string) $this->route('language');
+    }
+
+    public function slug(): string
+    {
+        return (string) $this->route('slug');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->query('resourceType');
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -88,6 +88,7 @@ use Source\Wiki\Wiki\Application\UseCase\Query\GetSongWiki\GetSongWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentDraftWiki\GetTalentDraftWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetTalentWiki\GetTalentWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListDraftWikis\ListDraftWikisInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\ListWikis\ListWikisInterface;
 use Source\Wiki\Wiki\Infrastructure\Query\GetAgencyDraftWiki;
@@ -99,6 +100,7 @@ use Source\Wiki\Wiki\Infrastructure\Query\GetSongWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentDraftWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\GetTalentWiki;
 use Source\Wiki\Wiki\Infrastructure\Query\ListDraftWikis;
+use Source\Wiki\Wiki\Infrastructure\Query\ListRelatedProfiles;
 use Source\Wiki\Wiki\Infrastructure\Query\ListVersionInconsistentWikis;
 use Source\Wiki\Wiki\Infrastructure\Query\ListWikis;
 
@@ -152,6 +154,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(GetTalentDraftWikiInterface::class, GetTalentDraftWiki::class);
         $this->app->singleton(GetTalentWikiInterface::class, GetTalentWiki::class);
         $this->app->singleton(ListDraftWikisInterface::class, ListDraftWikis::class);
+        $this->app->singleton(ListRelatedProfilesInterface::class, ListRelatedProfiles::class);
         $this->app->singleton(ListVersionInconsistentWikisInterface::class, ListVersionInconsistentWikis::class);
         $this->app->singleton(ListWikisInterface::class, ListWikis::class);
     }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1572,6 +1572,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /wiki/{language}/{slug}/related-profiles:
+    get:
+      operationId: WikiOperations_listRelatedProfiles
+      description: List related published wiki profiles for a source wiki.
+      parameters:
+        - name: language
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: resourceType
+          in: query
+          required: true
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: Response returned when related profile retrieval succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListRelatedProfilesResponseBody'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /wiki/{wikiId}/approve:
     post:
       operationId: WikiOperations_approveWiki
@@ -2951,6 +2997,17 @@ components:
           format: int32
           description: Number of wikis per page.
       description: Response body for the draft wiki list endpoint.
+    ListRelatedProfilesResponseBody:
+      type: object
+      required:
+        - profiles
+      properties:
+        profiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/RelatedProfileItem'
+          description: Related profile cards.
+      description: Response body for the related profiles endpoint.
     ListUploadedImagesResponseBody:
       type: object
       required:
@@ -3206,6 +3263,53 @@ components:
           format: int32
           description: Published version number.
       description: Summary of a published wiki.
+    RelatedProfileItem:
+      type: object
+      required:
+        - wikiIdentifier
+        - slug
+        - language
+        - resourceType
+        - name
+        - normalizedName
+        - imageIdentifier
+        - imageUrl
+        - imageAltText
+      properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Wiki identifier.
+        slug:
+          type: string
+          description: Unique slug for the wiki.
+        language:
+          type: string
+          description: Language of the wiki.
+        resourceType:
+          type: string
+          description: Resource type that the wiki belongs to.
+        name:
+          type: string
+          description: Display name of the wiki.
+        normalizedName:
+          type: string
+          description: Normalized name used for search.
+        imageIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
+          description: Representative image identifier for the wiki.
+        imageUrl:
+          type: string
+          nullable: true
+          description: Absolute URL of the representative image.
+        imageAltText:
+          type: string
+          nullable: true
+          description: Alternative text of the representative image.
+      description: Related profile card item returned by the related profiles endpoint.
     RequestCertificationRequestBody:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -44,6 +44,7 @@ use Application\Http\Action\Wiki\Wiki\Query\GetSongWiki\GetSongWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentDraftWiki\GetTalentDraftWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetTalentWiki\GetTalentWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\ListDraftWikis\ListDraftWikisAction;
+use Application\Http\Action\Wiki\Wiki\Query\ListRelatedProfiles\ListRelatedProfilesAction;
 use Application\Http\Action\Wiki\Wiki\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisAction;
 use Application\Http\Action\Wiki\Wiki\Query\ListWikis\ListWikisAction;
 use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
@@ -68,6 +69,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
 Route::get('/wikis/version-inconsistencies', ListVersionInconsistentWikisAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::get('/wikis/{language}', ListWikisAction::class);
 Route::get('/draft-wikis', ListDraftWikisAction::class)->middleware(['auth.api', 'resolve.actor']);
+Route::get('/wiki/{language}/{slug}/related-profiles', ListRelatedProfilesAction::class);
 Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);
 Route::get('/wiki/{language}/agency/{slug}/draft', GetAgencyDraftWikiAction::class);
 Route::get('/wiki/{language}/group/{slug}', GetGroupWikiAction::class);

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles;
+
+use InvalidArgumentException;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+readonly class ListRelatedProfilesInput implements ListRelatedProfilesInputPort
+{
+    public function __construct(
+        private Slug $slug,
+        private Language $language,
+        private ResourceType $resourceType,
+    ) {
+        if ($resourceType === ResourceType::IMAGE) {
+            throw new InvalidArgumentException('Unsupported related profile resource type.');
+        }
+    }
+
+    public function slug(): Slug
+    {
+        return $this->slug;
+    }
+
+    public function language(): Language
+    {
+        return $this->language;
+    }
+
+    public function resourceType(): ResourceType
+    {
+        return $this->resourceType;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInputPort.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+
+interface ListRelatedProfilesInputPort
+{
+    public function slug(): Slug;
+
+    public function language(): Language;
+
+    public function resourceType(): ResourceType;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles;
+
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+
+interface ListRelatedProfilesInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(ListRelatedProfilesInputPort $input, ListRelatedProfilesOutputPort $output): void;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesOutput.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\RelatedProfileReadModel;
+
+class ListRelatedProfilesOutput implements ListRelatedProfilesOutputPort
+{
+    /** @var list<RelatedProfileReadModel> */
+    private array $profiles = [];
+
+    /**
+     * @param list<RelatedProfileReadModel> $profiles
+     */
+    public function output(array $profiles): void
+    {
+        $this->profiles = $profiles;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'profiles' => array_map(static fn (RelatedProfileReadModel $profile): array => $profile->toArray(), $this->profiles),
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesOutputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\RelatedProfileReadModel;
+
+interface ListRelatedProfilesOutputPort
+{
+    /**
+     * @param list<RelatedProfileReadModel> $profiles
+     */
+    public function output(array $profiles): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Query/RelatedProfileReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/RelatedProfileReadModel.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Query;
+
+readonly class RelatedProfileReadModel
+{
+    public function __construct(
+        private string $wikiIdentifier,
+        private string $slug,
+        private string $language,
+        private string $resourceType,
+        private string $name,
+        private string $normalizedName,
+        private ?string $imageIdentifier,
+        private ?string $imageUrl,
+        private ?string $imageAltText,
+    ) {
+    }
+
+    public function wikiIdentifier(): string
+    {
+        return $this->wikiIdentifier;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'wikiIdentifier' => $this->wikiIdentifier,
+            'slug' => $this->slug,
+            'language' => $this->language,
+            'resourceType' => $this->resourceType,
+            'name' => $this->name,
+            'normalizedName' => $this->normalizedName,
+            'imageIdentifier' => $this->imageIdentifier,
+            'imageUrl' => $this->imageUrl,
+            'imageAltText' => $this->imageAltText,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Query/ListRelatedProfiles.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListRelatedProfiles.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+use Source\Shared\Infrastructure\Support\ImageUrl;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesOutputPort;
+use Source\Wiki\Wiki\Application\UseCase\Query\RelatedProfileReadModel;
+
+readonly class ListRelatedProfiles implements ListRelatedProfilesInterface
+{
+    /** @var array<string, array{relation: string, table: string}> */
+    private const BASIC_TABLES = [
+        ResourceType::AGENCY->value => ['relation' => 'agencyBasic', 'table' => 'wiki_agency_basics'],
+        ResourceType::GROUP->value => ['relation' => 'groupBasic', 'table' => 'wiki_group_basics'],
+        ResourceType::TALENT->value => ['relation' => 'talentBasic', 'table' => 'wiki_talent_basics'],
+        ResourceType::SONG->value => ['relation' => 'songBasic', 'table' => 'wiki_song_basics'],
+    ];
+
+    /**
+     * @throws WikiNotFoundException
+     */
+    public function process(ListRelatedProfilesInputPort $input, ListRelatedProfilesOutputPort $output): void
+    {
+        $source = WikiModel::query()
+            ->with(['agencyBasic', 'groupBasic', 'talentBasic', 'songBasic'])
+            ->where('language', $input->language()->value)
+            ->where('slug', (string) $input->slug())
+            ->whereIn('resource_type', array_keys(self::BASIC_TABLES))
+            ->first();
+
+        if ($source === null) {
+            throw new WikiNotFoundException("Wiki not found for slug: {$input->slug()} and language: {$input->language()->value}");
+        }
+
+        if ($source->resource_type === $input->resourceType()->value) {
+            throw new InvalidArgumentException('Source wiki and related profile resource type must be different.');
+        }
+
+        $targetBasic = self::BASIC_TABLES[$input->resourceType()->value] ?? null;
+        if ($targetBasic === null) {
+            throw new InvalidArgumentException('Unsupported related profile resource type.');
+        }
+
+        $query = WikiModel::query()
+            ->select(
+                'wikis.*',
+                'wiki_images.image_path as image_path',
+                'wiki_images.alt_text as image_alt_text',
+                "{$targetBasic['table']}.name as profile_name",
+                "{$targetBasic['table']}.normalized_name as profile_normalized_name",
+            )
+            ->join($targetBasic['table'], "{$targetBasic['table']}.wiki_id", '=', 'wikis.id')
+            ->leftJoin('wiki_images', 'wiki_images.id', '=', 'wikis.image_identifier')
+            ->where('wikis.language', $source->language)
+            ->where('wikis.resource_type', $input->resourceType()->value);
+
+        if (! $this->applyRelatedCondition($query, $source, $input->resourceType())) {
+            $output->output([]);
+
+            return;
+        }
+
+        $profiles = $query
+            ->orderBy("{$targetBasic['table']}.normalized_name")
+            ->orderBy('wikis.id')
+            ->get()
+            ->map(fn (WikiModel $wiki): RelatedProfileReadModel => $this->toReadModel($wiki))
+            ->values()
+            ->all();
+
+        $output->output($profiles);
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyRelatedCondition(Builder $query, WikiModel $source, ResourceType $targetType): bool
+    {
+        return match ($source->resource_type) {
+            ResourceType::AGENCY->value => $this->applyFromAgency($query, $source, $targetType),
+            ResourceType::GROUP->value => $this->applyFromGroup($query, $source, $targetType),
+            ResourceType::TALENT->value => $this->applyFromTalent($query, $source, $targetType),
+            ResourceType::SONG->value => $this->applyFromSong($query, $source, $targetType),
+            default => false,
+        };
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyFromAgency(Builder $query, WikiModel $source, ResourceType $targetType): bool
+    {
+        $agencyIdentifierColumn = match ($targetType) {
+            ResourceType::GROUP => 'wiki_group_basics.agency_identifier',
+            ResourceType::TALENT => 'wiki_talent_basics.agency_identifier',
+            ResourceType::SONG => 'wiki_song_basics.agency_identifier',
+            default => null,
+        };
+
+        if ($agencyIdentifierColumn === null) {
+            return false;
+        }
+
+        $query->where($agencyIdentifierColumn, $source->id);
+
+        return true;
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyFromGroup(Builder $query, WikiModel $source, ResourceType $targetType): bool
+    {
+        return match ($targetType) {
+            ResourceType::AGENCY => $this->applyAgencyIdentifierCondition($query, $this->agencyIdentifier($source)),
+            ResourceType::TALENT => $this->applyPivotCondition($query, 'wiki_talent_basic_groups', 'wiki_id', 'group_identifier', $source->id),
+            ResourceType::SONG => $this->applyPivotCondition($query, 'wiki_song_basic_groups', 'wiki_id', 'group_identifier', $source->id),
+            default => false,
+        };
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyFromTalent(Builder $query, WikiModel $source, ResourceType $targetType): bool
+    {
+        return match ($targetType) {
+            ResourceType::AGENCY => $this->applyAgencyIdentifierCondition($query, $this->agencyIdentifier($source)),
+            ResourceType::GROUP => $this->applyPivotCondition($query, 'wiki_talent_basic_groups', 'group_identifier', 'wiki_id', $source->id),
+            ResourceType::SONG => $this->applyPivotCondition($query, 'wiki_song_basic_talents', 'wiki_id', 'talent_identifier', $source->id),
+            default => false,
+        };
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyFromSong(Builder $query, WikiModel $source, ResourceType $targetType): bool
+    {
+        return match ($targetType) {
+            ResourceType::AGENCY => $this->applyAgencyIdentifierCondition($query, $this->agencyIdentifier($source)),
+            ResourceType::GROUP => $this->applyPivotCondition($query, 'wiki_song_basic_groups', 'group_identifier', 'wiki_id', $source->id),
+            ResourceType::TALENT => $this->applyPivotCondition($query, 'wiki_song_basic_talents', 'talent_identifier', 'wiki_id', $source->id),
+            default => false,
+        };
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyAgencyIdentifierCondition(Builder $query, ?string $agencyIdentifier): bool
+    {
+        if ($agencyIdentifier === null) {
+            return false;
+        }
+
+        $query->where('wikis.id', $agencyIdentifier);
+
+        return true;
+    }
+
+    /**
+     * @param Builder<WikiModel> $query
+     */
+    private function applyPivotCondition(
+        Builder $query,
+        string $table,
+        string $targetColumn,
+        string $sourceColumn,
+        string $sourceIdentifier,
+    ): bool {
+        $query->whereExists(function (\Illuminate\Database\Query\Builder $subQuery) use ($table, $targetColumn, $sourceColumn, $sourceIdentifier): void {
+            $subQuery->selectRaw('1')
+                ->from($table)
+                ->whereColumn("{$table}.{$targetColumn}", 'wikis.id')
+                ->where("{$table}.{$sourceColumn}", $sourceIdentifier);
+        });
+
+        return true;
+    }
+
+    private function agencyIdentifier(WikiModel $wiki): ?string
+    {
+        $basic = $this->sourceBasicModel($wiki);
+
+        $agencyIdentifier = $basic->getAttribute('agency_identifier');
+
+        return $agencyIdentifier === null ? null : (string) $agencyIdentifier;
+    }
+
+    private function sourceBasicModel(WikiModel $wiki): Model
+    {
+        $relation = self::BASIC_TABLES[$wiki->resource_type]['relation'] ?? null;
+        if ($relation === null) {
+            throw new InvalidArgumentException("Unsupported wiki resource type: {$wiki->resource_type}");
+        }
+
+        $basic = $wiki->{$relation};
+        if (! $basic instanceof Model) {
+            throw new InvalidArgumentException("Basic not found for Wiki: {$wiki->id}");
+        }
+
+        return $basic;
+    }
+
+    private function toReadModel(WikiModel $wiki): RelatedProfileReadModel
+    {
+        return new RelatedProfileReadModel(
+            wikiIdentifier: $wiki->id,
+            slug: $wiki->slug,
+            language: $wiki->language,
+            resourceType: $wiki->resource_type,
+            name: (string) $wiki->getAttribute('profile_name'),
+            normalizedName: (string) $wiki->getAttribute('profile_normalized_name'),
+            imageIdentifier: $wiki->image_identifier,
+            imageUrl: ImageUrl::fromPath($wiki->getAttribute('image_path')),
+            imageAltText: $wiki->getAttribute('image_alt_text'),
+        );
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesInputTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles;
+
+use InvalidArgumentException;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInput;
+use Tests\TestCase;
+
+class ListRelatedProfilesInputTest extends TestCase
+{
+    public function testPropertiesReturnConstructorValues(): void
+    {
+        $slug = new Slug('gr-twice');
+        $input = new ListRelatedProfilesInput($slug, Language::KOREAN, ResourceType::TALENT);
+
+        $this->assertSame($slug, $input->slug());
+        $this->assertSame(Language::KOREAN, $input->language());
+        $this->assertSame(ResourceType::TALENT, $input->resourceType());
+    }
+
+    public function testThrowsExceptionWhenResourceTypeIsImage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ListRelatedProfilesInput(new Slug('gr-twice'), Language::KOREAN, ResourceType::IMAGE);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/ListRelatedProfiles/ListRelatedProfilesOutputTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesOutput;
+use Source\Wiki\Wiki\Application\UseCase\Query\RelatedProfileReadModel;
+use Tests\TestCase;
+
+class ListRelatedProfilesOutputTest extends TestCase
+{
+    public function testToArrayReturnsProfiles(): void
+    {
+        $output = new ListRelatedProfilesOutput();
+        $output->output([
+            new RelatedProfileReadModel(
+                wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f001',
+                slug: 'tl-momo',
+                language: 'ko',
+                resourceType: 'talent',
+                name: 'Momo',
+                normalizedName: 'momo',
+                imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+                imageUrl: 'http://127.0.0.1:8080/images/test/momo.jpg',
+                imageAltText: 'Momo profile',
+            ),
+        ]);
+
+        $this->assertSame([
+            'profiles' => [
+                [
+                    'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f001',
+                    'slug' => 'tl-momo',
+                    'language' => 'ko',
+                    'resourceType' => 'talent',
+                    'name' => 'Momo',
+                    'normalizedName' => 'momo',
+                    'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+                    'imageUrl' => 'http://127.0.0.1:8080/images/test/momo.jpg',
+                    'imageAltText' => 'Momo profile',
+                ],
+            ],
+        ], $output->toArray());
+    }
+
+    public function testToArrayReturnsEmptyProfilesByDefault(): void
+    {
+        $output = new ListRelatedProfilesOutput();
+
+        $this->assertSame(['profiles' => []], $output->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Query/RelatedProfileReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/RelatedProfileReadModelTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Query;
+
+use Source\Wiki\Wiki\Application\UseCase\Query\RelatedProfileReadModel;
+use Tests\TestCase;
+
+class RelatedProfileReadModelTest extends TestCase
+{
+    public function testToArrayReturnsRelatedProfilePayload(): void
+    {
+        $readModel = new RelatedProfileReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f001',
+            slug: 'tl-momo',
+            language: 'ko',
+            resourceType: 'talent',
+            name: 'Momo',
+            normalizedName: 'momo',
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            imageUrl: 'http://127.0.0.1:8080/images/test/momo.jpg',
+            imageAltText: 'Momo profile',
+        );
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f001', $readModel->wikiIdentifier());
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f001',
+            'slug' => 'tl-momo',
+            'language' => 'ko',
+            'resourceType' => 'talent',
+            'name' => 'Momo',
+            'normalizedName' => 'momo',
+            'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f002',
+            'imageUrl' => 'http://127.0.0.1:8080/images/test/momo.jpg',
+            'imageAltText' => 'Momo profile',
+        ], $readModel->toArray());
+    }
+
+    public function testToArrayAllowsNullableImageFields(): void
+    {
+        $readModel = new RelatedProfileReadModel(
+            wikiIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f003',
+            slug: 'gr-twice',
+            language: 'ko',
+            resourceType: 'group',
+            name: 'TWICE',
+            normalizedName: 'twice',
+            imageIdentifier: null,
+            imageUrl: null,
+            imageAltText: null,
+        );
+
+        $this->assertSame([
+            'wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f003',
+            'slug' => 'gr-twice',
+            'language' => 'ko',
+            'resourceType' => 'group',
+            'name' => 'TWICE',
+            'normalizedName' => 'twice',
+            'imageIdentifier' => null,
+            'imageUrl' => null,
+            'imageAltText' => null,
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListRelatedProfilesTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListRelatedProfilesTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInput;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesInterface;
+use Source\Wiki\Wiki\Application\UseCase\Query\ListRelatedProfiles\ListRelatedProfilesOutput;
+use Tests\Helper\CreateImage;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class ListRelatedProfilesTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsTalentsRelatedToGroup(): void
+    {
+        $this->createGroup('01965bb2-bcc9-7c6f-8b90-89f7f217f101', 'gr-twice', 'TWICE', 'twice');
+        $this->createTalent('01965bb2-bcc9-7c6f-8b90-89f7f217f102', 'tl-momo', 'Momo', 'momo', [
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+        ]);
+        $this->createTalent('01965bb2-bcc9-7c6f-8b90-89f7f217f103', 'tl-sana', 'Sana', 'sana', [
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+        ]);
+        $this->createTalent('01965bb2-bcc9-7c6f-8b90-89f7f217f104', 'tl-unrelated', 'Unrelated', 'unrelated', []);
+
+        $payload = $this->process(new ListRelatedProfilesInput(
+            new Slug('gr-twice'),
+            Language::KOREAN,
+            ResourceType::TALENT,
+        ))->toArray();
+
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f102',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f103',
+        ], array_column($payload['profiles'], 'wikiIdentifier'));
+        $this->assertSame('tl-momo', $payload['profiles'][0]['slug']);
+        $this->assertSame('ko', $payload['profiles'][0]['language']);
+        $this->assertSame('talent', $payload['profiles'][0]['resourceType']);
+        $this->assertSame('Momo', $payload['profiles'][0]['name']);
+        $this->assertSame('momo', $payload['profiles'][0]['normalizedName']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsGroupsRelatedToTalent(): void
+    {
+        $this->createGroup('01965bb2-bcc9-7c6f-8b90-89f7f217f201', 'gr-twice', 'TWICE', 'twice');
+        $this->createGroup('01965bb2-bcc9-7c6f-8b90-89f7f217f202', 'gr-misamo', 'MISAMO', 'misamo');
+        $this->createTalent('01965bb2-bcc9-7c6f-8b90-89f7f217f203', 'tl-momo', 'Momo', 'momo', [
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f202',
+        ]);
+
+        $payload = $this->process(new ListRelatedProfilesInput(
+            new Slug('tl-momo'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+        ))->toArray();
+
+        $this->assertSame(['gr-misamo', 'gr-twice'], array_column($payload['profiles'], 'slug'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsSongsRelatedToTalent(): void
+    {
+        $this->createTalent('01965bb2-bcc9-7c6f-8b90-89f7f217f301', 'tl-nayeon', 'Nayeon', 'nayeon', []);
+        $this->createSong('01965bb2-bcc9-7c6f-8b90-89f7f217f302', 'sg-pop', 'POP!', 'pop', [], [
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f301',
+        ]);
+        $this->createSong('01965bb2-bcc9-7c6f-8b90-89f7f217f303', 'sg-unrelated', 'Unrelated', 'unrelated', [], []);
+
+        $payload = $this->process(new ListRelatedProfilesInput(
+            new Slug('tl-nayeon'),
+            Language::KOREAN,
+            ResourceType::SONG,
+        ))->toArray();
+
+        $this->assertSame(['sg-pop'], array_column($payload['profiles'], 'slug'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsAgencyRelatedToGroup(): void
+    {
+        $this->createAgency('01965bb2-bcc9-7c6f-8b90-89f7f217f401', 'ag-jyp', 'JYP Entertainment', 'jyp entertainment');
+        $this->createGroup(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f402',
+            'gr-twice',
+            'TWICE',
+            'twice',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f401',
+        );
+
+        $payload = $this->process(new ListRelatedProfilesInput(
+            new Slug('gr-twice'),
+            Language::KOREAN,
+            ResourceType::AGENCY,
+        ))->toArray();
+
+        $this->assertSame(['ag-jyp'], array_column($payload['profiles'], 'slug'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsGroupsRelatedToAgency(): void
+    {
+        $this->createAgency('01965bb2-bcc9-7c6f-8b90-89f7f217f501', 'ag-jyp', 'JYP Entertainment', 'jyp entertainment');
+        $this->createGroup(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
+            'gr-twice',
+            'TWICE',
+            'twice',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f501',
+        );
+        $this->createGroup('01965bb2-bcc9-7c6f-8b90-89f7f217f503', 'gr-unrelated', 'Unrelated', 'unrelated');
+
+        $payload = $this->process(new ListRelatedProfilesInput(
+            new Slug('ag-jyp'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+        ))->toArray();
+
+        $this->assertSame(['gr-twice'], array_column($payload['profiles'], 'slug'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsImageFields(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f601', [
+            'image_path' => '/images/test/momo.jpg',
+            'alt_text' => 'Momo profile image',
+        ]);
+        $this->createGroup('01965bb2-bcc9-7c6f-8b90-89f7f217f602', 'gr-twice', 'TWICE', 'twice');
+        $this->createTalent('01965bb2-bcc9-7c6f-8b90-89f7f217f603', 'tl-momo', 'Momo', 'momo', [
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f602',
+        ], imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f601');
+
+        $payload = $this->process(new ListRelatedProfilesInput(
+            new Slug('gr-twice'),
+            Language::KOREAN,
+            ResourceType::TALENT,
+        ))->toArray();
+
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f601', $payload['profiles'][0]['imageIdentifier']);
+        $this->assertSame('http://127.0.0.1:8080/images/test/momo.jpg', $payload['profiles'][0]['imageUrl']);
+        $this->assertSame('Momo profile image', $payload['profiles'][0]['imageAltText']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsEmptyWhenNoRelationExists(): void
+    {
+        $this->createGroup('01965bb2-bcc9-7c6f-8b90-89f7f217f701', 'gr-twice', 'TWICE', 'twice');
+
+        $payload = $this->process(new ListRelatedProfilesInput(
+            new Slug('gr-twice'),
+            Language::KOREAN,
+            ResourceType::SONG,
+        ))->toArray();
+
+        $this->assertSame([], $payload['profiles']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsWikiNotFoundExceptionWhenSourceWikiDoesNotExist(): void
+    {
+        $this->expectException(WikiNotFoundException::class);
+
+        $this->process(new ListRelatedProfilesInput(
+            new Slug('gr-missing'),
+            Language::KOREAN,
+            ResourceType::TALENT,
+        ));
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsInvalidArgumentExceptionWhenTargetTypeEqualsSourceType(): void
+    {
+        $this->createGroup('01965bb2-bcc9-7c6f-8b90-89f7f217f801', 'gr-twice', 'TWICE', 'twice');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->process(new ListRelatedProfilesInput(
+            new Slug('gr-twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+        ));
+    }
+
+    private function process(ListRelatedProfilesInput $input): ListRelatedProfilesOutput
+    {
+        $output = new ListRelatedProfilesOutput();
+        $this->app->make(ListRelatedProfilesInterface::class)->process($input, $output);
+
+        return $output;
+    }
+
+    private function createAgency(string $wikiId, string $slug, string $name, string $normalizedName): void
+    {
+        CreateWiki::create($wikiId, 'agency', [
+            'slug' => $slug,
+            'language' => 'ko',
+            'published_at' => '2026-04-01 00:00:00',
+        ], [
+            'name' => $name,
+            'normalized_name' => $normalizedName,
+        ]);
+    }
+
+    private function createGroup(
+        string $wikiId,
+        string $slug,
+        string $name,
+        string $normalizedName,
+        ?string $agencyIdentifier = null,
+    ): void {
+        CreateWiki::create($wikiId, 'group', [
+            'slug' => $slug,
+            'language' => 'ko',
+            'published_at' => '2026-04-01 00:00:00',
+        ], [
+            'name' => $name,
+            'normalized_name' => $normalizedName,
+            'agency_identifier' => $agencyIdentifier,
+        ]);
+    }
+
+    /**
+     * @param list<string> $groupIdentifiers
+     */
+    private function createTalent(
+        string $wikiId,
+        string $slug,
+        string $name,
+        string $normalizedName,
+        array $groupIdentifiers,
+        ?string $agencyIdentifier = null,
+        ?string $imageIdentifier = null,
+    ): void {
+        CreateWiki::create($wikiId, 'talent', [
+            'slug' => $slug,
+            'language' => 'ko',
+            'image_identifier' => $imageIdentifier,
+            'published_at' => '2026-04-01 00:00:00',
+        ], [
+            'name' => $name,
+            'normalized_name' => $normalizedName,
+            'agency_identifier' => $agencyIdentifier,
+            'group_identifiers' => json_encode($groupIdentifiers),
+        ]);
+    }
+
+    /**
+     * @param list<string> $groupIdentifiers
+     * @param list<string> $talentIdentifiers
+     */
+    private function createSong(
+        string $wikiId,
+        string $slug,
+        string $name,
+        string $normalizedName,
+        array $groupIdentifiers,
+        array $talentIdentifiers,
+        ?string $agencyIdentifier = null,
+    ): void {
+        CreateWiki::create($wikiId, 'song', [
+            'slug' => $slug,
+            'language' => 'ko',
+            'published_at' => '2026-04-01 00:00:00',
+        ], [
+            'name' => $name,
+            'normalized_name' => $normalizedName,
+            'agency_identifier' => $agencyIdentifier,
+            'group_identifiers' => json_encode($groupIdentifiers),
+            'talent_identifiers' => json_encode($talentIdentifiers),
+        ]);
+
+        DB::table('wikis')->where('id', $wikiId)->update(['updated_at' => '2026-05-01 00:00:00']);
+    }
+}

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -177,6 +177,28 @@ model WikiListItem {
   updatedAt: string | null;
 }
 
+@doc("Related profile card item returned by the related profiles endpoint.")
+model RelatedProfileItem {
+  @doc("Wiki identifier.")
+  wikiIdentifier: Uuid;
+  @doc("Unique slug for the wiki.")
+  slug: string;
+  @doc("Language of the wiki.")
+  language: string;
+  @doc("Resource type that the wiki belongs to.")
+  resourceType: string;
+  @doc("Display name of the wiki.")
+  name: string;
+  @doc("Normalized name used for search.")
+  normalizedName: string;
+  @doc("Representative image identifier for the wiki.")
+  imageIdentifier: Uuid | null;
+  @doc("Absolute URL of the representative image.")
+  imageUrl: string | null;
+  @doc("Alternative text of the representative image.")
+  imageAltText: string | null;
+}
+
 @doc("Approval status assigned to a draft wiki.")
 union DraftWikiStatus {
   "approved",
@@ -251,10 +273,22 @@ model ListDraftWikisResponseBody {
   per_page: int32;
 }
 
+@doc("Response body for the related profiles endpoint.")
+model ListRelatedProfilesResponseBody {
+  @doc("Related profile cards.")
+  profiles: RelatedProfileItem[];
+}
+
 @doc("Response returned when wiki list retrieval succeeds.")
 model ListWikisResponse {
   @statusCode statusCode: 200;
   @body body: ListWikisResponseBody;
+}
+
+@doc("Response returned when related profile retrieval succeeds.")
+model ListRelatedProfilesResponse {
+  @statusCode statusCode: 200;
+  @body body: ListRelatedProfilesResponseBody;
 }
 
 @doc("Response returned when draft wiki list retrieval succeeds.")
@@ -380,6 +414,15 @@ interface WikiOperations {
     @path wikiId: Uuid,
     @body body: WikiWorkflowRequestBody,
   ): TranslateWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/{language}/{slug}/related-profiles")
+  @doc("List related published wiki profiles for a source wiki.")
+  listRelatedProfiles(
+    @path language: string,
+    @path slug: string,
+    @query resourceType: string,
+  ): ListRelatedProfilesResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @get
   @route("/{language}/group/{slug}")


### PR DESCRIPTION
## 📝 変更内容

Wiki編集画面の Profiles ブロックから利用する、関連プロフィール取得APIを追加しました。

- `GET /api/wiki/wiki/{language}/{slug}/related-profiles?resourceType={target}` を追加
- Source Wiki を `language + slug` で特定
- `agency/group/talent/song` 間の既存 Basic 関連情報から関連プロフィールを取得
- カード表示用に `wikiIdentifier`, `slug`, `language`, `resourceType`, `name`, `normalizedName`, `imageIdentifier`, `imageUrl`, `imageAltText` を返却
- TypeSpec / OpenAPI を更新
- Application / Infrastructure / ReadModel のテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

kpool-frontend Issue #120 で、Wiki編集中に関連先 `resourceType` を選択した際、関連プロフィールカード一覧を自動取得できるようにするためです。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Source Wiki と同一 `resourceType` 指定時に 422 として扱っていること
- Source Wiki 未存在時に 404 として扱っていること
- 関連関係がない組み合わせは 200 + 空配列を返すこと
- 既存の Wiki Query と同じく Application Interface と Infrastructure Query を分離していること
- TypeSpec / OpenAPI のレスポンスキーが camelCase になっていること

## 📖 関連情報

### 関連Issue・タスク

Closes #396
Relates to kpool09122/kpool-frontend#120

## ⚠️ 注意事項

マイグレーションはありません。
破壊的変更はありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
