### PR TITLE
fix: 自動Wiki作成の出典リンク生成を改善

### DIFF
--- a/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyRequest.php
@@ -87,6 +87,11 @@ Research the following agency using Wikipedia, Namuwiki, and official homepage, 
 5. history: Chronological description of founding, growth, and major events, approximately 1200 characters.
 6. artists: Array of currently affiliated artist/group names (max 20).
 7. social_links: Array of official HTTPS SNS URLs. Include Instagram, TikTok, YouTube, and X(Twitter) URLs when found.
+8. sources: Array of referenced pages used for this response. Each item must have:
+   - page_title: Specific page title that describes the referenced content.
+   - site_name: Website or publication name, not a search/proxy/cache host.
+   - url: Direct HTTPS URL of the referenced page.
+   - description: Short description of what information was verified from this page.
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -102,9 +107,10 @@ Research the following agency using Wikipedia, Namuwiki, and official homepage, 
 - Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
 - Dates must use YYYY-MM-DD.
 - Enum fields must use only the allowed lowercase values listed above.
+- sources must include only pages actually used for the generated information. Do not include search result URLs, proxy URLs, cache URLs, or vertexaisearch.cloud.google.com URLs.
 
 ## Output Format
-Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.
+Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above, including sources.
 PROMPT;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyResponse.php
+++ b/application/Http/Client/GeminiClient/GenerateAgency/GenerateAgencyResponse.php
@@ -6,8 +6,8 @@ namespace Application\Http\Client\GeminiClient\GenerateAgency;
 
 use Application\Http\Client\Foundation\Json\Decoder;
 use Application\Http\Client\GeminiClient\JsonContentExtractor;
+use Application\Http\Client\GeminiClient\SourceReferenceExtractor;
 use Psr\Http\Message\ResponseInterface;
-use Source\Wiki\Shared\Application\DTO\SourceReference;
 
 final readonly class GenerateAgencyResponse
 {
@@ -27,34 +27,8 @@ final readonly class GenerateAgencyResponse
         /** @var array<string, mixed> $data */
         $data = JsonContentExtractor::decodeObject($content);
 
-        $sources = $this->extractSources($responseBody);
+        $sources = (new SourceReferenceExtractor())->extract($data, $responseBody);
 
         return GenerateAgencyParams::fromArray($data, $sources);
-    }
-
-    /**
-     * @param array<string, mixed> $responseBody
-     * @return SourceReference[]
-     */
-    private function extractSources(array $responseBody): array
-    {
-        $groundingMetadata = $responseBody['candidates'][0]['groundingMetadata'] ?? [];
-        $sources = [];
-        $seenUris = [];
-
-        foreach ($groundingMetadata['groundingChunks'] ?? [] as $chunk) {
-            $uri = $chunk['web']['uri'] ?? null;
-            $title = $chunk['web']['title'] ?? null;
-
-            if ($uri !== null && ! isset($seenUris[$uri])) {
-                $sources[] = new SourceReference(
-                    uri: $uri,
-                    title: $title ?? '',
-                );
-                $seenUris[$uri] = true;
-            }
-        }
-
-        return $sources;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupRequest.php
@@ -103,6 +103,11 @@ Research the following K-POP group/artist{$agencyContext} using Wikipedia, Namuw
 13. representative_songs: Array of representative songs (max 10). Format: "Song Title (Year)". Example: "Dynamite (2020)"
 14. awards: Array of major awards (max 10). Include award name and year.
 15. members: Array of current member names (stage names).
+16. sources: Array of referenced pages used for this response. Each item must have:
+   - page_title: Specific page title that describes the referenced content.
+   - site_name: Website or publication name, not a search/proxy/cache host.
+   - url: Direct HTTPS URL of the referenced page.
+   - description: Short description of what information was verified from this page.
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -118,9 +123,10 @@ Research the following K-POP group/artist{$agencyContext} using Wikipedia, Namuw
 - Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
 - Dates must use YYYY-MM-DD.
 - Enum fields must use only the allowed values listed above.
+- sources must include only pages actually used for the generated information. Do not include search result URLs, proxy URLs, cache URLs, or vertexaisearch.cloud.google.com URLs.
 
 ## Output Format
-Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.
+Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above, including sources.
 PROMPT;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupResponse.php
+++ b/application/Http/Client/GeminiClient/GenerateGroup/GenerateGroupResponse.php
@@ -6,8 +6,8 @@ namespace Application\Http\Client\GeminiClient\GenerateGroup;
 
 use Application\Http\Client\Foundation\Json\Decoder;
 use Application\Http\Client\GeminiClient\JsonContentExtractor;
+use Application\Http\Client\GeminiClient\SourceReferenceExtractor;
 use Psr\Http\Message\ResponseInterface;
-use Source\Wiki\Shared\Application\DTO\SourceReference;
 
 final readonly class GenerateGroupResponse
 {
@@ -27,34 +27,8 @@ final readonly class GenerateGroupResponse
         /** @var array<string, mixed> $data */
         $data = JsonContentExtractor::decodeObject($content);
 
-        $sources = $this->extractSources($responseBody);
+        $sources = (new SourceReferenceExtractor())->extract($data, $responseBody);
 
         return GenerateGroupParams::fromArray($data, $sources);
-    }
-
-    /**
-     * @param array<string, mixed> $responseBody
-     * @return SourceReference[]
-     */
-    private function extractSources(array $responseBody): array
-    {
-        $groundingMetadata = $responseBody['candidates'][0]['groundingMetadata'] ?? [];
-        $sources = [];
-        $seenUris = [];
-
-        foreach ($groundingMetadata['groundingChunks'] ?? [] as $chunk) {
-            $uri = $chunk['web']['uri'] ?? null;
-            $title = $chunk['web']['title'] ?? null;
-
-            if ($uri !== null && ! isset($seenUris[$uri])) {
-                $sources[] = new SourceReference(
-                    uri: $uri,
-                    title: $title ?? '',
-                );
-                $seenUris[$uri] = true;
-            }
-        }
-
-        return $sources;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateSong/GenerateSongRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateSong/GenerateSongRequest.php
@@ -108,6 +108,11 @@ Research the following K-POP song{$affiliationContext} using Wikipedia, Namuwiki
 8. arranger: Name of the arranger(s). If multiple arrangers, separate with commas. If unknown, set to null.
 9. overview: Background, production, music style, and characteristics of the song, approximately 800 characters.
 10. chart_performance: Array of chart performance records (max 10). Format: "Chart Name - Ranking/Certification". Example: "Billboard Hot 100 - #1"
+11. sources: Array of referenced pages used for this response. Each item must have:
+   - page_title: Specific page title that describes the referenced content.
+   - site_name: Website or publication name, not a search/proxy/cache host.
+   - url: Direct HTTPS URL of the referenced page.
+   - description: Short description of what information was verified from this page.
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -122,9 +127,10 @@ Research the following K-POP song{$affiliationContext} using Wikipedia, Namuwiki
 - Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
 - Dates must use YYYY-MM-DD.
 - Enum fields must use only the allowed values listed above.
+- sources must include only pages actually used for the generated information. Do not include search result URLs, proxy URLs, cache URLs, or vertexaisearch.cloud.google.com URLs.
 
 ## Output Format
-Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.
+Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above, including sources.
 PROMPT;
     }
 

--- a/application/Http/Client/GeminiClient/GenerateSong/GenerateSongResponse.php
+++ b/application/Http/Client/GeminiClient/GenerateSong/GenerateSongResponse.php
@@ -6,8 +6,8 @@ namespace Application\Http\Client\GeminiClient\GenerateSong;
 
 use Application\Http\Client\Foundation\Json\Decoder;
 use Application\Http\Client\GeminiClient\JsonContentExtractor;
+use Application\Http\Client\GeminiClient\SourceReferenceExtractor;
 use Psr\Http\Message\ResponseInterface;
-use Source\Wiki\Shared\Application\DTO\SourceReference;
 
 final readonly class GenerateSongResponse
 {
@@ -27,36 +27,8 @@ final readonly class GenerateSongResponse
         /** @var array<string, mixed> $data */
         $data = JsonContentExtractor::decodeObject($content);
 
-        $sources = $this->extractSources($responseBody);
+        $sources = (new SourceReferenceExtractor())->extract($data, $responseBody);
 
         return GenerateSongParams::fromArray($data, $sources);
-    }
-
-    /**
-     * @param array{candidates?: array<int, array{content?: array{parts?: array<int, array{text?: string}>}, groundingMetadata?: array{groundingChunks?: array<int, array{web?: array{uri?: string, title?: string}}>}}>} $responseBody
-     * @return SourceReference[]
-     */
-    private function extractSources(array $responseBody): array
-    {
-        $groundingMetadata = $responseBody['candidates'][0]['groundingMetadata'] ?? [];
-        $sources = [];
-        /** @var array<string, bool> $seenUris */
-        $seenUris = [];
-
-        /** @var array{web?: array{uri?: string, title?: string}} $chunk */
-        foreach ($groundingMetadata['groundingChunks'] ?? [] as $chunk) {
-            $uri = $chunk['web']['uri'] ?? null;
-            $title = $chunk['web']['title'] ?? null;
-
-            if ($uri !== null && ! isset($seenUris[$uri])) {
-                $sources[] = new SourceReference(
-                    uri: $uri,
-                    title: $title ?? '',
-                );
-                $seenUris[$uri] = true;
-            }
-        }
-
-        return $sources;
     }
 }

--- a/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentRequest.php
+++ b/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentRequest.php
@@ -114,6 +114,11 @@ Research the following K-POP idol/talent{$affiliationContext} using Wikipedia, N
 14. history: Chronological description of upbringing, debut, and career milestones, approximately 1200 characters.
 15. appearances: Array of appearances in works (max 10). Format: "Title (Type, Year)". Example: "Hwarang (Drama, 2016)"
 16. awards: Array of major individual awards (max 10).
+17. sources: Array of referenced pages used for this response. Each item must have:
+   - page_title: Specific page title that describes the referenced content.
+   - site_name: Website or publication name, not a search/proxy/cache host.
+   - url: Direct HTTPS URL of the referenced page.
+   - description: Short description of what information was verified from this page.
 
 ## Constraints
 - Limit your web searches to a maximum of 5 queries
@@ -129,9 +134,10 @@ Research the following K-POP idol/talent{$affiliationContext} using Wikipedia, N
 - Do not guess uncertain values. Return null for unknown scalar values and [] for unknown arrays.
 - Dates must use YYYY-MM-DD.
 - Enum fields must use only the allowed values listed above.
+- sources must include only pages actually used for the generated information. Do not include search result URLs, proxy URLs, cache URLs, or vertexaisearch.cloud.google.com URLs.
 
 ## Output Format
-Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above.
+Return only one valid JSON object. Do not wrap it in Markdown. Use the snake_case field names listed above, including sources.
 PROMPT;
     }
 

--- a/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentResponse.php
+++ b/application/Http/Client/GeminiClient/GenerateTalent/GenerateTalentResponse.php
@@ -6,8 +6,8 @@ namespace Application\Http\Client\GeminiClient\GenerateTalent;
 
 use Application\Http\Client\Foundation\Json\Decoder;
 use Application\Http\Client\GeminiClient\JsonContentExtractor;
+use Application\Http\Client\GeminiClient\SourceReferenceExtractor;
 use Psr\Http\Message\ResponseInterface;
-use Source\Wiki\Shared\Application\DTO\SourceReference;
 
 final readonly class GenerateTalentResponse
 {
@@ -27,34 +27,8 @@ final readonly class GenerateTalentResponse
         /** @var array<string, mixed> $data */
         $data = JsonContentExtractor::decodeObject($content);
 
-        $sources = $this->extractSources($responseBody);
+        $sources = (new SourceReferenceExtractor())->extract($data, $responseBody);
 
         return GenerateTalentParams::fromArray($data, $sources);
-    }
-
-    /**
-     * @param array<string, mixed> $responseBody
-     * @return SourceReference[]
-     */
-    private function extractSources(array $responseBody): array
-    {
-        $groundingMetadata = $responseBody['candidates'][0]['groundingMetadata'] ?? [];
-        $sources = [];
-        $seenUris = [];
-
-        foreach ($groundingMetadata['groundingChunks'] ?? [] as $chunk) {
-            $uri = $chunk['web']['uri'] ?? null;
-            $title = $chunk['web']['title'] ?? null;
-
-            if ($uri !== null && ! isset($seenUris[$uri])) {
-                $sources[] = new SourceReference(
-                    uri: $uri,
-                    title: $title ?? '',
-                );
-                $seenUris[$uri] = true;
-            }
-        }
-
-        return $sources;
     }
 }

--- a/application/Http/Client/GeminiClient/SourceReferenceExtractor.php
+++ b/application/Http/Client/GeminiClient/SourceReferenceExtractor.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Client\GeminiClient;
+
+use Source\Wiki\Shared\Application\DTO\SourceReference;
+
+final readonly class SourceReferenceExtractor
+{
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, mixed> $responseBody
+     * @return SourceReference[]
+     */
+    public function extract(array $data, array $responseBody): array
+    {
+        $generatedSources = $this->extractGeneratedSources($data);
+        if ($generatedSources !== []) {
+            return $generatedSources;
+        }
+
+        return $this->extractGroundingSources($responseBody);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return SourceReference[]
+     */
+    private function extractGeneratedSources(array $data): array
+    {
+        if (! is_array($data['sources'] ?? null)) {
+            return [];
+        }
+
+        $sources = [];
+        $seenUris = [];
+        foreach ($data['sources'] as $source) {
+            if (! is_array($source)) {
+                continue;
+            }
+
+            $uri = $source['url'] ?? null;
+            if (! is_string($uri) || ! $this->isValidHttpsUrl($uri) || isset($seenUris[$uri])) {
+                continue;
+            }
+
+            $sources[] = new SourceReference(
+                uri: $uri,
+                title: $this->generatedSourceTitle($source),
+            );
+            $seenUris[$uri] = true;
+        }
+
+        return $sources;
+    }
+
+    private function isValidHttpsUrl(string $uri): bool
+    {
+        return str_starts_with($uri, 'https://') && filter_var($uri, FILTER_VALIDATE_URL) !== false;
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     */
+    private function generatedSourceTitle(array $source): string
+    {
+        $pageTitle = $source['page_title'] ?? null;
+        $siteName = $source['site_name'] ?? null;
+        $pageTitle = is_string($pageTitle) ? trim($pageTitle) : '';
+        $siteName = is_string($siteName) ? trim($siteName) : '';
+
+        return match (true) {
+            $pageTitle !== '' && $siteName !== '' => "{$pageTitle} - {$siteName}",
+            $pageTitle !== '' => $pageTitle,
+            $siteName !== '' => $siteName,
+            default => '',
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $responseBody
+     * @return SourceReference[]
+     */
+    private function extractGroundingSources(array $responseBody): array
+    {
+        $groundingMetadata = $responseBody['candidates'][0]['groundingMetadata'] ?? [];
+        $groundingChunks = is_array($groundingMetadata) && is_array($groundingMetadata['groundingChunks'] ?? null)
+            ? $groundingMetadata['groundingChunks']
+            : [];
+        $sources = [];
+        $seenUris = [];
+
+        foreach ($groundingChunks as $chunk) {
+            if (! is_array($chunk) || ! is_array($chunk['web'] ?? null)) {
+                continue;
+            }
+
+            $uri = $chunk['web']['uri'] ?? null;
+            $title = $chunk['web']['title'] ?? null;
+
+            if (is_string($uri) && $uri !== '' && ! isset($seenUris[$uri])) {
+                $sources[] = new SourceReference(
+                    uri: $uri,
+                    title: is_string($title) ? $title : '',
+                );
+                $seenUris[$uri] = true;
+            }
+        }
+
+        return $sources;
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationService.php
+++ b/src/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationService.php
@@ -483,16 +483,26 @@ readonly class AutoWikiCreationService implements AutoWikiCreationServiceInterfa
             return null;
         }
 
-        $items = array_map(
-            static fn (SourceReference $source) => "{$source->title()} ({$source->uri()})",
-            $sources,
-        );
+        $items = array_map(fn (SourceReference $source) => $this->sourceMarkdownLink($source), $sources);
 
         return new Section(
             title: section_title('sources', $language),
             displayOrder: $displayOrder,
             contents: new SectionContentCollection([new ListBlock(displayOrder: 0, listType: ListType::BULLET, items: $items)]),
         );
+    }
+
+    private function sourceMarkdownLink(SourceReference $source): string
+    {
+        $title = trim($source->title());
+        $label = $title !== '' ? $title : $source->uri();
+
+        return '[' . $this->escapeMarkdownLinkLabel($label) . '](' . $source->uri() . ')';
+    }
+
+    private function escapeMarkdownLinkLabel(string $label): string
+    {
+        return str_replace(['\\', '[', ']'], ['\\\\', '\[', '\]'], $label);
     }
 
     /**

--- a/tests/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationServiceTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Service/AutoWikiCreationServiceTest.php
@@ -86,6 +86,14 @@ class AutoWikiCreationServiceTest extends TestCase
                                     'overview' => $overview,
                                     'history' => $history,
                                     'artists' => $artists,
+                                    'sources' => [
+                                        [
+                                            'page_title' => 'JYP Entertainment Company Info',
+                                            'site_name' => 'JYP Entertainment',
+                                            'url' => 'https://www.jypentertainment.com/en/Company/Info',
+                                            'description' => 'Company profile and founding information.',
+                                        ],
+                                    ],
                                 ], JSON_THROW_ON_ERROR),
                             ],
                         ],
@@ -94,8 +102,8 @@ class AutoWikiCreationServiceTest extends TestCase
                         'groundingChunks' => [
                             [
                                 'web' => [
-                                    'uri' => 'https://www.jypentertainment.com/',
-                                    'title' => 'JYP Entertainment 公式サイト',
+                                    'uri' => 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/example',
+                                    'title' => 'jypentertainment.com',
                                 ],
                             ],
                         ],
@@ -157,12 +165,12 @@ class AutoWikiCreationServiceTest extends TestCase
         $this->assertSame('出典', $sections[3]->title());
         $this->assertInstanceOf(ListBlock::class, $sections[3]->contents()->blocks()[0]);
         $this->assertSame(
-            ['JYP Entertainment 公式サイト (https://www.jypentertainment.com/)'],
+            ['[JYP Entertainment Company Info - JYP Entertainment](https://www.jypentertainment.com/en/Company/Info)'],
             $sections[3]->contents()->blocks()[0]->items(),
         );
 
         $this->assertCount(1, $result->sources());
-        $this->assertSame('https://www.jypentertainment.com/', $result->sources()[0]->uri());
+        $this->assertSame('https://www.jypentertainment.com/en/Company/Info', $result->sources()[0]->uri());
     }
 
     /**
@@ -343,7 +351,7 @@ class AutoWikiCreationServiceTest extends TestCase
         $this->assertSame('출처', $sections[5]->title());
         $this->assertInstanceOf(ListBlock::class, $sections[5]->contents()->blocks()[0]);
         $this->assertSame(
-            ['트와이스 - 위키백과 (https://ko.wikipedia.org/wiki/트와이스)'],
+            ['[트와이스 - 위키백과](https://ko.wikipedia.org/wiki/트와이스)'],
             $sections[5]->contents()->blocks()[0]->items(),
         );
 
@@ -588,7 +596,7 @@ class AutoWikiCreationServiceTest extends TestCase
         $this->assertSame('出典', $sections[4]->title());
         $this->assertInstanceOf(ListBlock::class, $sections[4]->contents()->blocks()[0]);
         $this->assertSame(
-            ['Example (https://example.com/)'],
+            ['[Example](https://example.com/)'],
             $sections[4]->contents()->blocks()[0]->items(),
         );
 
@@ -877,7 +885,7 @@ class AutoWikiCreationServiceTest extends TestCase
         $this->assertSame('出典', $sections[2]->title());
         $this->assertInstanceOf(ListBlock::class, $sections[2]->contents()->blocks()[0]);
         $this->assertSame(
-            ['Dynamite - Wikipedia (https://example.com/dynamite)'],
+            ['[Dynamite - Wikipedia](https://example.com/dynamite)'],
             $sections[2]->contents()->blocks()[0]->items(),
         );
 


### PR DESCRIPTION
## 📝 変更内容

- Gemini への生成プロンプトに `sources` 出力を追加
- 生成JSON内の `sources` から直接HTTPSの参照元URLを抽出する `SourceReferenceExtractor` を追加
- 生成JSONの `sources` がない場合は、従来通り Gemini の grounding metadata から出典を抽出
- 自動Wiki作成の出典表示を `タイトル (URL)` 形式から Markdown リンク形式に変更
- 出典リンク生成のテスト期待値を更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Gemini の grounding metadata 由来のURLが `vertexaisearch.cloud.google.com` のリダイレクトURLになる場合があるため、生成結果に実際に参照したページ情報を含めさせ、直接参照元URLを優先して出典リンクに利用できるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`
  - PHP CS Fixer: 変更なし
  - PHPStan: No errors
  - PHPUnit: OK (2678 tests, 8592 assertions)

## 🔍 レビューのポイント

- 生成JSONの `sources` を優先し、未取得時のみ grounding metadata にフォールバックする挙動
- `sources` のURL検証、重複排除、タイトル生成ロジック
- 出典セクションの Markdown リンク生成とラベルのエスケープ処理

## 📖 関連情報

関連Issueなし

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
