### PR TITLE
assignee変更時にSlack通知するワークフローを追加

### DIFF
--- a/.github/workflows/notify-assignee-changes.yml
+++ b/.github/workflows/notify-assignee-changes.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [assigned, unassigned]
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-assignee-changes.yml
+++ b/.github/workflows/notify-assignee-changes.yml
@@ -1,0 +1,42 @@
+name: Notify assignee changes
+
+on:
+  issues:
+    types: [assigned, unassigned]
+  pull_request:
+    types: [assigned, unassigned]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ACTION: ${{ github.event.action }}
+          ITEM_TYPE: ${{ github.event.issue && 'Issue' || 'Pull request' }}
+          ITEM_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+          ITEM_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+          ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ACTOR: ${{ github.actor }}
+          ASSIGNEE: ${{ github.event.assignee.login }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL is not set."
+            exit 1
+          fi
+
+          if [ "$ACTION" = "assigned" ]; then
+            ICON=":bust_in_silhouette:"
+            STATUS="assigned"
+          else
+            ICON=":no_entry_sign:"
+            STATUS="unassigned"
+          fi
+
+          MESSAGE="${ICON} ${ITEM_TYPE} ${STATUS}: #${ITEM_NUMBER} ${ITEM_TITLE}\nAssignee: ${ASSIGNEE}\nChanged by: ${ACTOR}\n${ITEM_URL}"
+
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n --arg text "$MESSAGE" '{text: $text}')" \
+            "$SLACK_WEBHOOK_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ clover.xml
 /build/
 /dist/
 /node_modules/
+/.pnpm-store/
 /public/storage/
 
 .codex/*


### PR DESCRIPTION
## 📝 変更内容

- Issue / Pull Request の assignee が assigned / unassigned されたときに Slack へ通知する GitHub Actions ワークフローを追加
- Slack通知本文に対象種別、番号、タイトル、assignee、変更者、URLを含めるようにした
- ローカルの pnpm store である `/.pnpm-store/` を `.gitignore` に追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Issue / Pull Request の担当者変更を Slack に通知し、担当変更の把握漏れを防ぐため。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

### 動作確認

未実施

## 🔍 レビューのポイント

- `issues` / `pull_request` の assigned / unassigned イベントで意図通り通知されるか
- Issue と Pull Request の両方でタイトル、URL、番号が正しく取得できるか
- Slack Webhook のJSON生成に `jq` を使う形で問題ないか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- `secrets.SLACK_WEBHOOK_URL` の設定が必要です
- 破壊的変更、マイグレーションはありません

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
