### PR TITLE
下書きWiki自動作成でBasic情報と作成者を保存

### DIFF
--- a/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyParams.php
+++ b/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyParams.php
@@ -10,12 +10,17 @@ final readonly class GenerateAgencyParams
 {
     /**
      * @param string[] $artists
+     * @param string[] $socialLinks
      * @param SourceReference[] $sources
      */
     public function __construct(
         private ?string $alphabetName,
         private ?string $ceoName,
         private ?int $foundedYear,
+        private ?string $foundedIn,
+        private ?string $status,
+        private ?string $officialWebsite,
+        private array $socialLinks,
         private ?string $overview,
         private ?string $history,
         private array $artists,
@@ -30,12 +35,16 @@ final readonly class GenerateAgencyParams
     public static function fromArray(array $data, array $sources): self
     {
         return new self(
-            alphabetName: $data['alphabet_name'] ?? null,
-            ceoName: $data['ceo_name'] ?? null,
-            foundedYear: isset($data['founded_year']) ? (int) $data['founded_year'] : null,
-            overview: $data['overview'] ?? null,
-            history: $data['history'] ?? null,
-            artists: $data['artists'] ?? [],
+            alphabetName: self::nullableString($data['alphabet_name'] ?? null),
+            ceoName: self::nullableString($data['ceo'] ?? $data['ceo_name'] ?? null),
+            foundedYear: self::nullableInt($data['founded_year'] ?? null),
+            foundedIn: self::nullableString($data['founded_in'] ?? null),
+            status: self::nullableString($data['status'] ?? null),
+            officialWebsite: self::nullableString($data['official_website'] ?? null),
+            socialLinks: self::extractSocialLinks($data),
+            overview: self::nullableString($data['overview'] ?? null),
+            history: self::nullableString($data['history'] ?? null),
+            artists: self::stringArray($data['artists'] ?? []),
             sources: $sources,
         );
     }
@@ -46,6 +55,10 @@ final readonly class GenerateAgencyParams
             alphabetName: null,
             ceoName: null,
             foundedYear: null,
+            foundedIn: null,
+            status: null,
+            officialWebsite: null,
+            socialLinks: [],
             overview: null,
             history: null,
             artists: [],
@@ -66,6 +79,29 @@ final readonly class GenerateAgencyParams
     public function foundedYear(): ?int
     {
         return $this->foundedYear;
+    }
+
+    public function foundedIn(): ?string
+    {
+        return $this->foundedIn;
+    }
+
+    public function status(): ?string
+    {
+        return $this->status;
+    }
+
+    public function officialWebsite(): ?string
+    {
+        return $this->officialWebsite;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function socialLinks(): array
+    {
+        return $this->socialLinks;
     }
 
     public function overview(): ?string
@@ -92,5 +128,49 @@ final readonly class GenerateAgencyParams
     public function sources(): array
     {
         return $this->sources;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return string[]
+     */
+    private static function extractSocialLinks(array $data): array
+    {
+        $links = [];
+        if (is_array($data['social_links'] ?? null)) {
+            $links = array_values($data['social_links']);
+        }
+
+        foreach (['instagram_url', 'tiktok_url', 'youtube_url', 'x_url'] as $key) {
+            if (is_string($data[$key] ?? null)) {
+                $links[] = $data[$key];
+            }
+        }
+
+        return array_values(array_filter($links, static fn (mixed $link) => is_string($link) && $link !== ''));
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function stringArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $item) => is_string($item)));
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        return is_string($value) ? $value : null;
+    }
+
+    private static function nullableInt(mixed $value): ?int
+    {
+        return is_int($value) || is_float($value) || is_string($value) && is_numeric($value)
+            ? (int) $value
+            : null;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyRequest.php
@@ -79,16 +79,14 @@ Research the following agency using Wikipedia, Namuwiki, and official homepage, 
 
 ## Required Information
 1. alphabet_name: Agency name in English alphabet only (e.g., "JYP Entertainment", "SM Entertainment"). Use official English name if available, otherwise romanize the name.
-2. CEO name (representative director, CEO, etc.)
-3. Founded year (year only, e.g., 2005)
+2. ceo: CEO name (representative director, CEO, etc.) or null.
+3. founded_in: Founding date in YYYY-MM-DD format or null. If only the year is known, return YYYY-01-01.
+4. status: One of "active", "closed", "merged", "rebranded", or null.
+5. official_website: Official website URL or null.
 4. overview: Company overview (characteristics, business areas, market position) approximately 800 characters.
 5. history: Chronological description of founding, growth, and major events, approximately 1200 characters.
 6. artists: Array of currently affiliated artist/group names (max 20).
-7. Official SNS URLs (extract from external links section of Wikipedia/Namuwiki):
-   - instagram_url: Official Instagram URL (e.g., "https://www.instagram.com/jaboritory/")
-   - tiktok_url: Official TikTok URL (e.g., "https://www.tiktok.com/@jypentertainment")
-   - youtube_url: Official YouTube channel URL (e.g., "https://www.youtube.com/@JYPEntertainment")
-   - x_url: Official X(Twitter) URL (e.g., "https://x.com/jypentertainment" or "https://twitter.com/jypentertainment")
+7. social_links: Array of official HTTPS SNS URLs. Include Instagram, TikTok, YouTube, and X(Twitter) URLs when found.
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -101,6 +99,9 @@ Research the following agency using Wikipedia, Namuwiki, and official homepage, 
 - If Korean sources are insufficient, then use other language sources (English Wikipedia, etc.)
 - Use reliable sources (Wikipedia, Namuwiki, official websites)
 - If information is not found, set the field to null
+- Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
+- Dates must use YYYY-MM-DD.
+- Enum fields must use only the allowed lowercase values listed above.
 
 ## Output Format
 Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.

--- a/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupParams.php
+++ b/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupParams.php
@@ -12,10 +12,20 @@ final readonly class GenerateGroupParams
      * @param string[] $representativeSongs
      * @param string[] $awards
      * @param string[] $members
+     * @param string[] $officialColors
      * @param SourceReference[] $sources
      */
     public function __construct(
         private ?string $alphabetName,
+        private ?string $groupType,
+        private ?string $status,
+        private ?string $generation,
+        private ?string $debutDate,
+        private ?string $disbandDate,
+        private ?string $fandomName,
+        private array $officialColors,
+        private ?string $emoji,
+        private ?string $representativeSymbol,
         private ?string $overview,
         private ?string $history,
         private array $representativeSongs,
@@ -32,12 +42,21 @@ final readonly class GenerateGroupParams
     public static function fromArray(array $data, array $sources): self
     {
         return new self(
-            alphabetName: $data['alphabet_name'] ?? null,
-            overview: $data['overview'] ?? null,
-            history: $data['history'] ?? null,
-            representativeSongs: $data['representative_songs'] ?? [],
-            awards: $data['awards'] ?? [],
-            members: $data['members'] ?? [],
+            alphabetName: self::nullableString($data['alphabet_name'] ?? null),
+            groupType: self::nullableString($data['group_type'] ?? null),
+            status: self::nullableString($data['status'] ?? null),
+            generation: self::nullableString($data['generation'] ?? null),
+            debutDate: self::nullableString($data['debut_date'] ?? null),
+            disbandDate: self::nullableString($data['disband_date'] ?? null),
+            fandomName: self::nullableString($data['fandom_name'] ?? null),
+            officialColors: self::stringArray($data['official_colors'] ?? []),
+            emoji: self::nullableString($data['emoji'] ?? null),
+            representativeSymbol: self::nullableString($data['representative_symbol'] ?? null),
+            overview: self::nullableString($data['overview'] ?? null),
+            history: self::nullableString($data['history'] ?? null),
+            representativeSongs: self::stringArray($data['representative_songs'] ?? []),
+            awards: self::stringArray($data['awards'] ?? []),
+            members: self::stringArray($data['members'] ?? []),
             sources: $sources,
         );
     }
@@ -46,6 +65,15 @@ final readonly class GenerateGroupParams
     {
         return new self(
             alphabetName: null,
+            groupType: null,
+            status: null,
+            generation: null,
+            debutDate: null,
+            disbandDate: null,
+            fandomName: null,
+            officialColors: [],
+            emoji: null,
+            representativeSymbol: null,
             overview: null,
             history: null,
             representativeSongs: [],
@@ -58,6 +86,54 @@ final readonly class GenerateGroupParams
     public function alphabetName(): ?string
     {
         return $this->alphabetName;
+    }
+
+    public function groupType(): ?string
+    {
+        return $this->groupType;
+    }
+
+    public function status(): ?string
+    {
+        return $this->status;
+    }
+
+    public function generation(): ?string
+    {
+        return $this->generation;
+    }
+
+    public function debutDate(): ?string
+    {
+        return $this->debutDate;
+    }
+
+    public function disbandDate(): ?string
+    {
+        return $this->disbandDate;
+    }
+
+    public function fandomName(): ?string
+    {
+        return $this->fandomName;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function officialColors(): array
+    {
+        return $this->officialColors;
+    }
+
+    public function emoji(): ?string
+    {
+        return $this->emoji;
+    }
+
+    public function representativeSymbol(): ?string
+    {
+        return $this->representativeSymbol;
     }
 
     public function overview(): ?string
@@ -100,5 +176,22 @@ final readonly class GenerateGroupParams
     public function sources(): array
     {
         return $this->sources;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function stringArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $item) => is_string($item)));
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        return is_string($value) ? $value : null;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupRequest.php
@@ -89,17 +89,20 @@ Research the following K-POP group/artist{$agencyContext} using Wikipedia, Namuw
 
 ## Required Information
 1. alphabet_name: Group/Artist name in English alphabet only (e.g., "BTS", "BLACKPINK", "NewJeans"). Use official English name if available, otherwise romanize the name.
-2. overview: Overview of the group (concept, characteristics, agency, etc.) approximately 800 characters.
-3. history: Chronological description of formation, debut, and career milestones, approximately 1200 characters.
-4. representative_songs: Array of representative songs (max 10). Format: "Song Title (Year)". Example: "Dynamite (2020)"
-5. awards: Array of major awards (max 10). Include award name and year.
-6. members: Array of current member names (stage names).
+2. group_type: One of "boy_group", "girl_group", "co_ed", or null.
+3. status: One of "active", "disbanded", "hiatus", or null.
+4. generation: One of "1st", "2nd", "3rd", "4th", "5th", or null.
+5. debut_date: Debut date in YYYY-MM-DD format or null.
+6. disband_date: Disbandment date in YYYY-MM-DD format or null.
 7. fandom_name: Official name for the fan community (e.g., "ARMY" for BTS, "BLINK" for BLACKPINK, "Bunnies" for NewJeans). If unknown, set to null.
-8. Official SNS URLs (extract from external links section of Wikipedia/Namuwiki):
-   - instagram_url: Official Instagram URL (e.g., "https://www.instagram.com/newjeans_official/")
-   - tiktok_url: Official TikTok URL (e.g., "https://www.tiktok.com/@newjeans_official")
-   - youtube_url: Official YouTube channel URL (e.g., "https://www.youtube.com/@NewJeans_official")
-   - x_url: Official X(Twitter) URL (e.g., "https://x.com/NewJeans_ADOR" or "https://twitter.com/NewJeans_ADOR")
+8. official_colors: Array of official colors as HEX color codes (e.g., "#FF5733"). If unknown, return [].
+9. emoji: Single representative emoji string or null.
+10. representative_symbol: Representative symbol text or null.
+11. overview: Overview of the group (concept, characteristics, agency, etc.) approximately 800 characters.
+12. history: Chronological description of formation, debut, and career milestones, approximately 1200 characters.
+13. representative_songs: Array of representative songs (max 10). Format: "Song Title (Year)". Example: "Dynamite (2020)"
+14. awards: Array of major awards (max 10). Include award name and year.
+15. members: Array of current member names (stage names).
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -112,6 +115,9 @@ Research the following K-POP group/artist{$agencyContext} using Wikipedia, Namuw
 - If Korean sources are insufficient, then use other language sources (English Wikipedia, etc.)
 - Use reliable sources (Wikipedia, Namuwiki, official websites)
 - If information is not found, set the field to null
+- Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
+- Dates must use YYYY-MM-DD.
+- Enum fields must use only the allowed values listed above.
 
 ## Output Format
 Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.

--- a/application/Http/Client/GeminiClient/GenerateSong/GenerateSongParams.php
+++ b/application/Http/Client/GeminiClient/GenerateSong/GenerateSongParams.php
@@ -10,13 +10,18 @@ final readonly class GenerateSongParams
 {
     /**
      * @param string[] $chartPerformance
+     * @param string[] $genres
      * @param SourceReference[] $sources
      */
     public function __construct(
         private ?string $alphabetName,
+        private ?string $songType,
+        private array $genres,
         private ?string $lyricist,
         private ?string $composer,
+        private ?string $arranger,
         private ?string $releaseDate,
+        private ?string $albumName,
         private ?string $overview,
         private array $chartPerformance,
         private array $sources,
@@ -29,24 +34,25 @@ final readonly class GenerateSongParams
      */
     public static function fromArray(array $data, array $sources): self
     {
-        /** @var string|null $alphabetName */
-        $alphabetName = $data['alphabet_name'] ?? null;
-        /** @var string|null $lyricist */
-        $lyricist = $data['lyricist'] ?? null;
-        /** @var string|null $composer */
-        $composer = $data['composer'] ?? null;
-        /** @var string|null $releaseDate */
-        $releaseDate = $data['release_date'] ?? null;
-        /** @var string|null $overview */
-        $overview = $data['overview'] ?? null;
+        $alphabetName = self::nullableString($data['alphabet_name'] ?? null);
+        $lyricist = self::nullableString($data['lyricist'] ?? null);
+        $composer = self::nullableString($data['composer'] ?? null);
+        $arranger = self::nullableString($data['arranger'] ?? null);
+        $releaseDate = self::nullableString($data['release_date'] ?? null);
+        $albumName = self::nullableString($data['album_name'] ?? null);
+        $overview = self::nullableString($data['overview'] ?? null);
 
         return new self(
             alphabetName: $alphabetName,
+            songType: self::nullableString($data['song_type'] ?? null),
+            genres: self::stringArray($data['genres'] ?? []),
             lyricist: $lyricist,
             composer: $composer,
+            arranger: $arranger,
             releaseDate: $releaseDate,
+            albumName: $albumName,
             overview: $overview,
-            chartPerformance: $data['chart_performance'] ?? [],
+            chartPerformance: self::stringArray($data['chart_performance'] ?? []),
             sources: $sources,
         );
     }
@@ -55,9 +61,13 @@ final readonly class GenerateSongParams
     {
         return new self(
             alphabetName: null,
+            songType: null,
+            genres: [],
             lyricist: null,
             composer: null,
+            arranger: null,
             releaseDate: null,
+            albumName: null,
             overview: null,
             chartPerformance: [],
             sources: [],
@@ -67,6 +77,19 @@ final readonly class GenerateSongParams
     public function alphabetName(): ?string
     {
         return $this->alphabetName;
+    }
+
+    public function songType(): ?string
+    {
+        return $this->songType;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function genres(): array
+    {
+        return $this->genres;
     }
 
     public function lyricist(): ?string
@@ -79,9 +102,19 @@ final readonly class GenerateSongParams
         return $this->composer;
     }
 
+    public function arranger(): ?string
+    {
+        return $this->arranger;
+    }
+
     public function releaseDate(): ?string
     {
         return $this->releaseDate;
+    }
+
+    public function albumName(): ?string
+    {
+        return $this->albumName;
     }
 
     public function overview(): ?string
@@ -103,5 +136,22 @@ final readonly class GenerateSongParams
     public function sources(): array
     {
         return $this->sources;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function stringArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $item) => is_string($item)));
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        return is_string($value) ? $value : null;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateSong/GenerateSongRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateSong/GenerateSongRequest.php
@@ -99,11 +99,15 @@ Research the following K-POP song{$affiliationContext} using Wikipedia, Namuwiki
 
 ## Required Information
 1. alphabet_name: Song title in English alphabet only (e.g., "Dynamite", "Butter", "Next Level"). Use official English title if available, otherwise romanize the title.
-2. lyricist: Name of the lyricist(s) who wrote the song lyrics. If multiple writers, separate with commas. If unknown, set to null.
-3. composer: Name of the composer(s) who created the music. If multiple composers, separate with commas. If unknown, set to null.
-4. release_date: Release date in ISO 8601 format (YYYY-MM-DD, e.g., "2020-08-21"). If unknown, set to null.
-5. overview: Background, production, music style, and characteristics of the song, approximately 800 characters.
-6. chart_performance: Array of chart performance records (max 10). Format: "Chart Name - Ranking/Certification". Example: "Billboard Hot 100 - #1"
+2. song_type: One of "title_track", "b_side", "ost", "solo", "collaboration", "pre_release", or null.
+3. genres: Array using only "pop", "dance", "ballad", "rnb", "hiphop", "edm", "rock", "jazz", "acoustic".
+4. release_date: Release date in YYYY-MM-DD format (e.g., "2020-08-21"). If unknown, set to null.
+5. album_name: Album or single name as a string, or null.
+6. lyricist: Name of the lyricist(s) who wrote the song lyrics. If multiple writers, separate with commas. If unknown, set to null.
+7. composer: Name of the composer(s) who created the music. If multiple composers, separate with commas. If unknown, set to null.
+8. arranger: Name of the arranger(s). If multiple arrangers, separate with commas. If unknown, set to null.
+9. overview: Background, production, music style, and characteristics of the song, approximately 800 characters.
+10. chart_performance: Array of chart performance records (max 10). Format: "Chart Name - Ranking/Certification". Example: "Billboard Hot 100 - #1"
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -115,6 +119,9 @@ Research the following K-POP song{$affiliationContext} using Wikipedia, Namuwiki
 - If Korean sources are insufficient, then use other language sources (English Wikipedia, etc.)
 - Use reliable sources (Wikipedia, Namuwiki, official websites)
 - If information is not found, set the field to null
+- Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
+- Dates must use YYYY-MM-DD.
+- Enum fields must use only the allowed values listed above.
 
 ## Output Format
 Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.

--- a/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentParams.php
+++ b/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentParams.php
@@ -17,6 +17,15 @@ final readonly class GenerateTalentParams
         private ?string $alphabetName,
         private ?string $realName,
         private ?string $birthday,
+        private ?string $position,
+        private ?string $mbti,
+        private ?string $zodiacSign,
+        private ?string $englishLevel,
+        private ?int $height,
+        private ?string $bloodType,
+        private ?string $fandomName,
+        private ?string $emoji,
+        private ?string $representativeSymbol,
         private ?string $overview,
         private ?string $history,
         private array $appearances,
@@ -32,13 +41,22 @@ final readonly class GenerateTalentParams
     public static function fromArray(array $data, array $sources): self
     {
         return new self(
-            alphabetName: $data['alphabet_name'] ?? null,
-            realName: $data['real_name'] ?? null,
-            birthday: $data['birthday'] ?? null,
-            overview: $data['overview'] ?? null,
-            history: $data['history'] ?? null,
-            appearances: $data['appearances'] ?? [],
-            awards: $data['awards'] ?? [],
+            alphabetName: self::nullableString($data['alphabet_name'] ?? null),
+            realName: self::nullableString($data['real_name'] ?? null),
+            birthday: self::nullableString($data['birthday'] ?? null),
+            position: self::nullableString($data['position'] ?? null),
+            mbti: self::nullableString($data['mbti'] ?? null),
+            zodiacSign: self::nullableString($data['zodiac_sign'] ?? null),
+            englishLevel: self::nullableString($data['english_level'] ?? null),
+            height: self::nullableInt($data['height'] ?? null),
+            bloodType: self::nullableString($data['blood_type'] ?? null),
+            fandomName: self::nullableString($data['fandom_name'] ?? null),
+            emoji: self::nullableString($data['emoji'] ?? null),
+            representativeSymbol: self::nullableString($data['representative_symbol'] ?? null),
+            overview: self::nullableString($data['overview'] ?? null),
+            history: self::nullableString($data['history'] ?? null),
+            appearances: self::stringArray($data['appearances'] ?? []),
+            awards: self::stringArray($data['awards'] ?? []),
             sources: $sources,
         );
     }
@@ -49,6 +67,15 @@ final readonly class GenerateTalentParams
             alphabetName: null,
             realName: null,
             birthday: null,
+            position: null,
+            mbti: null,
+            zodiacSign: null,
+            englishLevel: null,
+            height: null,
+            bloodType: null,
+            fandomName: null,
+            emoji: null,
+            representativeSymbol: null,
             overview: null,
             history: null,
             appearances: [],
@@ -70,6 +97,51 @@ final readonly class GenerateTalentParams
     public function birthday(): ?string
     {
         return $this->birthday;
+    }
+
+    public function position(): ?string
+    {
+        return $this->position;
+    }
+
+    public function mbti(): ?string
+    {
+        return $this->mbti;
+    }
+
+    public function zodiacSign(): ?string
+    {
+        return $this->zodiacSign;
+    }
+
+    public function englishLevel(): ?string
+    {
+        return $this->englishLevel;
+    }
+
+    public function height(): ?int
+    {
+        return $this->height;
+    }
+
+    public function bloodType(): ?string
+    {
+        return $this->bloodType;
+    }
+
+    public function fandomName(): ?string
+    {
+        return $this->fandomName;
+    }
+
+    public function emoji(): ?string
+    {
+        return $this->emoji;
+    }
+
+    public function representativeSymbol(): ?string
+    {
+        return $this->representativeSymbol;
     }
 
     public function overview(): ?string
@@ -104,5 +176,29 @@ final readonly class GenerateTalentParams
     public function sources(): array
     {
         return $this->sources;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function stringArray(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $item) => is_string($item)));
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        return is_string($value) ? $value : null;
+    }
+
+    private static function nullableInt(mixed $value): ?int
+    {
+        return is_int($value) || is_float($value) || is_string($value) && is_numeric($value)
+            ? (int) $value
+            : null;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentRequest.php
@@ -100,19 +100,20 @@ Research the following K-POP idol/talent{$affiliationContext} using Wikipedia, N
 ## Required Information
 1. alphabet_name: Talent name in English alphabet only (e.g., "Jimin", "Lisa", "Karina"). Use official English name if available, otherwise romanize the name.
 2. real_name: Real name (birth name) of the talent in the original language (e.g., "박지민", "김제니"). If unknown, set to null.
-3. birthday: Birth date in ISO 8601 format (YYYY-MM-DD, e.g., "1995-10-13"). If unknown, set to null.
-4. overview: Introduction of the person (group affiliation, agency, position, main characteristics) approximately 800 characters.
-5. history: Chronological description of upbringing, debut, and career milestones, approximately 1200 characters.
-6. appearances: Array of appearances in works (max 10). Format: "Title (Type, Year)". Example: "Hwarang (Drama, 2016)"
-7. awards: Array of major individual awards (max 10).
-8. English proficiency:
-   - english_level: Level of English proficiency (e.g., "Native", "Fluent", "Conversational", "Basic", "None"). If unknown, set to null.
-   - english_background: Background of English ability (e.g., "Born and raised in Australia", "Studied abroad in the US for 3 years", "Self-taught"). If unknown, set to null.
-6. Personal SNS URLs (extract from external links section of Wikipedia/Namuwiki):
-   - instagram_url: Personal Instagram URL (e.g., "https://www.instagram.com/j.m/")
-   - tiktok_url: Personal TikTok URL (e.g., "https://www.tiktok.com/@j.m")
-   - youtube_url: Personal YouTube channel URL (e.g., "https://www.youtube.com/@jimin")
-   - x_url: Personal X(Twitter) URL (e.g., "https://x.com/jikiE_twt" or "https://twitter.com/jikiE_twt")
+3. birthday: Birth date in YYYY-MM-DD format (e.g., "1995-10-13"). If unknown, set to null.
+4. position: Main group position or role as a string, or null.
+5. mbti: One of "INTJ", "INTP", "ENTJ", "ENTP", "INFJ", "INFP", "ENFJ", "ENFP", "ISTJ", "ISFJ", "ESTJ", "ESFJ", "ISTP", "ISFP", "ESTP", "ESFP", or null.
+6. zodiac_sign: One of "aries", "taurus", "gemini", "cancer", "leo", "virgo", "libra", "scorpio", "sagittarius", "capricorn", "aquarius", "pisces", or null.
+7. english_level: One of "native", "fluent", "conversational", "basic", "none", or null.
+8. height: Height in centimeters as a number, or null.
+9. blood_type: One of "A", "B", "O", "AB", or null.
+10. fandom_name: Personal fandom name as a string, or null.
+11. emoji: Single representative emoji string or null.
+12. representative_symbol: Representative symbol text or null.
+13. overview: Introduction of the person (group affiliation, agency, position, main characteristics) approximately 800 characters.
+14. history: Chronological description of upbringing, debut, and career milestones, approximately 1200 characters.
+15. appearances: Array of appearances in works (max 10). Format: "Title (Type, Year)". Example: "Hwarang (Drama, 2016)"
+16. awards: Array of major individual awards (max 10).
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -125,6 +126,9 @@ Research the following K-POP idol/talent{$affiliationContext} using Wikipedia, N
 - If Korean sources are insufficient, then use other language sources (English Wikipedia, etc.)
 - Use reliable sources (Wikipedia, Namuwiki, official websites)
 - If information is not found, set the field to null
+- Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
+- Dates must use YYYY-MM-DD.
+- Enum fields must use only the allowed values listed above.
 
 ## Output Format
 Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.

--- a/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWiki.php
@@ -74,7 +74,7 @@ readonly class AutoCreateWiki implements AutoCreateWikiInterface
         $basic = $generatedBasic::fromArray($basicArray);
 
         $draftWiki = $this->draftWikiFactory->create(
-            editorIdentifier: null,
+            editorIdentifier: $input->principalIdentifier(),
             language: $payload->language(),
             basic: $basic,
             slug: $payload->slug(),

--- a/src/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationService.php
+++ b/src/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationService.php
@@ -23,10 +23,20 @@ use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
 use Source\Wiki\Wiki\Domain\Service\AutoWikiCreationServiceInterface;
 use Source\Wiki\Wiki\Domain\ValueObject\AutoWikiCreationPayload;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Agency\AgencyBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Agency\AgencyStatus;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\Generation;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupStatus;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Group\GroupType;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Song\SongBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Song\SongGenre;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Song\SongType;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\Birthday;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\BloodType;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\EnglishLevel;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\MBTI;
 use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\TalentBasic;
+use Source\Wiki\Wiki\Domain\ValueObject\Basic\Talent\ZodiacSign;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\ListBlock;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\ListType;
 use Source\Wiki\Wiki\Domain\ValueObject\Block\TextBlock;
@@ -77,7 +87,11 @@ readonly class AutoWikiCreationService implements AutoWikiCreationServiceInterfa
             'type' => 'agency',
             'name' => (string) $payload->name(),
             'ceo' => $params->ceoName() ?? '',
-            'founded_in' => $params->foundedYear() !== null ? $params->foundedYear() . '-01-01' : null,
+            'founded_in' => $this->validDate($params->foundedIn())
+                ?? ($params->foundedYear() !== null ? $params->foundedYear() . '-01-01' : null),
+            'status' => $this->allowedValue($params->status(), AgencyStatus::cases()),
+            'official_website' => $this->validHttpsUrl($params->officialWebsite()),
+            'social_links' => $this->validHttpsUrls($params->socialLinks()),
         ]);
 
         return new GeneratedWikiData(
@@ -112,6 +126,15 @@ readonly class AutoWikiCreationService implements AutoWikiCreationServiceInterfa
             'type' => 'group',
             'name' => (string) $payload->name(),
             'agency_identifier' => $payload->agencyIdentifier() !== null ? (string) $payload->agencyIdentifier() : null,
+            'group_type' => $this->allowedValue($params->groupType(), GroupType::cases()),
+            'status' => $this->allowedValue($params->status(), GroupStatus::cases()),
+            'generation' => $this->allowedValue($params->generation(), Generation::cases()),
+            'debut_date' => $this->validDate($params->debutDate()),
+            'disband_date' => $this->validDate($params->disbandDate()),
+            'fandom_name' => $params->fandomName() ?? '',
+            'official_colors' => $this->validHexColors($params->officialColors()),
+            'emoji' => $params->emoji() ?? '',
+            'representative_symbol' => $params->representativeSymbol() ?? '',
         ]);
 
         return new GeneratedWikiData(
@@ -163,6 +186,15 @@ readonly class AutoWikiCreationService implements AutoWikiCreationServiceInterfa
                 static fn (WikiIdentifier $id) => (string) $id,
                 $payload->groupIdentifiers(),
             ),
+            'emoji' => $params->emoji() ?? '',
+            'representative_symbol' => $params->representativeSymbol() ?? '',
+            'position' => $params->position() ?? '',
+            'mbti' => $this->allowedValue($params->mbti(), MBTI::cases()),
+            'zodiac_sign' => $this->allowedValue($params->zodiacSign(), ZodiacSign::cases()),
+            'english_level' => $this->allowedValue($params->englishLevel(), EnglishLevel::cases()),
+            'height' => $params->height() !== null && $params->height() > 0 ? $params->height() : null,
+            'blood_type' => $this->allowedValue($params->bloodType(), BloodType::cases()),
+            'fandom_name' => $params->fandomName() ?? '',
         ]);
 
         return new GeneratedWikiData(
@@ -220,9 +252,13 @@ readonly class AutoWikiCreationService implements AutoWikiCreationServiceInterfa
                 static fn (WikiIdentifier $id) => (string) $id,
                 $payload->talentIdentifiers(),
             ),
-            'release_date' => $params->releaseDate(),
+            'song_type' => $this->allowedValue($params->songType(), SongType::cases()),
+            'genres' => $this->allowedValues($params->genres(), SongGenre::cases()),
+            'release_date' => $this->validDate($params->releaseDate()),
+            'album_name' => $params->albumName(),
             'lyricist' => $params->lyricist() ?? '',
             'composer' => $params->composer() ?? '',
+            'arranger' => $params->arranger() ?? '',
         ]);
 
         return new GeneratedWikiData(
@@ -457,5 +493,84 @@ readonly class AutoWikiCreationService implements AutoWikiCreationServiceInterfa
             displayOrder: $displayOrder,
             contents: new SectionContentCollection([new ListBlock(displayOrder: 0, listType: ListType::BULLET, items: $items)]),
         );
+    }
+
+    /**
+     * @param array<\BackedEnum> $cases
+     */
+    private function allowedValue(?string $value, array $cases): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        foreach ($cases as $case) {
+            if ($case->value === $value) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string[] $values
+     * @param array<\BackedEnum> $cases
+     * @return string[]
+     */
+    private function allowedValues(array $values, array $cases): array
+    {
+        return array_values(array_filter(
+            $values,
+            fn (string $value) => $this->allowedValue($value, $cases) !== null,
+        ));
+    }
+
+    private function validDate(?string $value): ?string
+    {
+        if ($value === null || ! preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            return null;
+        }
+
+        try {
+            $date = new DateTimeImmutable($value);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $date->format('Y-m-d') === $value ? $value : null;
+    }
+
+    private function validHttpsUrl(?string $value): ?string
+    {
+        if ($value === null || ! str_starts_with($value, 'https://') || ! filter_var($value, FILTER_VALIDATE_URL)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string[] $values
+     * @return string[]
+     */
+    private function validHttpsUrls(array $values): array
+    {
+        return array_values(array_filter(
+            $values,
+            fn (string $value) => $this->validHttpsUrl($value) !== null,
+        ));
+    }
+
+    /**
+     * @param string[] $values
+     * @return string[]
+     */
+    private function validHexColors(array $values): array
+    {
+        return array_values(array_filter(
+            $values,
+            static fn (string $value) => preg_match('/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/', $value) === 1,
+        ));
     }
 }

--- a/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiTest.php
@@ -74,7 +74,8 @@ class AutoCreateWikiTest extends TestCase
         $repository = Mockery::mock(DraftWikiRepositoryInterface::class);
         $repository->shouldReceive('save')
             ->once()
-            ->with(Mockery::on(static fn ($draftWiki) => (string) $draftWiki->slug() === (string) $payload->slug()))
+            ->with(Mockery::on(static fn ($draftWiki) => (string) $draftWiki->slug() === (string) $payload->slug()
+                && (string) $draftWiki->editorIdentifier() === (string) $principalIdentifier))
             ->andReturn(null);
 
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);

--- a/tests/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationServiceTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationServiceTest.php
@@ -78,8 +78,11 @@ class AutoWikiCreationServiceTest extends TestCase
                             [
                                 'text' => json_encode([
                                     'alphabet_name' => 'JYP Entertainment',
-                                    'ceo_name' => 'J.Y. Park',
-                                    'founded_year' => 1997,
+                                    'ceo' => 'J.Y. Park',
+                                    'founded_in' => '1997-04-25',
+                                    'status' => 'active',
+                                    'official_website' => 'https://www.jype.com/',
+                                    'social_links' => ['https://www.youtube.com/@JYPEntertainment', 'http://invalid.example.com/'],
                                     'overview' => $overview,
                                     'history' => $history,
                                     'artists' => $artists,
@@ -130,6 +133,10 @@ class AutoWikiCreationServiceTest extends TestCase
         $basic = $result->basic();
         $this->assertSame('J.Y. Park', (string) $basic->ceo());
         $this->assertNotNull($basic->foundedIn());
+        $this->assertSame('1997-04-25', $basic->foundedIn()->format('Y-m-d'));
+        $this->assertSame('active', $basic->status()?->value);
+        $this->assertSame('https://www.jype.com/', (string) $basic->officialWebsite());
+        $this->assertSame(['https://www.youtube.com/@JYPEntertainment'], array_map('strval', $basic->socialLinks()));
 
         $this->assertFalse($result->sections()->isEmpty());
         $sections = $result->sections()->sections();
@@ -258,6 +265,15 @@ class AutoWikiCreationServiceTest extends TestCase
 
         $responseJson = $this->createGeminiResponseJson([
             'alphabet_name' => 'TWICE',
+            'group_type' => 'girl_group',
+            'status' => 'unknown',
+            'generation' => '3rd',
+            'debut_date' => '2015-10-20',
+            'disband_date' => 'invalid-date',
+            'fandom_name' => 'ONCE',
+            'official_colors' => ['#FF5FA2', 'apricot'],
+            'emoji' => '🍭',
+            'representative_symbol' => 'Candy Bong',
             'overview' => $overview,
             'history' => $history,
             'representative_songs' => $representativeSongs,
@@ -296,6 +312,15 @@ class AutoWikiCreationServiceTest extends TestCase
         /** @var GroupBasic $basic */
         $basic = $result->basic();
         $this->assertSame((string) $agencyId, (string) $basic->agencyIdentifier());
+        $this->assertSame('girl_group', $basic->groupType()?->value);
+        $this->assertNull($basic->status());
+        $this->assertSame('3rd', $basic->generation()?->value);
+        $this->assertSame('2015-10-20', $basic->debutDate()?->format('Y-m-d'));
+        $this->assertNull($basic->disbandDate());
+        $this->assertSame('ONCE', $basic->fandomName()->value());
+        $this->assertSame(['#FF5FA2'], array_map('strval', $basic->officialColors()));
+        $this->assertSame('🍭', $basic->emoji()->value());
+        $this->assertSame('Candy Bong', $basic->representativeSymbol()->value());
 
         $this->assertFalse($result->sections()->isEmpty());
         $sections = $result->sections()->sections();
@@ -484,6 +509,15 @@ class AutoWikiCreationServiceTest extends TestCase
             'alphabet_name' => 'Jimin',
             'real_name' => '박지민',
             'birthday' => '1995-10-13',
+            'position' => 'Main dancer',
+            'mbti' => 'ENFJ',
+            'zodiac_sign' => 'invalid',
+            'english_level' => 'conversational',
+            'height' => 174,
+            'blood_type' => 'A',
+            'fandom_name' => 'Jjangu',
+            'emoji' => '🐥',
+            'representative_symbol' => 'Chick',
             'overview' => $overview,
             'history' => $history,
             'appearances' => $appearances,
@@ -526,6 +560,15 @@ class AutoWikiCreationServiceTest extends TestCase
         $this->assertSame((string) $agencyId, (string) $basic->agencyIdentifier());
         $this->assertCount(1, $basic->groupIdentifiers());
         $this->assertSame((string) $groupId, (string) $basic->groupIdentifiers()[0]);
+        $this->assertSame('Main dancer', $basic->position()->value());
+        $this->assertSame('ENFJ', $basic->mbti()?->value);
+        $this->assertNull($basic->zodiacSign());
+        $this->assertSame('conversational', $basic->englishLevel()?->value);
+        $this->assertSame(174, $basic->height()?->centimeters());
+        $this->assertSame('A', $basic->bloodType()?->value);
+        $this->assertSame('Jjangu', $basic->fandomName()->value());
+        $this->assertSame('🐥', $basic->emoji()->value());
+        $this->assertSame('Chick', $basic->representativeSymbol()->value());
 
         $this->assertFalse($result->sections()->isEmpty());
         $sections = $result->sections()->sections();
@@ -765,9 +808,13 @@ class AutoWikiCreationServiceTest extends TestCase
 
         $responseJson = $this->createGeminiResponseJson([
             'alphabet_name' => 'Dynamite',
+            'song_type' => 'title_track',
+            'genres' => ['pop', 'unknown'],
             'lyricist' => 'David Stewart',
             'composer' => 'Jessica Agombar',
+            'arranger' => 'David Stewart',
             'release_date' => '2020-08-21',
+            'album_name' => 'Dynamite',
             'overview' => $overview,
             'chart_performance' => $chartPerformance,
         ], [
@@ -804,8 +851,13 @@ class AutoWikiCreationServiceTest extends TestCase
 
         /** @var SongBasic $basic */
         $basic = $result->basic();
+        $this->assertSame('title_track', $basic->songType()?->value);
+        $this->assertSame(['pop'], array_map(static fn ($genre) => $genre->value, $basic->genres()));
+        $this->assertSame('2020-08-21', $basic->releaseDate()?->format('Y-m-d'));
+        $this->assertSame('Dynamite', $basic->albumName());
         $this->assertSame('David Stewart', (string) $basic->lyricist());
         $this->assertSame('Jessica Agombar', (string) $basic->composer());
+        $this->assertSame('David Stewart', (string) $basic->arranger());
         $this->assertSame((string) $agencyId, (string) $basic->agencyIdentifier());
         $this->assertCount(1, $basic->groupIdentifiers());
         $this->assertCount(1, $basic->talentIdentifiers());


### PR DESCRIPTION
## 📝 変更内容

- 下書きWiki自動作成時に、作成者として実行ユーザーの principal identifier を保存するよう変更
- Gemini の agency / group / talent / song 生成プロンプトに Basic 情報項目を追加
- 生成レスポンスのパラメータ変換で型チェック・配列正規化を追加
- 自動生成された Basic 情報を DraftWiki に反映する処理を追加
- 不正な enum / 日付 / URL / HEX color を保存しないようバリデーションを追加
- 追加項目の保存挙動をテストで確認

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

下書きWiki自動作成で生成された Basic 情報が十分に保存されず、作成者情報も紐づいていなかったため、生成結果を DraftWiki の Basic 情報として反映できるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`
  - PHP CS Fixer: Fixed 0 files
  - PHPStan: No errors
  - PHPUnit: OK (2678 tests, 8592 assertions)

## 🔍 レビューのポイント

- Gemini 生成プロンプトの追加項目が各 Basic value object の許容値と対応しているか
- 生成レスポンスの不正値を保存せず null / 空配列に落とすバリデーション方針が妥当か
- 下書きWiki作成時の editorIdentifier に principalIdentifier を設定する変更が既存仕様と整合しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #414

## ⚠️ 注意事項

破壊的変更、マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した