### PR TITLE
Wikiコマンドレスポンスに識別子を含める

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -3529,11 +3529,16 @@ components:
     PublishedWikiSummary:
       type: object
       required:
+        - wikiIdentifier
         - language
         - name
         - resourceType
         - version
       properties:
+        wikiIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Published wiki identifier.
         language:
           type: string
           description: Language of the wiki.

--- a/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiOutput.php
@@ -16,12 +16,13 @@ class ApproveWikiOutput implements ApproveWikiOutputPort
     }
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array
     {
         if ($this->draftWiki === null) {
             return [
+                'wikiIdentifier' => null,
                 'language' => null,
                 'name' => null,
                 'resourceType' => null,
@@ -30,6 +31,7 @@ class ApproveWikiOutput implements ApproveWikiOutputPort
         }
 
         return [
+            'wikiIdentifier' => (string) $this->draftWiki->wikiIdentifier(),
             'language' => $this->draftWiki->language()->value,
             'name' => (string) $this->draftWiki->basic()->name(),
             'resourceType' => $this->draftWiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiOutputPort.php
@@ -11,7 +11,7 @@ interface ApproveWikiOutputPort
     public function setDraftWiki(DraftWiki $draftWiki): void;
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutput.php
@@ -16,12 +16,13 @@ class EditWikiOutput implements EditWikiOutputPort
     }
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array
     {
         if ($this->draftWiki === null) {
             return [
+                'wikiIdentifier' => null,
                 'language' => null,
                 'name' => null,
                 'resourceType' => null,
@@ -30,6 +31,7 @@ class EditWikiOutput implements EditWikiOutputPort
         }
 
         return [
+            'wikiIdentifier' => (string) $this->draftWiki->wikiIdentifier(),
             'language' => $this->draftWiki->language()->value,
             'name' => (string) $this->draftWiki->basic()->name(),
             'resourceType' => $this->draftWiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputPort.php
@@ -11,7 +11,7 @@ interface EditWikiOutputPort
     public function setDraftWiki(DraftWiki $draftWiki): void;
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutput.php
@@ -16,12 +16,13 @@ class MergeWikiOutput implements MergeWikiOutputPort
     }
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array
     {
         if ($this->draftWiki === null) {
             return [
+                'wikiIdentifier' => null,
                 'language' => null,
                 'name' => null,
                 'resourceType' => null,
@@ -30,6 +31,7 @@ class MergeWikiOutput implements MergeWikiOutputPort
         }
 
         return [
+            'wikiIdentifier' => (string) $this->draftWiki->wikiIdentifier(),
             'language' => $this->draftWiki->language()->value,
             'name' => (string) $this->draftWiki->basic()->name(),
             'resourceType' => $this->draftWiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputPort.php
@@ -11,7 +11,7 @@ interface MergeWikiOutputPort
     public function setDraftWiki(DraftWiki $draftWiki): void;
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutput.php
@@ -16,12 +16,13 @@ class PublishWikiOutput implements PublishWikiOutputPort
     }
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, version: ?int}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, version: ?int}
      */
     public function toArray(): array
     {
         if ($this->wiki === null) {
             return [
+                'wikiIdentifier' => null,
                 'language' => null,
                 'name' => null,
                 'resourceType' => null,
@@ -30,6 +31,7 @@ class PublishWikiOutput implements PublishWikiOutputPort
         }
 
         return [
+            'wikiIdentifier' => (string) $this->wiki->wikiIdentifier(),
             'language' => $this->wiki->language()->value,
             'name' => (string) $this->wiki->basic()->name(),
             'resourceType' => $this->wiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputPort.php
@@ -11,7 +11,7 @@ interface PublishWikiOutputPort
     public function setWiki(Wiki $wiki): void;
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, version: ?int}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, version: ?int}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutput.php
@@ -16,12 +16,13 @@ class RejectWikiOutput implements RejectWikiOutputPort
     }
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array
     {
         if ($this->draftWiki === null) {
             return [
+                'wikiIdentifier' => null,
                 'language' => null,
                 'name' => null,
                 'resourceType' => null,
@@ -30,6 +31,7 @@ class RejectWikiOutput implements RejectWikiOutputPort
         }
 
         return [
+            'wikiIdentifier' => (string) $this->draftWiki->wikiIdentifier(),
             'language' => $this->draftWiki->language()->value,
             'name' => (string) $this->draftWiki->basic()->name(),
             'resourceType' => $this->draftWiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputPort.php
@@ -11,7 +11,7 @@ interface RejectWikiOutputPort
     public function setDraftWiki(DraftWiki $draftWiki): void;
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutput.php
@@ -20,7 +20,7 @@ class RollbackWikiOutput implements RollbackWikiOutputPort
     }
 
     /**
-     * @return array{wikis: array<int, array{language: string, name: string, resourceType: string, version: int}>}
+     * @return array{wikis: array<int, array{wikiIdentifier: string, language: string, name: string, resourceType: string, version: int}>}
      */
     public function toArray(): array
     {
@@ -31,6 +31,7 @@ class RollbackWikiOutput implements RollbackWikiOutputPort
         return [
             'wikis' => array_map(
                 static fn (Wiki $wiki) => [
+                    'wikiIdentifier' => (string) $wiki->wikiIdentifier(),
                     'language' => $wiki->language()->value,
                     'name' => (string) $wiki->basic()->name(),
                     'resourceType' => $wiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputPort.php
@@ -14,7 +14,7 @@ interface RollbackWikiOutputPort
     public function setWikis(array $wikis): void;
 
     /**
-     * @return array{wikis: array<int, array{language: string, name: string, resourceType: string, version: int}>}
+     * @return array{wikis: array<int, array{wikiIdentifier: string, language: string, name: string, resourceType: string, version: int}>}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutput.php
@@ -16,12 +16,13 @@ class SubmitWikiOutput implements SubmitWikiOutputPort
     }
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array
     {
         if ($this->draftWiki === null) {
             return [
+                'wikiIdentifier' => null,
                 'language' => null,
                 'name' => null,
                 'resourceType' => null,
@@ -30,6 +31,7 @@ class SubmitWikiOutput implements SubmitWikiOutputPort
         }
 
         return [
+            'wikiIdentifier' => (string) $this->draftWiki->wikiIdentifier(),
             'language' => $this->draftWiki->language()->value,
             'name' => (string) $this->draftWiki->basic()->name(),
             'resourceType' => $this->draftWiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputPort.php
@@ -11,7 +11,7 @@ interface SubmitWikiOutputPort
     public function setDraftWiki(DraftWiki $draftWiki): void;
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutput.php
@@ -20,7 +20,7 @@ class TranslateWikiOutput implements TranslateWikiOutputPort
     }
 
     /**
-     * @return array{draftWikis: array<int, array{language: string, name: string, resourceType: string, status: string}>}
+     * @return array{draftWikis: array<int, array{wikiIdentifier: string, language: string, name: string, resourceType: string, status: string}>}
      */
     public function toArray(): array
     {
@@ -31,6 +31,7 @@ class TranslateWikiOutput implements TranslateWikiOutputPort
         return [
             'draftWikis' => array_map(
                 static fn (DraftWiki $draftWiki) => [
+                    'wikiIdentifier' => (string) $draftWiki->wikiIdentifier(),
                     'language' => $draftWiki->language()->value,
                     'name' => (string) $draftWiki->basic()->name(),
                     'resourceType' => $draftWiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputPort.php
@@ -14,7 +14,7 @@ interface TranslateWikiOutputPort
     public function setDraftWikis(array $draftWikis): void;
 
     /**
-     * @return array{draftWikis: array<int, array{language: string, name: string, resourceType: string, status: string}>}
+     * @return array{draftWikis: array<int, array{wikiIdentifier: string, language: string, name: string, resourceType: string, status: string}>}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutput.php
@@ -16,12 +16,13 @@ class WithdrawWikiOutput implements WithdrawWikiOutputPort
     }
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array
     {
         if ($this->draftWiki === null) {
             return [
+                'wikiIdentifier' => null,
                 'language' => null,
                 'name' => null,
                 'resourceType' => null,
@@ -30,6 +31,7 @@ class WithdrawWikiOutput implements WithdrawWikiOutputPort
         }
 
         return [
+            'wikiIdentifier' => (string) $this->draftWiki->wikiIdentifier(),
             'language' => $this->draftWiki->language()->value,
             'name' => (string) $this->draftWiki->basic()->name(),
             'resourceType' => $this->draftWiki->resourceType()->value,

--- a/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputPort.php
@@ -11,7 +11,7 @@ interface WithdrawWikiOutputPort
     public function setDraftWiki(DraftWiki $draftWiki): void;
 
     /**
-     * @return array{language: ?string, name: ?string, resourceType: ?string, status: ?string}
+     * @return array{wikiIdentifier: ?string, language: ?string, name: ?string, resourceType: ?string, status: ?string}
      */
     public function toArray(): array;
 }

--- a/tests/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiOutputTest.php
@@ -64,6 +64,7 @@ class ApproveWikiOutputTest extends TestCase
 
         $result = $output->toArray();
 
+        $this->assertSame((string) $draftWiki->wikiIdentifier(), $result['wikiIdentifier']);
         $this->assertSame('ko', $result['language']);
         $this->assertSame('TWICE', $result['name']);
         $this->assertSame('group', $result['resourceType']);
@@ -82,6 +83,7 @@ class ApproveWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame([
+            'wikiIdentifier' => null,
             'language' => null,
             'name' => null,
             'resourceType' => null,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiOutputTest.php
@@ -64,6 +64,7 @@ class EditWikiOutputTest extends TestCase
 
         $result = $output->toArray();
 
+        $this->assertSame((string) $draftWiki->wikiIdentifier(), $result['wikiIdentifier']);
         $this->assertSame('ko', $result['language']);
         $this->assertSame('TWICE', $result['name']);
         $this->assertSame('group', $result['resourceType']);
@@ -82,6 +83,7 @@ class EditWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame([
+            'wikiIdentifier' => null,
             'language' => null,
             'name' => null,
             'resourceType' => null,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiOutputTest.php
@@ -64,6 +64,7 @@ class MergeWikiOutputTest extends TestCase
 
         $result = $output->toArray();
 
+        $this->assertSame((string) $draftWiki->wikiIdentifier(), $result['wikiIdentifier']);
         $this->assertSame('ko', $result['language']);
         $this->assertSame('TWICE', $result['name']);
         $this->assertSame('group', $result['resourceType']);
@@ -82,6 +83,7 @@ class MergeWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame([
+            'wikiIdentifier' => null,
             'language' => null,
             'name' => null,
             'resourceType' => null,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiOutputTest.php
@@ -60,6 +60,7 @@ class PublishWikiOutputTest extends TestCase
 
         $result = $output->toArray();
 
+        $this->assertSame((string) $wiki->wikiIdentifier(), $result['wikiIdentifier']);
         $this->assertSame('ko', $result['language']);
         $this->assertSame('TWICE', $result['name']);
         $this->assertSame('group', $result['resourceType']);
@@ -78,6 +79,7 @@ class PublishWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame([
+            'wikiIdentifier' => null,
             'language' => null,
             'name' => null,
             'resourceType' => null,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiOutputTest.php
@@ -64,6 +64,7 @@ class RejectWikiOutputTest extends TestCase
 
         $result = $output->toArray();
 
+        $this->assertSame((string) $draftWiki->wikiIdentifier(), $result['wikiIdentifier']);
         $this->assertSame('ko', $result['language']);
         $this->assertSame('TWICE', $result['name']);
         $this->assertSame('group', $result['resourceType']);
@@ -82,6 +83,7 @@ class RejectWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame([
+            'wikiIdentifier' => null,
             'language' => null,
             'name' => null,
             'resourceType' => null,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiOutputTest.php
@@ -86,10 +86,12 @@ class RollbackWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertCount(2, $result['wikis']);
+        $this->assertSame((string) $wiki1->wikiIdentifier(), $result['wikis'][0]['wikiIdentifier']);
         $this->assertSame('ko', $result['wikis'][0]['language']);
         $this->assertSame('TWICE', $result['wikis'][0]['name']);
         $this->assertSame('group', $result['wikis'][0]['resourceType']);
         $this->assertSame(3, $result['wikis'][0]['version']);
+        $this->assertSame((string) $wiki2->wikiIdentifier(), $result['wikis'][1]['wikiIdentifier']);
         $this->assertSame('ja', $result['wikis'][1]['language']);
     }
 

--- a/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiOutputTest.php
@@ -64,6 +64,7 @@ class SubmitWikiOutputTest extends TestCase
 
         $result = $output->toArray();
 
+        $this->assertSame((string) $draftWiki->wikiIdentifier(), $result['wikiIdentifier']);
         $this->assertSame('ko', $result['language']);
         $this->assertSame('TWICE', $result['name']);
         $this->assertSame('group', $result['resourceType']);
@@ -82,6 +83,7 @@ class SubmitWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame([
+            'wikiIdentifier' => null,
             'language' => null,
             'name' => null,
             'resourceType' => null,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiOutputTest.php
@@ -92,10 +92,12 @@ class TranslateWikiOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertCount(2, $result['draftWikis']);
+        $this->assertSame((string) $draftWiki1->wikiIdentifier(), $result['draftWikis'][0]['wikiIdentifier']);
         $this->assertSame('ja', $result['draftWikis'][0]['language']);
         $this->assertSame('TWICE', $result['draftWikis'][0]['name']);
         $this->assertSame('group', $result['draftWikis'][0]['resourceType']);
         $this->assertSame('pending', $result['draftWikis'][0]['status']);
+        $this->assertSame((string) $draftWiki2->wikiIdentifier(), $result['draftWikis'][1]['wikiIdentifier']);
         $this->assertSame('en', $result['draftWikis'][1]['language']);
     }
 

--- a/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiOutputTest.php
@@ -58,6 +58,7 @@ class WithdrawWikiOutputTest extends TestCase
         $output->setDraftWiki($draftWiki);
 
         $this->assertSame([
+            'wikiIdentifier' => (string) $draftWiki->wikiIdentifier(),
             'language' => 'ko',
             'name' => 'TWICE',
             'resourceType' => 'group',
@@ -70,6 +71,7 @@ class WithdrawWikiOutputTest extends TestCase
         $output = new WithdrawWikiOutput();
 
         $this->assertSame([
+            'wikiIdentifier' => null,
             'language' => null,
             'name' => null,
             'resourceType' => null,

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -29,6 +29,8 @@ model DraftWikiSummary {
 
 @doc("Summary of a published wiki.")
 model PublishedWikiSummary {
+  @doc("Published wiki identifier.")
+  wikiIdentifier: Uuid;
   @doc("Language of the wiki.")
   language: string;
   @doc("Display name of the wiki.")


### PR DESCRIPTION
## 📝 変更内容

- Wikiのコマンド系Outputで `wikiIdentifier` を返すように変更
  - draft wiki: approve/edit/merge/reject/submit/withdraw
  - published wiki: publish/rollback
  - translated draft wiki: translate
- `PublishedWikiSummary` に `wikiIdentifier` を追加
- TypeSpec と OpenAPI を更新
- 各OutputTestで `wikiIdentifier` の返却を検証

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🚀 新機能 (Feature)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki編集・審査系操作ではAPI処理自体は成功していても、レスポンスがTypeSpec/OpenAPI/フロント生成型の `DraftWikiSummary` と一致せず、フロント側で成功レスポンスのパースに失敗していました。

コマンド系レスポンスをAPI契約に揃え、成功時に対象Wikiの識別子を返すようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi-generate` を実行し、OpenAPI生成が成功することを確認
- [x] `task test -- ...` を実行し、全テストがパスすることを確認
  - `OK (2678 tests, 8602 assertions)`
- [x] 新しく追加したレスポンス項目に対するOutputTestを更新
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- TypeSpec/OpenAPIとLaravel Outputのレスポンス形状が一致しているか
- `DraftWikiSummary` / `PublishedWikiSummary` の `wikiIdentifier` が適切な識別子を返しているか
- `delete` は 204 No Content のため変更していない点

## ⚠️ 注意事項

- マイグレーションなし
- 破壊的変更なし
- `PublishedWikiSummary` に `wikiIdentifier` が追加されるため、生成型側では必須フィールドが増えます

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
