### PR TITLE
fix: レビュー中Draft Wiki編集を拒否

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
@@ -6,6 +6,7 @@ namespace Application\Http\Action\Wiki\Wiki\Command\EditWiki;
 
 use Application\Http\Action\Wiki\Wiki\Command\Support\WikiCommandPayloadMapper;
 use Application\Http\Context\WikiContext;
+use Application\Http\Exceptions\ConflictHttpException;
 use Application\Http\Exceptions\ForbiddenHttpException;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
 use Application\Http\Exceptions\NotFoundHttpException;
@@ -15,6 +16,7 @@ use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
@@ -84,6 +86,11 @@ readonly class EditWikiAction
                 $this->logger->error((string) $e);
 
                 throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (InvalidStatusException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new ConflictHttpException(detail: error_message('invalid_status', $language), previous: $e);
             } catch (PrincipalNotFoundException $e) {
                 DB::rollBack();
                 $this->logger->error((string) $e);
@@ -95,7 +102,7 @@ readonly class EditWikiAction
 
                 throw $e;
             }
-        } catch (NotFoundHttpException|ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+        } catch (NotFoundHttpException|ForbiddenHttpException|ConflictHttpException|UnprocessableEntityHttpException $e) {
             $this->logger->error((string) $e);
 
             return response()->json($e->toProblemDetails(), $e->getHttpStatus());

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWiki.php
@@ -8,8 +8,10 @@ use DateTimeImmutable;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\Action;
+use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Domain\Repository\DraftWikiRepositoryInterface;
@@ -30,6 +32,7 @@ readonly class EditWiki implements EditWikiInterface
      * @return void
      * @throws WikiNotFoundException
      * @throws DisallowedException
+     * @throws InvalidStatusException
      * @throws PrincipalNotFoundException
      */
     public function process(EditWikiInputPort $input, EditWikiOutputPort $output): void
@@ -60,6 +63,11 @@ readonly class EditWiki implements EditWikiInterface
 
         if (! $this->policyEvaluator->evaluate($principal, Action::EDIT, $resource)) {
             throw new DisallowedException();
+        }
+
+        if ($wiki->status() !== ApprovalStatus::Pending
+            && $wiki->status() !== ApprovalStatus::Rejected) {
+            throw new InvalidStatusException();
         }
 
         $wiki->setBasic($input->basic());

--- a/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
@@ -11,6 +11,7 @@ readonly class DraftWikiReadModel
     private string $slug;
     private string $language;
     private string $resourceType;
+    private ?string $status;
     private ?string $themeColor;
     /** @var array<string, mixed> */
     private array $heroImage;
@@ -33,12 +34,14 @@ readonly class DraftWikiReadModel
         array $heroImage,
         array|WikiBasicReadModel $basic,
         array $sections,
+        ?string $status = null,
     ) {
         $this->wikiIdentifier = $wikiIdentifier;
         $this->translationSetIdentifier = $translationSetIdentifier;
         $this->slug = $slug;
         $this->language = $language;
         $this->resourceType = $resourceType;
+        $this->status = $status;
         $this->themeColor = $themeColor;
         $this->heroImage = $heroImage;
         $this->basic = is_array($basic) ? match ($resourceType) {
@@ -74,6 +77,11 @@ readonly class DraftWikiReadModel
     public function resourceType(): string
     {
         return $this->resourceType;
+    }
+
+    public function status(): ?string
+    {
+        return $this->status;
     }
 
     public function themeColor(): ?string
@@ -115,6 +123,7 @@ readonly class DraftWikiReadModel
             'slug' => $this->slug,
             'language' => $this->language,
             'resourceType' => $this->resourceType,
+            'status' => $this->status,
             'themeColor' => $this->themeColor,
             'heroImage' => $this->heroImage,
             'basic' => $this->basic->toArray(),

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
@@ -61,6 +61,7 @@ readonly class GetAgencyDraftWiki implements GetAgencyDraftWikiInterface
                 socialLinks: $basic->social_links,
             ),
             sections: $this->sectionsWithImages($model->sections),
+            status: $model->status,
         );
     }
 

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
@@ -66,6 +66,7 @@ readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
                 representativeSymbol: $basic->representative_symbol,
             ),
             sections: $this->sectionsWithImages($model->sections),
+            status: $model->status,
         );
     }
 

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
@@ -70,6 +70,7 @@ readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
                 talents: $basic->talents->map(fn (WikiModel $talent) => $this->talentSummary($talent))->values()->all(),
             ),
             sections: $this->sectionsWithImages($model->sections),
+            status: $model->status,
         );
     }
 

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
@@ -72,6 +72,7 @@ readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
                 groups: $basic->groups->map(fn (WikiModel $group) => $this->groupSummary($group))->values()->all(),
             ),
             sections: $this->sectionsWithImages($model->sections),
+            status: $model->status,
         );
     }
 

--- a/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiTest.php
@@ -13,6 +13,7 @@ use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Shared\Domain\ValueObject\ApprovalStatus;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
@@ -332,11 +333,89 @@ class EditWikiTest extends TestCase
     }
 
     /**
+     * 異常系：レビュー中のDraftWikiを編集しようとした場合、例外がスローされること.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testUnderReviewIsInvalidStatus(): void
+    {
+        $this->assertInvalidStatus(ApprovalStatus::UnderReview);
+    }
+
+    /**
+     * 異常系：承認済みのDraftWikiを編集しようとした場合、例外がスローされること.
+     *
+     * @return void
+     * @throws BindingResolutionException
+     * @throws WikiNotFoundException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function testApprovedIsInvalidStatus(): void
+    {
+        $this->assertInvalidStatus(ApprovalStatus::Approved);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     * @throws WikiNotFoundException
+     */
+    private function assertInvalidStatus(ApprovalStatus $status): void
+    {
+        $testData = $this->createDummyEditWiki($status);
+
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+
+        $input = new EditWikiInput(
+            $testData->wikiIdentifier,
+            $testData->basic,
+            $testData->sections,
+            $testData->themeColor,
+            $principalIdentifier,
+            $testData->resourceType,
+            $testData->agencyIdentifier,
+            $testData->groupIdentifiers,
+            $testData->talentIdentifiers,
+        );
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findById')
+            ->with($principalIdentifier)
+            ->once()
+            ->andReturn($principal);
+
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->once()->andReturn(true);
+
+        $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
+        $draftWikiRepository->shouldReceive('findById')
+            ->once()
+            ->with($testData->wikiIdentifier)
+            ->andReturn($testData->draftWiki);
+        $draftWikiRepository->shouldNotReceive('save');
+
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(PolicyEvaluatorInterface::class, $policyEvaluator);
+        $this->app->instance(DraftWikiRepositoryInterface::class, $draftWikiRepository);
+
+        $this->expectException(InvalidStatusException::class);
+        $editWiki = $this->app->make(EditWikiInterface::class);
+        $editWiki->process($input, new EditWikiOutput());
+    }
+
+    /**
      * ダミーデータを作成するヘルパーメソッド
      *
      * @return EditWikiTestData
      */
-    private function createDummyEditWiki(): EditWikiTestData
+    private function createDummyEditWiki(ApprovalStatus $status = ApprovalStatus::Pending): EditWikiTestData
     {
         $wikiIdentifier = new DraftWikiIdentifier(StrTestHelper::generateUuid());
         $publishedWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
@@ -364,8 +443,6 @@ class EditWikiTest extends TestCase
         $agencyIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
         $groupIdentifiers = [];
         $talentIdentifiers = [];
-        $status = ApprovalStatus::Pending;
-
         $draftWiki = new DraftWiki(
             $wikiIdentifier,
             $publishedWikiIdentifier,

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
@@ -46,6 +46,7 @@ class DraftWikiReadModelTest extends TestCase
                     'content' => 'Draft sample for checking the TWICE group wiki editor state.',
                 ],
             ],
+            status: 'under_review',
         );
 
         $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f002', $readModel->wikiIdentifier());
@@ -53,6 +54,7 @@ class DraftWikiReadModelTest extends TestCase
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());
+        $this->assertSame('under_review', $readModel->status());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
         $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
         $this->assertInstanceOf(GroupWikiBasicReadModel::class, $readModel->basic());
@@ -64,6 +66,7 @@ class DraftWikiReadModelTest extends TestCase
             'slug' => 'gr-twice',
             'language' => 'ko',
             'resourceType' => 'group',
+            'status' => 'under_review',
             'themeColor' => '#FE5F8F',
             'heroImage' => [
                 'imageIdentifier' => null,

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
@@ -29,6 +29,7 @@ class GetGroupDraftWikiTest extends TestCase
         $this->assertSame('gr-twice', $readModel->slug());
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('group', $readModel->resourceType());
+        $this->assertSame('pending', $readModel->status());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
         $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
         $this->assertInstanceOf(GroupWikiBasicReadModel::class, $readModel->basic());

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -87,6 +87,8 @@ model DraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
+  @doc("Current workflow status of the draft wiki.")
+  status: string;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")
@@ -203,6 +205,8 @@ model TalentDraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
+  @doc("Current workflow status of the draft wiki.")
+  status: string;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")
@@ -357,6 +361,8 @@ model SongDraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
+  @doc("Current workflow status of the draft wiki.")
+  status: string;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")
@@ -425,6 +431,8 @@ model AgencyDraftWikiDetail {
   language: string;
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
+  @doc("Current workflow status of the draft wiki.")
+  status: string;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
   @doc("Hero image payload for the editor.")

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -379,7 +379,7 @@ interface WikiOperations {
   editWiki(
     @path wikiId: Uuid,
     @body body: UpdateWikiDraftRequestBody,
-  ): CreateDraftWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): CreateDraftWikiResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/{wikiId}/merge")


### PR DESCRIPTION
## 📝 変更内容

- Draft Wiki編集時に、編集可能なステータスを `pending` / `rejected` に限定
- `under_review` / `approved` のDraft Wiki編集を `InvalidStatusException` として拒否
- 編集APIで不正ステータス時に HTTP 409 Conflict を返すように変更
- Draft Wiki詳細レスポンスに `status` を追加
- TypeSpec の編集APIレスポンスに `ConflictProblemResponse` を追加
- ステータス制御とDraft Wiki詳細の `status` 出力に関するテストを追加

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🚀 新機能 (Feature)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

レビュー中または承認済みのDraft Wikiが編集できると、レビュー対象の内容や承認済み状態との整合性が崩れる可能性があるため、編集可能な状態を明示的に制限します。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`
  - CS Fixer: 修正なし
  - PHPStan: No errors
  - PHPUnit: OK (2672 tests, 8546 assertions)

## 🔍 レビューのポイント

- Draft Wiki編集可能ステータスが `pending` / `rejected` に限定されていること
- 不正ステータス時の例外がHTTP 409として返されること
- Draft Wiki詳細レスポンスの `status` 追加が各resource typeで反映されていること
- TypeSpecのレスポンス定義が実装と一致していること

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
