### PR TITLE
fix: Draft Wikiレビュー取り下げ時のresourceType要求を除去

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiAction.php
@@ -17,7 +17,6 @@ use Psr\Log\LoggerInterface;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInput;
 use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInterface;
@@ -47,7 +46,6 @@ readonly class WithdrawWikiAction
                 $input = new WithdrawWikiInput(
                     new DraftWikiIdentifier($request->wikiId()),
                     $this->wikiContext->principalIdentifier,
-                    ResourceType::from($request->resourceType()),
                     $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,
                     array_map(static fn (string $id) => new WikiIdentifier($id), $request->groupIdentifiers()),
                     array_map(static fn (string $id) => new WikiIdentifier($id), $request->talentIdentifiers()),

--- a/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/WithdrawWiki/WithdrawWikiRequest.php
@@ -29,7 +29,6 @@ class WithdrawWikiRequest extends FormRequest
     {
         return [
             'wikiId' => ['required', 'uuid'],
-            'resourceType' => ['required', 'string'],
             'agencyIdentifier' => ['nullable', 'uuid'],
             'groupIdentifiers' => ['nullable', 'array'],
             'groupIdentifiers.*' => ['uuid'],
@@ -41,11 +40,6 @@ class WithdrawWikiRequest extends FormRequest
     public function wikiId(): string
     {
         return (string) $this->route('wikiId');
-    }
-
-    public function resourceType(): string
-    {
-        return (string) $this->input('resourceType');
     }
 
     public function agencyIdentifier(): ?string

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2133,11 +2133,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WikiWorkflowRequestBody'
+              $ref: '#/components/schemas/WithdrawWikiRequestBody'
   /wikis/version-inconsistencies:
     get:
       operationId: WikiListOperations_listVersionInconsistentWikis
@@ -4452,6 +4452,11 @@ components:
       allOf:
         - $ref: '#/components/schemas/WikiAssociationTargets'
       description: Request body for wiki workflow actions.
+    WithdrawWikiRequestBody:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/WikiAssociationTargets'
+      description: Request body for withdrawing a wiki draft review request.
 servers:
   - url: /api/wiki
     description: Laravel route prefix from bootstrap/app.php.

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWiki.php
@@ -51,7 +51,7 @@ readonly class WithdrawWiki implements WithdrawWikiInterface
         }
 
         $resource = new Resource(
-            type: $input->resourceType(),
+            type: $wiki->resourceType(),
             agencyId: $input->agencyIdentifier() ? (string) $input->agencyIdentifier() : null,
             groupIds: array_map(
                 static fn (WikiIdentifier $id) => (string) $id,

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInput.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
 
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
@@ -18,7 +17,6 @@ readonly class WithdrawWikiInput implements WithdrawWikiInputPort
     public function __construct(
         private DraftWikiIdentifier $wikiIdentifier,
         private PrincipalIdentifier $principalIdentifier,
-        private ResourceType        $resourceType,
         private ?WikiIdentifier     $agencyIdentifier = null,
         private array               $groupIdentifiers = [],
         private array               $talentIdentifiers = [],
@@ -33,11 +31,6 @@ readonly class WithdrawWikiInput implements WithdrawWikiInputPort
     public function principalIdentifier(): PrincipalIdentifier
     {
         return $this->principalIdentifier;
-    }
-
-    public function resourceType(): ResourceType
-    {
-        return $this->resourceType;
     }
 
     public function agencyIdentifier(): ?WikiIdentifier

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputPort.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
 
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
@@ -14,8 +13,6 @@ interface WithdrawWikiInputPort
     public function wikiIdentifier(): DraftWikiIdentifier;
 
     public function principalIdentifier(): PrincipalIdentifier;
-
-    public function resourceType(): ResourceType;
 
     public function agencyIdentifier(): ?WikiIdentifier;
 

--- a/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiInputTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki;
 
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Source\Wiki\Wiki\Application\UseCase\Command\WithdrawWiki\WithdrawWikiInput;
 use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
@@ -18,7 +17,6 @@ class WithdrawWikiInputTest extends TestCase
     {
         $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $resourceType = ResourceType::GROUP;
         $agencyIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
         $groupIdentifiers = [new WikiIdentifier(StrTestHelper::generateUuid())];
         $talentIdentifiers = [new WikiIdentifier(StrTestHelper::generateUuid())];
@@ -26,7 +24,6 @@ class WithdrawWikiInputTest extends TestCase
         $input = new WithdrawWikiInput(
             $wikiIdentifier,
             $principalIdentifier,
-            $resourceType,
             $agencyIdentifier,
             $groupIdentifiers,
             $talentIdentifiers,
@@ -34,7 +31,6 @@ class WithdrawWikiInputTest extends TestCase
 
         $this->assertSame((string) $wikiIdentifier, (string) $input->wikiIdentifier());
         $this->assertSame($principalIdentifier, $input->principalIdentifier());
-        $this->assertSame($resourceType->value, $input->resourceType()->value);
         $this->assertSame((string) $agencyIdentifier, (string) $input->agencyIdentifier());
         $this->assertSame($groupIdentifiers, $input->groupIdentifiers());
         $this->assertSame($talentIdentifiers, $input->talentIdentifiers());
@@ -44,17 +40,14 @@ class WithdrawWikiInputTest extends TestCase
     {
         $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $resourceType = ResourceType::GROUP;
 
         $input = new WithdrawWikiInput(
             $wikiIdentifier,
             $principalIdentifier,
-            $resourceType,
         );
 
         $this->assertSame((string) $wikiIdentifier, (string) $input->wikiIdentifier());
         $this->assertSame($principalIdentifier, $input->principalIdentifier());
-        $this->assertSame($resourceType->value, $input->resourceType()->value);
         $this->assertNull($input->agencyIdentifier());
         $this->assertSame([], $input->groupIdentifiers());
         $this->assertSame([], $input->talentIdentifiers());

--- a/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiTest.php
@@ -231,7 +231,8 @@ class WithdrawWikiTest extends TestCase
             ->with(
                 $principal,
                 Action::WITHDRAW,
-                Mockery::on(static fn (Resource $resource): bool => $resource->editorId() === (string) $draftWiki->editorIdentifier()),
+                Mockery::on(static fn (Resource $resource): bool => $resource->type() === $draftWiki->resourceType()
+                    && $resource->editorId() === (string) $draftWiki->editorIdentifier()),
             )
             ->andReturn($isAllowed);
 
@@ -271,7 +272,6 @@ class WithdrawWikiTest extends TestCase
         return new WithdrawWikiInput(
             $wikiIdentifier,
             $principalIdentifier,
-            ResourceType::GROUP,
             new WikiIdentifier(StrTestHelper::generateUuid()),
             [],
             [],

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -56,6 +56,9 @@ model WikiWorkflowRequestBody extends WikiAssociationTargets {
 @doc("Request body for deleting a wiki draft.")
 model DeleteWikiRequestBody extends WikiAssociationTargets {}
 
+@doc("Request body for withdrawing a wiki draft review request.")
+model WithdrawWikiRequestBody extends WikiAssociationTargets {}
+
 @doc("Request body for rolling back a wiki to a previous version.")
 model RollbackWikiRequestBody extends WikiAssociationTargets {
   @doc("Resource type that the wiki belongs to.")
@@ -423,7 +426,7 @@ interface WikiOperations {
   @doc("Withdraw a wiki draft review request.")
   withdrawWiki(
     @path wikiId: Uuid,
-    @body body: WikiWorkflowRequestBody,
+    @body body?: WithdrawWikiRequestBody,
   ): CreateDraftWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post


### PR DESCRIPTION
## 📝 変更内容

Draft Wikiレビュー申請取り下げAPIで、リクエストBodyの `resourceType` を不要にしました。

- `WithdrawWikiRequest` の `resourceType` バリデーションとアクセサを削除
- `WithdrawWikiInput` / `WithdrawWikiInputPort` から `resourceType` を削除
- 権限判定用の `Resource` には、入力値ではなく取得済みDraft Wikiの `resourceType` を使用
- TypeSpec / OpenAPIで取り下げ専用の `WithdrawWikiRequestBody` を追加し、requestBodyを任意に変更
- 関連ユースケーステストを更新

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

Draft Wikiレビュー申請取り下げ時に、対象Draft Wikiからresource typeを取得できるにもかかわらず、クライアントに `resourceType` の指定を要求していました。
入力必須項目を減らし、既存のDraft Wiki情報に基づいて権限判定を行うようにします。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 既存のテストが壊れていないことを確認

`task check` 実行結果:
- PHP CS Fixer: OK（修正なし）
- PHPStan: OK
- Test: `testing_db` 起動時に `0.0.0.0:5433` が使用中のため失敗

## 🔍 レビューのポイント

- 取り下げ時の権限判定で、リクエスト由来ではなくDraft Wiki由来の `resourceType` を使っていること
- TypeSpec / OpenAPI上で、取り下げAPIのrequestBodyが任意になっていること
- `resourceType` 削除に伴うInputPort・テスト更新に漏れがないこと

## ⚠️ 注意事項

マイグレーションや破壊的変更はありません。
ただしAPIリクエスト仕様として、取り下げ時の `resourceType` は不要になります。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
