### PR TITLE
Draft Wiki削除時のresourceType要求を除去

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/DeleteWiki/DeleteWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/DeleteWiki/DeleteWikiAction.php
@@ -16,7 +16,6 @@ use Psr\Log\LoggerInterface;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\DeleteWiki\DeleteWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\DeleteWiki\DeleteWikiInterface;
@@ -45,7 +44,6 @@ readonly class DeleteWikiAction
                 $input = new DeleteWikiInput(
                     new DraftWikiIdentifier($request->wikiId()),
                     $this->wikiContext->principalIdentifier,
-                    ResourceType::from($request->resourceType()),
                     $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
                     array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
                     array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),

--- a/application/Http/Action/Wiki/Wiki/Command/DeleteWiki/DeleteWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/DeleteWiki/DeleteWikiRequest.php
@@ -29,7 +29,6 @@ class DeleteWikiRequest extends FormRequest
     {
         return [
             'wikiId' => ['required', 'uuid'],
-            'resourceType' => ['required', 'string'],
             'agencyIdentifier' => ['nullable', 'uuid'],
             'groupIdentifiers' => ['nullable', 'array'],
             'groupIdentifiers.*' => ['uuid'],
@@ -41,11 +40,6 @@ class DeleteWikiRequest extends FormRequest
     public function wikiId(): string
     {
         return (string) $this->route('wikiId');
-    }
-
-    public function resourceType(): string
-    {
-        return (string) $this->input('resourceType');
     }
 
     public function agencyIdentifier(): ?string

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1662,11 +1662,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WikiWorkflowRequestBody'
+              $ref: '#/components/schemas/DeleteWikiRequestBody'
   /wiki/{wikiId}/approve:
     post:
       operationId: WikiOperations_approveWiki
@@ -2570,6 +2570,11 @@ components:
           type: boolean
           description: Whether the principal is enabled.
       description: Summary of a newly created principal.
+    DeleteWikiRequestBody:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/WikiAssociationTargets'
+      description: Request body for deleting a wiki draft.
     DraftImageListItem:
       type: object
       required:

--- a/src/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWiki.php
@@ -38,7 +38,7 @@ readonly class DeleteWiki implements DeleteWikiInterface
         }
 
         $resource = new Resource(
-            type: $input->resourceType(),
+            type: $wiki->resourceType(),
             agencyId: $input->agencyIdentifier() ? (string) $input->agencyIdentifier() : null,
             groupIds: array_map(
                 static fn (WikiIdentifier $id) => (string) $id,

--- a/src/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiInput.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Application\UseCase\Command\DeleteWiki;
 
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
@@ -18,7 +17,6 @@ readonly class DeleteWikiInput implements DeleteWikiInputPort
     public function __construct(
         private DraftWikiIdentifier $wikiIdentifier,
         private PrincipalIdentifier $principalIdentifier,
-        private ResourceType $resourceType,
         private ?WikiIdentifier $agencyIdentifier = null,
         private array $groupIdentifiers = [],
         private array $talentIdentifiers = [],
@@ -33,11 +31,6 @@ readonly class DeleteWikiInput implements DeleteWikiInputPort
     public function principalIdentifier(): PrincipalIdentifier
     {
         return $this->principalIdentifier;
-    }
-
-    public function resourceType(): ResourceType
-    {
-        return $this->resourceType;
     }
 
     public function agencyIdentifier(): ?WikiIdentifier

--- a/src/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiInputPort.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Application\UseCase\Command\DeleteWiki;
 
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
@@ -14,8 +13,6 @@ interface DeleteWikiInputPort
     public function wikiIdentifier(): DraftWikiIdentifier;
 
     public function principalIdentifier(): PrincipalIdentifier;
-
-    public function resourceType(): ResourceType;
 
     public function agencyIdentifier(): ?WikiIdentifier;
 

--- a/tests/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiInputTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Wiki\Wiki\Application\UseCase\Command\DeleteWiki;
 
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\UseCase\Command\DeleteWiki\DeleteWikiInput;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
@@ -18,7 +17,6 @@ class DeleteWikiInputTest extends TestCase
     {
         $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $resourceType = ResourceType::GROUP;
         $agencyIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
         $groupIdentifiers = [new WikiIdentifier(StrTestHelper::generateUuid())];
         $talentIdentifiers = [new WikiIdentifier(StrTestHelper::generateUuid())];
@@ -26,7 +24,6 @@ class DeleteWikiInputTest extends TestCase
         $input = new DeleteWikiInput(
             $wikiIdentifier,
             $principalIdentifier,
-            $resourceType,
             $agencyIdentifier,
             $groupIdentifiers,
             $talentIdentifiers,
@@ -34,7 +31,6 @@ class DeleteWikiInputTest extends TestCase
 
         $this->assertSame($wikiIdentifier, $input->wikiIdentifier());
         $this->assertSame($principalIdentifier, $input->principalIdentifier());
-        $this->assertSame($resourceType, $input->resourceType());
         $this->assertSame($agencyIdentifier, $input->agencyIdentifier());
         $this->assertSame($groupIdentifiers, $input->groupIdentifiers());
         $this->assertSame($talentIdentifiers, $input->talentIdentifiers());

--- a/tests/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiTest.php
@@ -247,7 +247,8 @@ class DeleteWikiTest extends TestCase
             ->with(
                 $principal,
                 Action::DELETE,
-                Mockery::on(static fn (Resource $resource): bool => $resource->editorId() === (string) $draftWiki->editorIdentifier()),
+                Mockery::on(static fn (Resource $resource): bool => $resource->type() === $draftWiki->resourceType()
+                    && $resource->editorId() === (string) $draftWiki->editorIdentifier()),
             )
             ->andReturn($isAllowed);
 
@@ -261,7 +262,6 @@ class DeleteWikiTest extends TestCase
         return new DeleteWikiInput(
             $wikiIdentifier,
             $principalIdentifier,
-            ResourceType::GROUP,
             new WikiIdentifier(StrTestHelper::generateUuid()),
             [],
             [],

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -53,6 +53,9 @@ model WikiWorkflowRequestBody extends WikiAssociationTargets {
   resourceType: string;
 }
 
+@doc("Request body for deleting a wiki draft.")
+model DeleteWikiRequestBody extends WikiAssociationTargets {}
+
 @doc("Request body for rolling back a wiki to a previous version.")
 model RollbackWikiRequestBody extends WikiAssociationTargets {
   @doc("Resource type that the wiki belongs to.")
@@ -356,7 +359,7 @@ interface WikiOperations {
   @doc("Delete a wiki draft.")
   deleteWiki(
     @path wikiId: Uuid,
-    @body body: WikiWorkflowRequestBody,
+    @body body?: DeleteWikiRequestBody,
   ): KPool.Common.NoContentResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post


### PR DESCRIPTION
## 📝 変更内容

Draft Wiki 削除 API で `resourceType` をリクエスト必須にしないよう修正しました。

- `DeleteWikiRequest` から `resourceType` 必須バリデーションを削除
- `DeleteWikiInput` / `DeleteWikiInputPort` から `resourceType` を削除
- Policy 評価時の `Resource.type` は削除対象の Draft Wiki から取得
- DELETE API の TypeSpec / OpenAPI を更新し、requestBody を任意化
- 関連テストを更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

DELETE リクエストで body が送られない場合に `resourceType` 必須バリデーションで 422 になるため修正しました。

削除対象の Draft Wiki は `wikiId` から取得でき、`resourceType` も Draft Wiki 自身が保持しているため、クライアントから受け取らずサーバ側で取得する形にしています。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi` を実行し、OpenAPI生成が成功することを確認
- [x] `task test-no-db filter=DeleteWiki` を実行し、関連テストがパスすることを確認
- [x] `task phpstan` を実行し、静的解析がパスすることを確認
- [x] `git diff --check` を実行し、空白エラーがないことを確認
- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

未実施

## 🔍 レビューのポイント

- `DeleteWiki` の Policy 評価で Draft Wiki 自身の `resourceType` を使っていること
- DELETE API の requestBody が任意になっていること
- `resourceType` を要求しなくても既存の削除権限評価が維持されていること

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
