### PR TITLE
Draft Wikiレビュー申請取り下げAPIを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiAction.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\WithdrawWiki;
+
+use Application\Http\Context\WikiContext;
+use Application\Http\Exceptions\ConflictHttpException;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiOutput;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use ValueError;
+
+readonly class WithdrawWikiAction
+{
+    public function __construct(
+        private WithdrawWikiInterface $withdrawWiki,
+        private WikiContext $wikiContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(WithdrawWikiRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new WithdrawWikiInput(
+                    new DraftWikiIdentifier($request->wikiId()),
+                    $this->wikiContext->principalIdentifier,
+                    ResourceType::from($request->resourceType()),
+                    $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
+                    array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),
+                );
+                $output = new WithdrawWikiOutput();
+            } catch (InvalidArgumentException|ValueError $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            $language = $request->language();
+
+            try {
+                $this->withdrawWiki->process($input, $output);
+                DB::commit();
+            } catch (WikiNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new NotFoundHttpException(detail: error_message('wiki_not_found', $language), previous: $e);
+            } catch (InvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('invalid_status', $language), previous: $e);
+            } catch (DisallowedException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_CREATED);
+    }
+}

--- a/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Wiki\Command\WithdrawWiki;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class WithdrawWikiRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function validationData(): array
+    {
+        return [
+            ...parent::validationData(),
+            'wikiId' => $this->route('wikiId'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'wikiId' => ['required', 'uuid'],
+            'resourceType' => ['required', 'string'],
+            'agencyIdentifier' => ['nullable', 'uuid'],
+            'groupIdentifiers' => ['nullable', 'array'],
+            'groupIdentifiers.*' => ['uuid'],
+            'talentIdentifiers' => ['nullable', 'array'],
+            'talentIdentifiers.*' => ['uuid'],
+        ];
+    }
+
+    public function wikiId(): string
+    {
+        return (string) $this->route('wikiId');
+    }
+
+    public function resourceType(): string
+    {
+        return (string) $this->input('resourceType');
+    }
+
+    public function agencyIdentifier(): ?string
+    {
+        $value = $this->input('agencyIdentifier');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function groupIdentifiers(): array
+    {
+        return (array) ($this->input('groupIdentifiers') ?? []);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function talentIdentifiers(): array
+    {
+        return (array) ($this->input('talentIdentifiers') ?? []);
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -81,6 +81,8 @@ use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\SubmitWiki\SubmitWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\TranslateWiki\TranslateWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWiki;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyDraftWiki\GetAgencyDraftWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki\GetAgencyWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Query\GetGroupDraftWiki\GetGroupDraftWikiInterface;
@@ -148,6 +150,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(PublishWikiInterface::class, PublishWiki::class);
         $this->app->singleton(RollbackWikiInterface::class, RollbackWiki::class);
         $this->app->singleton(TranslateWikiInterface::class, TranslateWiki::class);
+        $this->app->singleton(WithdrawWikiInterface::class, WithdrawWiki::class);
         $this->app->singleton(GetAgencyDraftWikiInterface::class, GetAgencyDraftWiki::class);
         $this->app->singleton(GetAgencyWikiInterface::class, GetAgencyWiki::class);
         $this->app->singleton(GetGroupDraftWikiInterface::class, GetGroupDraftWiki::class);

--- a/database/seeders/SystemPolicySeeder.php
+++ b/database/seeders/SystemPolicySeeder.php
@@ -66,7 +66,7 @@ class SystemPolicySeeder extends Seeder
                 ),
                 new Statement(
                     effect: Effect::ALLOW,
-                    actions: [Action::DELETE],
+                    actions: [Action::DELETE, Action::WITHDRAW],
                     resourceTypes: ResourceType::cases(),
                     condition: new Condition([
                         new ConditionClause(

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2085,6 +2085,59 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/WikiWorkflowRequestBody'
+  /wiki/{wikiId}/withdraw:
+    post:
+      operationId: WikiOperations_withdrawWiki
+      description: Withdraw a wiki draft review request.
+      parameters:
+        - name: wikiId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '201':
+          description: Response returned when a wiki draft is created or updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DraftWikiSummary'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WikiWorkflowRequestBody'
   /wikis/version-inconsistencies:
     get:
       operationId: WikiListOperations_listVersionInconsistentWikis

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -53,6 +53,7 @@ use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImag
 use Application\Http\Action\Wiki\Image\Command\RequestImageHide\RequestImageHideAction;
 use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinksAction;
 use Application\Http\Action\Wiki\Wiki\Command\TranslateWiki\TranslateWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\WithdrawWiki\WithdrawWikiAction;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function () {
@@ -67,6 +68,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
     Route::post('/wiki/{wikiId}/rollback', RollbackWikiAction::class);
     Route::post('/wiki/{wikiId}/submit', SubmitWikiAction::class);
     Route::post('/wiki/{wikiId}/translate', TranslateWikiAction::class);
+    Route::post('/wiki/{wikiId}/withdraw', WithdrawWikiAction::class);
 });
 Route::get('/wikis/version-inconsistencies', ListVersionInconsistentWikisAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::get('/wikis/{language}', ListWikisAction::class);

--- a/src/Wiki/Shared/Domain/ValueObject/Action.php
+++ b/src/Wiki/Shared/Domain/ValueObject/Action.php
@@ -9,6 +9,7 @@ enum Action: string
     case CREATE = 'create';
     case EDIT = 'edit';
     case SUBMIT = 'submit';
+    case WITHDRAW = 'withdraw';
     case APPROVE = 'approve';
     case REJECT = 'reject';
     case TRANSLATE = 'translate';

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWiki.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\Action;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\HistoryActionType;
+use Source\Wiki\Shared\Domain\ValueObject\Resource;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
+use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
+use Source\Wiki\Wiki\Domain\Repository\WikiHistoryRepositoryInterface;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+
+readonly class WithdrawWiki implements WithdrawWikiInterface
+{
+    public function __construct(
+        private DraftWikiRepositoryInterface   $draftWikiRepository,
+        private WikiHistoryRepositoryInterface $wikiHistoryRepository,
+        private WikiHistoryFactoryInterface    $wikiHistoryFactory,
+        private PrincipalRepositoryInterface   $principalRepository,
+        private PolicyEvaluatorInterface       $policyEvaluator,
+    ) {
+    }
+
+    /**
+     * @throws WikiNotFoundException
+     * @throws InvalidStatusException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function process(WithdrawWikiInputPort $input, WithdrawWikiOutputPort $output): void
+    {
+        $wiki = $this->draftWikiRepository->findById($input->wikiIdentifier());
+
+        if ($wiki === null) {
+            throw new WikiNotFoundException();
+        }
+
+        $principal = $this->principalRepository->findById($input->principalIdentifier());
+        if ($principal === null) {
+            throw new PrincipalNotFoundException();
+        }
+
+        $resource = new Resource(
+            type: $input->resourceType(),
+            agencyId: $input->agencyIdentifier() ? (string) $input->agencyIdentifier() : null,
+            groupIds: array_map(
+                static fn (WikiIdentifier $id) => (string) $id,
+                $input->groupIdentifiers(),
+            ),
+            talentIds: array_map(
+                static fn (WikiIdentifier $id) => (string) $id,
+                $input->talentIdentifiers(),
+            ),
+            editorId: $wiki->editorIdentifier() ? (string) $wiki->editorIdentifier() : null,
+        );
+
+        if (! $this->policyEvaluator->evaluate($principal, Action::WITHDRAW, $resource)) {
+            throw new DisallowedException();
+        }
+
+        if ($wiki->status() !== ApprovalStatus::UnderReview) {
+            throw new InvalidStatusException();
+        }
+
+        $previousStatus = $wiki->status();
+        $wiki->setStatus(ApprovalStatus::Pending);
+
+        $this->draftWikiRepository->save($wiki);
+
+        $history = $this->wikiHistoryFactory->create(
+            actionType: HistoryActionType::DraftStatusChange,
+            actorIdentifier: $input->principalIdentifier(),
+            submitterIdentifier: $wiki->editorIdentifier(),
+            wikiIdentifier: $wiki->publishedWikiIdentifier(),
+            draftWikiIdentifier: new DraftWikiIdentifier((string) $wiki->wikiIdentifier()),
+            fromStatus: $previousStatus,
+            toStatus: $wiki->status(),
+            fromVersion: null,
+            toVersion: null,
+            subjectName: $wiki->basic()->name(),
+        );
+        $this->wikiHistoryRepository->save($history);
+
+        $output->setDraftWiki($wiki);
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInput.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+
+readonly class WithdrawWikiInput implements WithdrawWikiInputPort
+{
+    /**
+     * @param WikiIdentifier[] $groupIdentifiers
+     * @param WikiIdentifier[] $talentIdentifiers
+     */
+    public function __construct(
+        private DraftWikiIdentifier $wikiIdentifier,
+        private PrincipalIdentifier $principalIdentifier,
+        private ResourceType        $resourceType,
+        private ?WikiIdentifier     $agencyIdentifier = null,
+        private array               $groupIdentifiers = [],
+        private array               $talentIdentifiers = [],
+    ) {
+    }
+
+    public function wikiIdentifier(): DraftWikiIdentifier
+    {
+        return $this->wikiIdentifier;
+    }
+
+    public function principalIdentifier(): PrincipalIdentifier
+    {
+        return $this->principalIdentifier;
+    }
+
+    public function resourceType(): ResourceType
+    {
+        return $this->resourceType;
+    }
+
+    public function agencyIdentifier(): ?WikiIdentifier
+    {
+        return $this->agencyIdentifier;
+    }
+
+    /** @return WikiIdentifier[] */
+    public function groupIdentifiers(): array
+    {
+        return $this->groupIdentifiers;
+    }
+
+    /** @return WikiIdentifier[] */
+    public function talentIdentifiers(): array
+    {
+        return $this->talentIdentifiers;
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputPort.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+
+interface WithdrawWikiInputPort
+{
+    public function wikiIdentifier(): DraftWikiIdentifier;
+
+    public function principalIdentifier(): PrincipalIdentifier;
+
+    public function resourceType(): ResourceType;
+
+    public function agencyIdentifier(): ?WikiIdentifier;
+
+    /** @return WikiIdentifier[] */
+    public function groupIdentifiers(): array;
+
+    /** @return WikiIdentifier[] */
+    public function talentIdentifiers(): array;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+
+interface WithdrawWikiInterface
+{
+    /**
+     * @throws WikiNotFoundException
+     * @throws InvalidStatusException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function process(WithdrawWikiInputPort $input, WithdrawWikiOutputPort $output): void;
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+class WithdrawWikiOutput implements WithdrawWikiOutputPort
+{
+    private ?DraftWiki $draftWiki = null;
+
+    public function setDraftWiki(DraftWiki $draftWiki): void
+    {
+        $this->draftWiki = $draftWiki;
+    }
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array
+    {
+        if ($this->draftWiki === null) {
+            return [
+                'language' => null,
+                'name' => null,
+                'resourceType' => null,
+                'status' => null,
+            ];
+        }
+
+        return [
+            'language' => $this->draftWiki->language()->value,
+            'name' => (string) $this->draftWiki->basic()->name(),
+            'resourceType' => $this->draftWiki->resourceType()->value,
+            'status' => $this->draftWiki->status()->value,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputPort.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+
+interface WithdrawWikiOutputPort
+{
+    public function setDraftWiki(DraftWiki $draftWiki): void;
+
+    /**
+     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     */
+    public function toArray(): array;
+}

--- a/tests/Wiki/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
@@ -1066,7 +1066,7 @@ class PolicyEvaluatorTest extends TestCase
             ),
             new Statement(
                 Effect::ALLOW,
-                [Action::DELETE],
+                [Action::DELETE, Action::WITHDRAW],
                 ResourceType::cases(),
                 new Condition([
                     new ConditionClause(
@@ -1099,10 +1099,18 @@ class PolicyEvaluatorTest extends TestCase
         $this->assertTrue($policyEvaluator->evaluate($principal, Action::EDIT, $resource));
         $this->assertTrue($policyEvaluator->evaluate($principal, Action::SUBMIT, $resource));
         $this->assertFalse($policyEvaluator->evaluate($principal, Action::DELETE, $resource));
+        $this->assertFalse($policyEvaluator->evaluate($principal, Action::WITHDRAW, $resource));
         $this->assertTrue(
             $policyEvaluator->evaluate(
                 $principal,
                 Action::DELETE,
+                new Resource(ResourceType::GROUP, editorId: (string) $principal->principalIdentifier()),
+            )
+        );
+        $this->assertTrue(
+            $policyEvaluator->evaluate(
+                $principal,
+                Action::WITHDRAW,
                 new Resource(ResourceType::GROUP, editorId: (string) $principal->principalIdentifier()),
             )
         );
@@ -1125,7 +1133,7 @@ class PolicyEvaluatorTest extends TestCase
         $policy = $this->createAndSavePolicy([
             new Statement(
                 Effect::ALLOW,
-                [Action::DELETE],
+                [Action::DELETE, Action::WITHDRAW],
                 ResourceType::cases(),
                 new Condition([
                     new ConditionClause(
@@ -1156,6 +1164,8 @@ class PolicyEvaluatorTest extends TestCase
 
         $this->assertTrue($policyEvaluator->evaluate($principal, Action::DELETE, $ownDraft));
         $this->assertFalse($policyEvaluator->evaluate($principal, Action::DELETE, $otherDraft));
+        $this->assertTrue($policyEvaluator->evaluate($principal, Action::WITHDRAW, $ownDraft));
+        $this->assertFalse($policyEvaluator->evaluate($principal, Action::WITHDRAW, $otherDraft));
     }
 
     /**

--- a/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInput;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class WithdrawWikiInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $resourceType = ResourceType::GROUP;
+        $agencyIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+        $groupIdentifiers = [new WikiIdentifier(StrTestHelper::generateUuid())];
+        $talentIdentifiers = [new WikiIdentifier(StrTestHelper::generateUuid())];
+
+        $input = new WithdrawWikiInput(
+            $wikiIdentifier,
+            $principalIdentifier,
+            $resourceType,
+            $agencyIdentifier,
+            $groupIdentifiers,
+            $talentIdentifiers,
+        );
+
+        $this->assertSame((string) $wikiIdentifier, (string) $input->wikiIdentifier());
+        $this->assertSame($principalIdentifier, $input->principalIdentifier());
+        $this->assertSame($resourceType->value, $input->resourceType()->value);
+        $this->assertSame((string) $agencyIdentifier, (string) $input->agencyIdentifier());
+        $this->assertSame($groupIdentifiers, $input->groupIdentifiers());
+        $this->assertSame($talentIdentifiers, $input->talentIdentifiers());
+    }
+
+    public function test__constructWithDefaults(): void
+    {
+        $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $resourceType = ResourceType::GROUP;
+
+        $input = new WithdrawWikiInput(
+            $wikiIdentifier,
+            $principalIdentifier,
+            $resourceType,
+        );
+
+        $this->assertSame((string) $wikiIdentifier, (string) $input->wikiIdentifier());
+        $this->assertSame($principalIdentifier, $input->principalIdentifier());
+        $this->assertSame($resourceType->value, $input->resourceType()->value);
+        $this->assertNull($input->agencyIdentifier());
+        $this->assertSame([], $input->groupIdentifiers());
+        $this->assertSame([], $input->talentIdentifiers());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class WithdrawWikiOutputTest extends TestCase
+{
+    public function testToArrayWithDraftWiki(): void
+    {
+        $draftWiki = new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('gr-twice'),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+            ),
+            new SectionContentCollection(),
+            null,
+            ApprovalStatus::Pending,
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+        );
+
+        $output = new WithdrawWikiOutput();
+        $output->setDraftWiki($draftWiki);
+
+        $this->assertSame([
+            'language' => 'ko',
+            'name' => 'TWICE',
+            'resourceType' => 'group',
+            'status' => 'pending',
+        ], $output->toArray());
+    }
+
+    public function testToArrayWithoutDraftWiki(): void
+    {
+        $output = new WithdrawWikiOutput();
+
+        $this->assertSame([
+            'language' => null,
+            'name' => null,
+            'resourceType' => null,
+            'status' => null,
+        ], $output->toArray());
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
+
+use DateTimeImmutable;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Mockery;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
+use Source\Shared\Domain\ValueObject\TranslationSetIdentifier;
+use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\Action;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
+use Source\Wiki\Shared\Domain\ValueObject\HistoryActionType;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\Resource;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Shared\Domain\ValueObject\Slug;
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWiki;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInput;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInterface;
+use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiOutput;
+use Source\Wiki\Wiki\Domain\Entity\DraftWiki;
+use Source\Wiki\Wiki\Domain\Entity\WikiHistory;
+use Source\Wiki\Wiki\Domain\Factory\WikiHistoryFactoryInterface;
+use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
+use Source\Wiki\Wiki\Domain\Repository\WikiHistoryRepositoryInterface;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Emoji;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\FandomName;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\Name;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Shared\RepresentativeSymbol;
+use Source\Wiki\Wiki\Domain\ValueObject\Color;
+use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiHistoryIdentifier;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class WithdrawWikiTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $this->app->instance(DraftWikiRepositoryInterface::class, Mockery::mock(DraftWikiRepositoryInterface::class));
+        $this->app->instance(WikiHistoryRepositoryInterface::class, Mockery::mock(WikiHistoryRepositoryInterface::class));
+        $this->app->instance(WikiHistoryFactoryInterface::class, Mockery::mock(WikiHistoryFactoryInterface::class));
+        $this->app->instance(PrincipalRepositoryInterface::class, Mockery::mock(PrincipalRepositoryInterface::class));
+
+        $withdrawWiki = $this->app->make(WithdrawWikiInterface::class);
+
+        $this->assertInstanceOf(WithdrawWiki::class, $withdrawWiki);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws InvalidStatusException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testProcessWithdrawsUnderReviewDraftWiki(): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $draftWiki = $this->createDraftWiki(ApprovalStatus::UnderReview, $principalIdentifier);
+        $history = $this->createHistory($draftWiki, $principalIdentifier, ApprovalStatus::UnderReview, ApprovalStatus::Pending);
+        $input = $this->createInput($draftWiki->wikiIdentifier(), $principalIdentifier);
+
+        $this->bindRepositoriesForPolicyResult($draftWiki, $principalIdentifier, true, true, $history);
+
+        $output = new WithdrawWikiOutput();
+        $this->app->make(WithdrawWikiInterface::class)->process($input, $output);
+
+        $this->assertSame(ApprovalStatus::Pending->value, $output->toArray()['status']);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws InvalidStatusException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testProcessWikiNotFound(): void
+    {
+        $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $input = $this->createInput($wikiIdentifier, $principalIdentifier);
+
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+        $draftWikiRepository->shouldReceive('findById')->once()->with($wikiIdentifier)->andReturn(null);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldNotReceive('findById');
+
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(WikiHistoryRepositoryInterface::class, Mockery::mock(WikiHistoryRepositoryInterface::class));
+        $this->app->instance(WikiHistoryFactoryInterface::class, Mockery::mock(WikiHistoryFactoryInterface::class));
+
+        $this->expectException(WikiNotFoundException::class);
+        $this->app->make(WithdrawWikiInterface::class)->process($input, new WithdrawWikiOutput());
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws InvalidStatusException
+     * @throws DisallowedException
+     */
+    public function testProcessPrincipalNotFound(): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $draftWiki = $this->createDraftWiki(ApprovalStatus::UnderReview, $principalIdentifier);
+        $input = $this->createInput($draftWiki->wikiIdentifier(), $principalIdentifier);
+
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+        $draftWikiRepository->shouldReceive('findById')->once()->with($draftWiki->wikiIdentifier())->andReturn($draftWiki);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findById')->once()->with($principalIdentifier)->andReturn(null);
+
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(WikiHistoryRepositoryInterface::class, Mockery::mock(WikiHistoryRepositoryInterface::class));
+        $this->app->instance(WikiHistoryFactoryInterface::class, Mockery::mock(WikiHistoryFactoryInterface::class));
+
+        $this->expectException(PrincipalNotFoundException::class);
+        $this->app->make(WithdrawWikiInterface::class)->process($input, new WithdrawWikiOutput());
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws InvalidStatusException
+     * @throws PrincipalNotFoundException
+     */
+    public function testProcessDisallowedByPolicy(): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $draftWiki = $this->createDraftWiki(ApprovalStatus::UnderReview, $principalIdentifier);
+        $input = $this->createInput($draftWiki->wikiIdentifier(), $principalIdentifier);
+
+        $this->bindRepositoriesForPolicyResult($draftWiki, $principalIdentifier, false);
+
+        $this->expectException(DisallowedException::class);
+        $this->app->make(WithdrawWikiInterface::class)->process($input, new WithdrawWikiOutput());
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testProcessPendingIsInvalidStatus(): void
+    {
+        $this->assertInvalidStatus(ApprovalStatus::Pending);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testProcessRejectedIsInvalidStatus(): void
+    {
+        $this->assertInvalidStatus(ApprovalStatus::Rejected);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testProcessApprovedIsInvalidStatus(): void
+    {
+        $this->assertInvalidStatus(ApprovalStatus::Approved);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    private function assertInvalidStatus(ApprovalStatus $status): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $draftWiki = $this->createDraftWiki($status, $principalIdentifier);
+        $input = $this->createInput($draftWiki->wikiIdentifier(), $principalIdentifier);
+
+        $this->bindRepositoriesForPolicyResult($draftWiki, $principalIdentifier, true);
+
+        $this->expectException(InvalidStatusException::class);
+        $this->app->make(WithdrawWikiInterface::class)->process($input, new WithdrawWikiOutput());
+    }
+
+    private function bindRepositoriesForPolicyResult(
+        DraftWiki $draftWiki,
+        PrincipalIdentifier $principalIdentifier,
+        bool $isAllowed,
+        bool $expectSave = false,
+        ?WikiHistory $history = null,
+    ): void {
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+        $draftWikiRepository->shouldReceive('findById')->once()->with($draftWiki->wikiIdentifier())->andReturn($draftWiki);
+        if ($expectSave) {
+            $draftWikiRepository->shouldReceive('save')->once()->with($draftWiki)->andReturn(null);
+        } else {
+            $draftWikiRepository->shouldNotReceive('save');
+        }
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findById')->once()->with($principalIdentifier)->andReturn($principal);
+
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')
+            ->once()
+            ->with(
+                $principal,
+                Action::WITHDRAW,
+                Mockery::on(static fn (Resource $resource): bool => $resource->editorId() === (string) $draftWiki->editorIdentifier()),
+            )
+            ->andReturn($isAllowed);
+
+        $wikiHistoryFactory = Mockery::mock(WikiHistoryFactoryInterface::class);
+        $wikiHistoryRepository = Mockery::mock(WikiHistoryRepositoryInterface::class);
+        if ($history !== null) {
+            $wikiHistoryFactory->shouldReceive('create')
+                ->once()
+                ->with(
+                    HistoryActionType::DraftStatusChange,
+                    $principalIdentifier,
+                    $draftWiki->editorIdentifier(),
+                    $draftWiki->publishedWikiIdentifier(),
+                    Mockery::type(DraftWikiIdentifier::class),
+                    ApprovalStatus::UnderReview,
+                    ApprovalStatus::Pending,
+                    null,
+                    null,
+                    $draftWiki->basic()->name(),
+                )
+                ->andReturn($history);
+            $wikiHistoryRepository->shouldReceive('save')->once()->with($history)->andReturn(null);
+        } else {
+            $wikiHistoryFactory->shouldNotReceive('create');
+            $wikiHistoryRepository->shouldNotReceive('save');
+        }
+
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(PolicyEvaluatorInterface::class, $policyEvaluator);
+        $this->app->instance(WikiHistoryFactoryInterface::class, $wikiHistoryFactory);
+        $this->app->instance(WikiHistoryRepositoryInterface::class, $wikiHistoryRepository);
+    }
+
+    private function createInput(DraftWikiIdentifier $wikiIdentifier, PrincipalIdentifier $principalIdentifier): WithdrawWikiInput
+    {
+        return new WithdrawWikiInput(
+            $wikiIdentifier,
+            $principalIdentifier,
+            ResourceType::GROUP,
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            [],
+            [],
+        );
+    }
+
+    private function createDraftWiki(ApprovalStatus $status, ?PrincipalIdentifier $editorIdentifier): DraftWiki
+    {
+        return new DraftWiki(
+            new DraftWikiIdentifier(StrTestHelper::generateUuid()),
+            new WikiIdentifier(StrTestHelper::generateUuid()),
+            new TranslationSetIdentifier(StrTestHelper::generateUuid()),
+            new Slug('gr-twice-' . StrTestHelper::generateSmallAlphaStr(8)),
+            Language::KOREAN,
+            ResourceType::GROUP,
+            new GroupBasic(
+                name: new Name('TWICE'),
+                normalizedName: 'twice',
+                agencyIdentifier: null,
+                groupType: null,
+                status: null,
+                generation: null,
+                debutDate: null,
+                disbandDate: null,
+                fandomName: new FandomName('ONCE'),
+                officialColors: [],
+                emoji: new Emoji(''),
+                representativeSymbol: new RepresentativeSymbol(''),
+            ),
+            new SectionContentCollection(),
+            new Color('#FF5733'),
+            $status,
+            $editorIdentifier,
+            editedAt: new DateTimeImmutable(),
+        );
+    }
+
+    private function createHistory(
+        DraftWiki $draftWiki,
+        PrincipalIdentifier $actorIdentifier,
+        ApprovalStatus $fromStatus,
+        ApprovalStatus $toStatus,
+    ): WikiHistory {
+        return new WikiHistory(
+            new WikiHistoryIdentifier(StrTestHelper::generateUuid()),
+            HistoryActionType::DraftStatusChange,
+            $actorIdentifier,
+            $draftWiki->editorIdentifier(),
+            $draftWiki->publishedWikiIdentifier(),
+            new DraftWikiIdentifier((string) $draftWiki->wikiIdentifier()),
+            $fromStatus,
+            $toStatus,
+            null,
+            null,
+            $draftWiki->basic()->name(),
+            new DateTimeImmutable(),
+        );
+    }
+}

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -416,6 +416,14 @@ interface WikiOperations {
   ): CreateDraftWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
+  @route("/{wikiId}/withdraw")
+  @doc("Withdraw a wiki draft review request.")
+  withdrawWiki(
+    @path wikiId: Uuid,
+    @body body: WikiWorkflowRequestBody,
+  ): CreateDraftWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
   @route("/{wikiId}/translate")
   @doc("Translate a wiki draft into additional languages.")
   translateWiki(


### PR DESCRIPTION
## 📝 変更内容

Draft Wiki のレビュー申請を取り下げるユースケースと API を追加しました。

- `POST /wiki/{wikiId}/withdraw` を追加
- `under_review` の Draft Wiki を `pending` に戻す `WithdrawWiki` ユースケースを追加
- `Action::WITHDRAW` を追加し、Policy 評価で取り下げ権限を判定
- ステータス変更履歴を保存
- TypeSpec / OpenAPI を更新
- UseCase / Input / Output / Policy 評価のテストを追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

レビュー申請後に作成者が内容修正や申請取り消しを行えるようにするため、申請中の Draft Wiki を未申請状態へ戻す操作を追加しました。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

### 動作確認

未実施

## 🔍 レビューのポイント

- `WithdrawWiki` のステータス遷移が `under_review -> pending` のみに制限されていること
- Policy 評価に `Action::WITHDRAW` と `Resource.editorId` が渡されていること
- Draft Wiki のステータス変更履歴が保存されていること
- TypeSpec / OpenAPI / route / DI binding が実装と整合していること

## 📖 関連情報

### 関連Issue・タスク

Closes #401

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
