### PR TITLE
fix: Wiki関連プロフィールをセクション取得時に復元する

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapper.php
+++ b/application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapper.php
@@ -95,7 +95,7 @@ final class WikiCommandPayloadMapper
             'normalized_real_name' => $basic['normalizedRealName'] ?? '',
             'birthday' => $basic['birthday'] ?? null,
             'agency_identifier' => $basic['agencyIdentifier'] ?? null,
-            'group_identifiers' => $basic['groupIdentifiers'] ?? [],
+            'group_identifiers' => self::relatedWikiIdentifiers($basic, 'groupIdentifiers', 'groups'),
             'emoji' => $basic['emoji'] ?? '',
             'representative_symbol' => $basic['representativeSymbol'] ?? '',
             'position' => $basic['position'] ?? '',
@@ -139,8 +139,8 @@ final class WikiCommandPayloadMapper
             'song_type' => $basic['songType'] ?? null,
             'genres' => $basic['genres'] ?? [],
             'agency_identifier' => $basic['agencyIdentifier'] ?? null,
-            'group_identifiers' => $basic['groupIdentifiers'] ?? [],
-            'talent_identifiers' => $basic['talentIdentifiers'] ?? [],
+            'group_identifiers' => self::relatedWikiIdentifiers($basic, 'groupIdentifiers', 'groups'),
+            'talent_identifiers' => self::relatedWikiIdentifiers($basic, 'talentIdentifiers', 'talents'),
             'release_date' => $basic['releaseDate'] ?? null,
             'album_name' => $basic['albumName'] ?? null,
             'lyricist' => $basic['lyricist'] ?? '',
@@ -200,5 +200,27 @@ final class WikiCommandPayloadMapper
             'wiki_identifiers' => $content['wikiIdentifiers'] ?? [],
             'title' => $content['title'] ?? null,
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $basic
+     * @return list<string>
+     */
+    private static function relatedWikiIdentifiers(array $basic, string $identifierKey, string $summaryKey): array
+    {
+        if (array_key_exists($identifierKey, $basic)) {
+            return (array) $basic[$identifierKey];
+        }
+
+        if (! array_key_exists($summaryKey, $basic)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $summary): ?string => is_array($summary) && isset($summary['wikiIdentifier'])
+                ? (string) $summary['wikiIdentifier']
+                : null,
+            (array) $basic[$summaryKey],
+        )));
     }
 }

--- a/database/seeders/WikiEditorSampleSeeder.php
+++ b/database/seeders/WikiEditorSampleSeeder.php
@@ -12,7 +12,7 @@ class WikiEditorSampleSeeder extends Seeder
     private const string GROUP_PUBLISHED_WIKI_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f001';
     private const string GROUP_DRAFT_WIKI_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f002';
     private const string GROUP_TRANSLATION_SET_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f003';
-    private const string EDITOR_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217f004';
+    private const string EDITOR_ID = '01965bb2-bcc9-7c6f-8b90-89f7f217fa03';
 
     /**
      * Repo 内にフロントの mock fixture は見当たらないため、

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Wiki\Infrastructure\Query;
 
 use Application\Models\Wiki\DraftWiki as DraftWikiModel;
 use Application\Models\Wiki\DraftWikiAgencyBasic as DraftWikiAgencyBasicModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -80,120 +79,6 @@ readonly class GetAgencyDraftWiki implements GetAgencyDraftWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Wiki\Infrastructure\Query;
 
 use Application\Models\Wiki\Wiki as WikiModel;
 use Application\Models\Wiki\WikiAgencyBasic as WikiAgencyBasicModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -81,120 +80,6 @@ readonly class GetAgencyWiki implements GetAgencyWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Wiki\Infrastructure\Query;
 
 use Application\Models\Wiki\DraftWiki as DraftWikiModel;
 use Application\Models\Wiki\DraftWikiGroupBasic as DraftWikiGroupBasicModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -85,120 +84,6 @@ readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Wiki\Infrastructure\Query;
 
 use Application\Models\Wiki\Wiki as WikiModel;
 use Application\Models\Wiki\WikiGroupBasic as WikiGroupBasicModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -84,120 +83,6 @@ readonly class GetGroupWiki implements GetGroupWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
@@ -7,7 +7,6 @@ namespace Source\Wiki\Wiki\Infrastructure\Query;
 use Application\Models\Wiki\DraftWiki as DraftWikiModel;
 use Application\Models\Wiki\DraftWikiSongBasic as DraftWikiSongBasicModel;
 use Application\Models\Wiki\Wiki as WikiModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -148,117 +147,6 @@ readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Infrastructure\Query;
 
 use Application\Models\Wiki\Wiki as WikiModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use Application\Models\Wiki\WikiSongBasic as WikiSongBasicModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
@@ -148,117 +147,6 @@ readonly class GetSongWiki implements GetSongWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
@@ -6,7 +6,6 @@ namespace Source\Wiki\Wiki\Infrastructure\Query;
 
 use Application\Models\Wiki\DraftWiki as DraftWikiModel;
 use Application\Models\Wiki\Wiki as WikiModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -110,117 +109,6 @@ readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Infrastructure\Query;
 
 use Application\Models\Wiki\Wiki as WikiModel;
-use Application\Models\Wiki\WikiImage as WikiImageModel;
 use InvalidArgumentException;
 use Source\Shared\Infrastructure\Support\ImageUrl;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -110,117 +109,6 @@ readonly class GetTalentWiki implements GetTalentWikiInterface
      */
     private function sectionsWithImages(array $sections): array
     {
-        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
-
-        return array_map(fn (array $section): array => $this->sectionWithImages($section, $imageDetails), $sections);
-    }
-
-    /**
-     * @param array<string, mixed> $section
-     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
-     * @return array<string, mixed>
-     */
-    private function sectionWithImages(array $section, array $imageDetails): array
-    {
-        if (! isset($section['contents']) || ! is_array($section['contents'])) {
-            return $section;
-        }
-
-        $section['contents'] = array_map(function (mixed $content) use ($imageDetails): mixed {
-            if (! is_array($content)) {
-                return $content;
-            }
-
-            if (($content['type'] ?? null) === 'section') {
-                return $this->sectionWithImages($content, $imageDetails);
-            }
-
-            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-            if ($blockType === 'image') {
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
-                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
-                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
-                }
-            }
-
-            if ($blockType === 'image_gallery') {
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
-                if (is_array($imageIdentifiers)) {
-                    $content['images'] = array_values(array_filter(array_map(
-                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
-                            ? [
-                                'imageIdentifier' => $imageIdentifier,
-                                'src' => $imageDetails[$imageIdentifier]['src'],
-                                'alt' => $imageDetails[$imageIdentifier]['alt'],
-                            ]
-                            : null,
-                        $imageIdentifiers,
-                    )));
-                }
-            }
-
-            return $content;
-        }, $section['contents']);
-
-        return $section;
-    }
-
-    /**
-     * @param list<array<string, mixed>> $sections
-     * @return list<string>
-     */
-    private function imageIdentifiers(array $sections): array
-    {
-        $identifiers = [];
-        foreach ($sections as $section) {
-            foreach (($section['contents'] ?? []) as $content) {
-                if (! is_array($content)) {
-                    continue;
-                }
-                if (($content['type'] ?? null) === 'section') {
-                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
-
-                    continue;
-                }
-                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
-                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
-                if ($blockType === 'image' && is_string($imageIdentifier)) {
-                    $identifiers[] = $imageIdentifier;
-                }
-                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
-                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
-                    foreach ($imageIdentifiers as $imageIdentifier) {
-                        if (is_string($imageIdentifier)) {
-                            $identifiers[] = $imageIdentifier;
-                        }
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($identifiers));
-    }
-
-    /**
-     * @param list<string> $imageIdentifiers
-     * @return array<string, array{src: ?string, alt: ?string}>
-     */
-    private function imageDetails(array $imageIdentifiers): array
-    {
-        if ($imageIdentifiers === []) {
-            return [];
-        }
-
-        $details = [];
-        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
-        foreach ($images as $image) {
-            $details[(string) $image->id] = [
-                'src' => ImageUrl::fromPath($image->image_path),
-                'alt' => $image->alt_text,
-            ];
-        }
-
-        return $details;
+        return WikiSectionReadModelBuilder::build($sections);
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/WikiSectionReadModelBuilder.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/WikiSectionReadModelBuilder.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Infrastructure\Query;
+
+use Application\Models\Wiki\Wiki as WikiModel;
+use Application\Models\Wiki\WikiImage as WikiImageModel;
+use Source\Shared\Infrastructure\Support\ImageUrl;
+use Source\Wiki\Wiki\Application\UseCase\Query\RelatedProfileReadModel;
+
+final readonly class WikiSectionReadModelBuilder
+{
+    /**
+     * @param list<array<string, mixed>> $sections
+     * @return list<array<string, mixed>>
+     */
+    public static function build(array $sections): array
+    {
+        return (new self())->sectionsWithDetails($sections);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $sections
+     * @return list<array<string, mixed>>
+     */
+    private function sectionsWithDetails(array $sections): array
+    {
+        $imageDetails = $this->imageDetails($this->imageIdentifiers($sections));
+        $profileDetails = $this->profileDetails($this->profileWikiIdentifiers($sections));
+
+        return array_map(fn (array $section): array => $this->sectionWithDetails($section, $imageDetails, $profileDetails), $sections);
+    }
+
+    /**
+     * @param array<string, mixed> $section
+     * @param array<string, array{src: ?string, alt: ?string}> $imageDetails
+     * @param array<string, array<string, mixed>> $profileDetails
+     * @return array<string, mixed>
+     */
+    private function sectionWithDetails(array $section, array $imageDetails, array $profileDetails): array
+    {
+        if (! isset($section['contents']) || ! is_array($section['contents'])) {
+            return $section;
+        }
+
+        $section['contents'] = array_map(function (mixed $content) use ($imageDetails, $profileDetails): mixed {
+            if (! is_array($content)) {
+                return $content;
+            }
+
+            if (($content['type'] ?? null) === 'section') {
+                return $this->sectionWithDetails($content, $imageDetails, $profileDetails);
+            }
+
+            $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
+            if ($blockType === 'image') {
+                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
+                if (is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])) {
+                    $content['src'] = $imageDetails[$imageIdentifier]['src'];
+                    $content['alt'] = $content['alt'] ?? $imageDetails[$imageIdentifier]['alt'];
+                }
+            }
+
+            if ($blockType === 'image_gallery') {
+                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? [];
+                if (is_array($imageIdentifiers)) {
+                    $content['images'] = array_values(array_filter(array_map(
+                        static fn (mixed $imageIdentifier): ?array => is_string($imageIdentifier) && isset($imageDetails[$imageIdentifier])
+                            ? [
+                                'imageIdentifier' => $imageIdentifier,
+                                'src' => $imageDetails[$imageIdentifier]['src'],
+                                'alt' => $imageDetails[$imageIdentifier]['alt'],
+                            ]
+                            : null,
+                        $imageIdentifiers,
+                    )));
+                }
+            }
+
+            if ($blockType === 'profile_card_list') {
+                $wikiIdentifiers = $this->stringList($content['wiki_identifiers'] ?? $content['wikiIdentifiers'] ?? []);
+                $profiles = array_values(array_filter(array_map(
+                    static fn (string $wikiIdentifier): ?array => $profileDetails[$wikiIdentifier] ?? null,
+                    $wikiIdentifiers,
+                )));
+
+                $content['wikiIdentifiers'] = $content['wikiIdentifiers'] ?? $wikiIdentifiers;
+                $content['profiles'] = $profiles;
+                $content['relatedResourceType'] = $content['relatedResourceType'] ?? $content['related_resource_type'] ?? $this->relatedResourceType($profiles);
+            }
+
+            return $content;
+        }, $section['contents']);
+
+        return $section;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $sections
+     * @return list<string>
+     */
+    private function imageIdentifiers(array $sections): array
+    {
+        $identifiers = [];
+        foreach ($sections as $section) {
+            foreach (($section['contents'] ?? []) as $content) {
+                if (! is_array($content)) {
+                    continue;
+                }
+
+                if (($content['type'] ?? null) === 'section') {
+                    $identifiers = [...$identifiers, ...$this->imageIdentifiers([$content])];
+
+                    continue;
+                }
+
+                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
+                $imageIdentifier = $content['image_identifier'] ?? $content['imageIdentifier'] ?? null;
+                if ($blockType === 'image' && is_string($imageIdentifier)) {
+                    $identifiers[] = $imageIdentifier;
+                }
+
+                $imageIdentifiers = $content['image_identifiers'] ?? $content['imageIdentifiers'] ?? null;
+                if ($blockType === 'image_gallery' && is_array($imageIdentifiers)) {
+                    foreach ($imageIdentifiers as $imageIdentifier) {
+                        if (is_string($imageIdentifier)) {
+                            $identifiers[] = $imageIdentifier;
+                        }
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($identifiers));
+    }
+
+    /**
+     * @param list<string> $imageIdentifiers
+     * @return array<string, array{src: ?string, alt: ?string}>
+     */
+    private function imageDetails(array $imageIdentifiers): array
+    {
+        if ($imageIdentifiers === []) {
+            return [];
+        }
+
+        $details = [];
+        $images = WikiImageModel::query()->whereIn('id', $imageIdentifiers)->get(['id', 'image_path', 'alt_text']);
+        foreach ($images as $image) {
+            $details[(string) $image->id] = [
+                'src' => ImageUrl::fromPath($image->image_path),
+                'alt' => $image->alt_text,
+            ];
+        }
+
+        return $details;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $sections
+     * @return list<string>
+     */
+    private function profileWikiIdentifiers(array $sections): array
+    {
+        $identifiers = [];
+        foreach ($sections as $section) {
+            foreach (($section['contents'] ?? []) as $content) {
+                if (! is_array($content)) {
+                    continue;
+                }
+
+                if (($content['type'] ?? null) === 'section') {
+                    $identifiers = [...$identifiers, ...$this->profileWikiIdentifiers([$content])];
+
+                    continue;
+                }
+
+                $blockType = $content['block_type'] ?? $content['blockType'] ?? $content['type'] ?? null;
+                if ($blockType === 'profile_card_list') {
+                    $identifiers = [...$identifiers, ...$this->stringList($content['wiki_identifiers'] ?? $content['wikiIdentifiers'] ?? [])];
+                }
+            }
+        }
+
+        return array_values(array_unique($identifiers));
+    }
+
+    /**
+     * @param list<string> $wikiIdentifiers
+     * @return array<string, array<string, mixed>>
+     */
+    private function profileDetails(array $wikiIdentifiers): array
+    {
+        if ($wikiIdentifiers === []) {
+            return [];
+        }
+
+        $profiles = WikiModel::query()
+            ->select(
+                'wikis.*',
+                'wiki_images.image_path as image_path',
+                'wiki_images.alt_text as image_alt_text',
+            )
+            ->selectRaw('COALESCE(wiki_agency_basics.name, wiki_group_basics.name, wiki_talent_basics.name, wiki_song_basics.name) as profile_name')
+            ->selectRaw('COALESCE(wiki_agency_basics.normalized_name, wiki_group_basics.normalized_name, wiki_talent_basics.normalized_name, wiki_song_basics.normalized_name) as profile_normalized_name')
+            ->leftJoin('wiki_agency_basics', 'wiki_agency_basics.wiki_id', '=', 'wikis.id')
+            ->leftJoin('wiki_group_basics', 'wiki_group_basics.wiki_id', '=', 'wikis.id')
+            ->leftJoin('wiki_talent_basics', 'wiki_talent_basics.wiki_id', '=', 'wikis.id')
+            ->leftJoin('wiki_song_basics', 'wiki_song_basics.wiki_id', '=', 'wikis.id')
+            ->leftJoin('wiki_images', 'wiki_images.id', '=', 'wikis.image_identifier')
+            ->whereIn('wikis.id', $wikiIdentifiers)
+            ->get();
+
+        $details = [];
+        foreach ($profiles as $profile) {
+            $details[(string) $profile->id] = (new RelatedProfileReadModel(
+                wikiIdentifier: $profile->id,
+                slug: $profile->slug,
+                language: $profile->language,
+                resourceType: $profile->resource_type,
+                name: (string) $profile->getAttribute('profile_name'),
+                normalizedName: (string) $profile->getAttribute('profile_normalized_name'),
+                imageIdentifier: $profile->image_identifier,
+                imageUrl: ImageUrl::fromPath($profile->getAttribute('image_path')),
+                imageAltText: $profile->getAttribute('image_alt_text'),
+            ))->toArray();
+        }
+
+        return $details;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $profiles
+     */
+    private function relatedResourceType(array $profiles): ?string
+    {
+        $resourceTypes = array_values(array_unique(array_filter(array_map(
+            static fn (array $profile): ?string => is_string($profile['resourceType'] ?? null) ? $profile['resourceType'] : null,
+            $profiles,
+        ))));
+
+        return count($resourceTypes) === 1 ? $resourceTypes[0] : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $item): ?string => is_string($item) ? $item : null,
+            $value,
+        )));
+    }
+}

--- a/tests/Application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapperTest.php
+++ b/tests/Application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapperTest.php
@@ -7,6 +7,9 @@ namespace Tests\Application\Http\Action\Wiki\Wiki\Command\Support;
 use Application\Http\Action\Wiki\Wiki\Command\Support\WikiCommandPayloadMapper;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Song\SongBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\TalentBasic;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TableBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TextBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\Section;
@@ -78,5 +81,44 @@ class WikiCommandPayloadMapperTest extends TestCase
 
         $this->assertInstanceOf(TableBlock::class, $block);
         $this->assertSame('320', $block->tableWidth());
+    }
+
+    public function testTalentBasicMapsGroupIdentifiersFromDetailSummary(): void
+    {
+        $basic = WikiCommandPayloadMapper::basic(ResourceType::TALENT, [
+            'name' => 'Momo',
+            'groups' => [
+                ['wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f001'],
+            ],
+        ]);
+
+        $this->assertInstanceOf(TalentBasic::class, $basic);
+        $this->assertSame(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f001',
+            (string) $basic->groupIdentifiers()[0],
+        );
+    }
+
+    public function testSongBasicMapsRelatedIdentifiersFromDetailSummaries(): void
+    {
+        $basic = WikiCommandPayloadMapper::basic(ResourceType::SONG, [
+            'name' => 'Fancy',
+            'groups' => [
+                ['wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f001'],
+            ],
+            'talents' => [
+                ['wikiIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101'],
+            ],
+        ]);
+
+        $this->assertInstanceOf(SongBasic::class, $basic);
+        $this->assertSame(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f001',
+            (string) $basic->groupIdentifiers()[0],
+        );
+        $this->assertSame(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            (string) $basic->talentIdentifiers()[0],
+        );
     }
 }

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
@@ -138,6 +138,71 @@ class GetGroupWikiTest extends TestCase
     }
 
     #[Group('useDb')]
+    public function testProcessReturnsProfilesForProfileCardListBlocks(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f504', [
+            'image_path' => '/images/wiki/momo.jpg',
+            'alt_text' => 'Momo profile image',
+        ]);
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f503',
+            'talent',
+            [
+                'slug' => 'tl-momo',
+                'language' => 'ko',
+                'image_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f504',
+            ],
+            [
+                'name' => 'Momo',
+                'normalized_name' => 'momo',
+            ],
+        );
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f502',
+            'group',
+            [
+                'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f505',
+                'slug' => 'gr-twice-profiles',
+                'language' => 'ko',
+                'sections' => json_encode([
+                    [
+                        'type' => 'section',
+                        'title' => 'Members',
+                        'display_order' => 1,
+                        'contents' => [
+                            [
+                                'block_type' => 'profile_card_list',
+                                'display_order' => 1,
+                                'wiki_identifiers' => ['01965bb2-bcc9-7c6f-8b90-89f7f217f503'],
+                                'title' => 'Members',
+                            ],
+                        ],
+                    ],
+                ]),
+            ],
+            [
+                'name' => 'TWICE',
+                'normalized_name' => 'twice',
+                'group_type' => 'girl_group',
+                'generation' => '3',
+            ],
+        );
+
+        $useCase = $this->app->make(GetGroupWikiInterface::class);
+        $readModel = $useCase->process(new GetGroupWikiInput(new Slug('gr-twice-profiles'), Language::KOREAN));
+        $block = $readModel->sections()[0]['contents'][0];
+
+        $this->assertSame(['01965bb2-bcc9-7c6f-8b90-89f7f217f503'], $block['wikiIdentifiers']);
+        $this->assertSame('talent', $block['relatedResourceType']);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f503', $block['profiles'][0]['wikiIdentifier']);
+        $this->assertSame('tl-momo', $block['profiles'][0]['slug']);
+        $this->assertSame('talent', $block['profiles'][0]['resourceType']);
+        $this->assertSame('Momo', $block['profiles'][0]['name']);
+        $this->assertSame('http://127.0.0.1:8080/images/wiki/momo.jpg', $block['profiles'][0]['imageUrl']);
+        $this->assertSame('Momo profile image', $block['profiles'][0]['imageAltText']);
+    }
+
+    #[Group('useDb')]
     public function testProcessThrowsWhenGroupWikiDoesNotExist(): void
     {
         $useCase = $this->app->make(GetGroupWikiInterface::class);

--- a/tests/Wiki/Wiki/Infrastructure/Query/WikiSectionReadModelBuilderTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/WikiSectionReadModelBuilderTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Infrastructure\Query;
+
+use PHPUnit\Framework\Attributes\Group;
+use Source\Wiki\Wiki\Infrastructure\Query\WikiSectionReadModelBuilder;
+use Tests\Helper\CreateImage;
+use Tests\Helper\CreateWiki;
+use Tests\TestCase;
+
+class WikiSectionReadModelBuilderTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testBuildReturnsImageDetailsAndProfileCardProfiles(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f701', [
+            'image_path' => '/images/wiki/section.jpg',
+            'alt_text' => 'Section image',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f702', [
+            'image_path' => '/images/wiki/momo.jpg',
+            'alt_text' => 'Momo profile image',
+        ]);
+        CreateWiki::create(
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f703',
+            'talent',
+            [
+                'slug' => 'tl-momo',
+                'language' => 'ko',
+                'image_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f702',
+            ],
+            [
+                'name' => 'Momo',
+                'normalized_name' => 'momo',
+            ],
+        );
+
+        $sections = WikiSectionReadModelBuilder::build([
+            [
+                'type' => 'section',
+                'title' => 'Overview',
+                'contents' => [
+                    [
+                        'block_type' => 'image',
+                        'image_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f701',
+                        'alt' => null,
+                    ],
+                    [
+                        'block_type' => 'profile_card_list',
+                        'wiki_identifiers' => ['01965bb2-bcc9-7c6f-8b90-89f7f217f703'],
+                        'title' => 'Members',
+                    ],
+                ],
+            ],
+        ]);
+
+        $imageBlock = $sections[0]['contents'][0];
+        $profileBlock = $sections[0]['contents'][1];
+
+        $this->assertSame('http://127.0.0.1:8080/images/wiki/section.jpg', $imageBlock['src']);
+        $this->assertSame('Section image', $imageBlock['alt']);
+        $this->assertSame(['01965bb2-bcc9-7c6f-8b90-89f7f217f703'], $profileBlock['wikiIdentifiers']);
+        $this->assertSame('talent', $profileBlock['relatedResourceType']);
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f703', $profileBlock['profiles'][0]['wikiIdentifier']);
+        $this->assertSame('tl-momo', $profileBlock['profiles'][0]['slug']);
+        $this->assertSame('Momo', $profileBlock['profiles'][0]['name']);
+        $this->assertSame('http://127.0.0.1:8080/images/wiki/momo.jpg', $profileBlock['profiles'][0]['imageUrl']);
+        $this->assertSame('Momo profile image', $profileBlock['profiles'][0]['imageAltText']);
+    }
+
+    public function testBuildKeepsProfileCardListEmptyWhenIdentifiersAreMissing(): void
+    {
+        $sections = WikiSectionReadModelBuilder::build([
+            [
+                'type' => 'section',
+                'title' => 'Overview',
+                'contents' => [
+                    [
+                        'block_type' => 'profile_card_list',
+                        'title' => 'Members',
+                    ],
+                ],
+            ],
+        ]);
+
+        $profileBlock = $sections[0]['contents'][0];
+
+        $this->assertSame([], $profileBlock['wikiIdentifiers']);
+        $this->assertSame([], $profileBlock['profiles']);
+        $this->assertNull($profileBlock['relatedResourceType']);
+    }
+}


### PR DESCRIPTION
## 📝 変更内容

- Wiki セクション取得時の画像復元処理を `WikiSectionReadModelBuilder` に共通化
- `profile_card_list` ブロックの `wiki_identifiers` から関連プロフィール情報を復元し、`profiles` / `relatedResourceType` / `wikiIdentifiers` を返すように変更
- Agency / Group / Talent / Song の公開・下書き Wiki 取得処理で共通 builder を利用
- Wiki 更新 payload で、詳細サマリ形式の `groups` / `talents` から関連 Wiki identifier を復元できるように変更
- 関連プロフィール復元と payload mapper の回帰テストを追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki 詳細取得時に `profile_card_list` ブロックの関連プロフィール情報が復元されず、表示側でプロフィールカードに必要な情報を取得できない状態だったため、セクション read model 構築時に画像情報と同じタイミングで関連プロフィール情報も補完するようにしました。

また、各 Wiki 種別ごとに重複していた画像復元処理を共通化し、今後のブロック復元処理を一箇所で扱えるようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `WikiSectionReadModelBuilder` で既存の画像ブロック / 画像ギャラリー復元挙動が維持されていること
- `profile_card_list` の `wiki_identifiers` / `wikiIdentifiers` 双方から関連プロフィールを復元できること
- 関連プロフィールの `resourceType` が単一の場合のみ `relatedResourceType` を補完する仕様で問題ないこと
- 各 Wiki 取得 query から重複実装を削除し、共通 builder 呼び出しに置き換えていること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

破壊的変更、マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
