### PR TITLE
fix: Wiki自動作成APIのZodスキーマ生成を修正

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2454,8 +2454,20 @@ components:
         name:
           type: string
           description: Display name of the wiki.
-      allOf:
-        - $ref: '#/components/schemas/WikiAssociationTargets'
+        agencyIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated agency identifier.
+        groupIdentifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated group identifiers.
+        talentIdentifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Associated talent identifiers.
       description: Request body for automatically creating a wiki draft.
     CreatePolicyRequestBody:
       type: object

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -24,7 +24,7 @@ model CreateWikiRequestBody extends WikiAssociationTargets {
 }
 
 @doc("Request body for automatically creating a wiki draft.")
-model AutoCreateWikiRequestBody extends WikiAssociationTargets {
+model AutoCreateWikiRequestBody {
   @doc("Resource type that the wiki belongs to.")
   resourceType: string;
   @doc("Language of the wiki.")
@@ -33,6 +33,12 @@ model AutoCreateWikiRequestBody extends WikiAssociationTargets {
   slug: string;
   @doc("Display name of the wiki.")
   name: string;
+  @doc("Associated agency identifier.")
+  agencyIdentifier?: Uuid;
+  @doc("Associated group identifiers.")
+  groupIdentifiers?: Uuid[];
+  @doc("Associated talent identifiers.")
+  talentIdentifiers?: Uuid[];
 }
 
 @doc("Request body for updating a wiki draft.")


### PR DESCRIPTION
## 📝 変更内容

- `AutoCreateWikiRequestBody` の TypeSpec 定義から `extends WikiAssociationTargets` を外し、関連 Wiki 入力フィールドを同一 model 内に明示
- 生成済み OpenAPI の `AutoCreateWikiRequestBody` から `allOf: WikiAssociationTargets` を除去
- frontend Zod schema 生成時に `resourceType` / `language` / `slug` / `name` が `AutoCreateWikiRequestBody` に含まれる形へ修正

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

PR #409 で `AutoCreateWikiRequestBody` に `slug` を追加したが、OpenAPI が `properties` と `allOf` の混在になり、frontend の `openapi-zod-client` 生成結果に反映されなかったため。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi-generate`
- [x] `git diff --check`
- [x] 一時 checkout した frontend に対して `generate_frontend_zod_schemas.sh` を実行し、`AutoCreateWikiRequestBody` に `slug` が含まれることを確認

## 🔍 レビューのポイント

- `AutoCreateWikiRequestBody` から `allOf` が消え、生成器が解釈しやすい OpenAPI になっているか
- `agencyIdentifier` / `groupIdentifiers` / `talentIdentifiers` の optional 性が維持されているか
- frontend schema 更新 workflow で差分が検出される形になっているか

## 📖 関連情報

### 関連Issue・タスク

Relates to #408

## ⚠️ 注意事項

マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
