### PR TITLE
add: OpenAPIを再生成

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1749,6 +1749,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '409':
+          description: The request conflicts with the current state of the server.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
         '422':
           description: Client error
           content:
@@ -2312,6 +2318,7 @@ components:
         - slug
         - language
         - resourceType
+        - status
         - themeColor
         - heroImage
         - basic
@@ -2334,6 +2341,9 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
+        status:
+          type: string
+          description: Current workflow status of the draft wiki.
         themeColor:
           type: string
           nullable: true
@@ -2668,6 +2678,7 @@ components:
         - slug
         - language
         - resourceType
+        - status
         - themeColor
         - heroImage
         - basic
@@ -2690,6 +2701,9 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
+        status:
+          type: string
+          description: Current workflow status of the draft wiki.
         themeColor:
           type: string
           nullable: true
@@ -3617,6 +3631,7 @@ components:
         - slug
         - language
         - resourceType
+        - status
         - themeColor
         - heroImage
         - basic
@@ -3639,6 +3654,9 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
+        status:
+          type: string
+          description: Current workflow status of the draft wiki.
         themeColor:
           type: string
           nullable: true
@@ -3969,6 +3987,7 @@ components:
         - slug
         - language
         - resourceType
+        - status
         - themeColor
         - heroImage
         - basic
@@ -3991,6 +4010,9 @@ components:
         resourceType:
           type: string
           description: Resource type that the wiki belongs to.
+        status:
+          type: string
+          description: Current workflow status of the draft wiki.
         themeColor:
           type: string
           nullable: true


### PR DESCRIPTION
## 📝 変更内容

- Wiki Private API のOpenAPI生成物を再生成
- Draft Wiki関連スキーマに `status` を追加
- Draft Wiki編集系のレスポンスに `409 Conflict` を追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

TypeSpec定義の変更に対して、生成済みOpenAPIドキュメントを追従させるため。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi-generate` を実行し、OpenAPI生成が成功することを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `doc/openapi/KPool.WikiPrivateApi.openapi.yaml` の生成差分がTypeSpec変更内容と一致していること
- Draft Wiki関連レスポンスの `status` 追加が必要なスキーマに反映されていること
- `409 Conflict` レスポンスの追加が想定APIに反映されていること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
