### PR TITLE
unassigned通知の表示ラベルを修正

### DIFF
--- a/.github/workflows/notify-assignee-changes.yml
+++ b/.github/workflows/notify-assignee-changes.yml
@@ -32,12 +32,14 @@ jobs:
           if [ "$ACTION" = "assigned" ]; then
             ICON=":bust_in_silhouette:"
             STATUS="assigned"
+            ASSIGNEE_LABEL="Assignee"
           else
             ICON=":no_entry_sign:"
             STATUS="unassigned"
+            ASSIGNEE_LABEL="Unassigned"
           fi
 
-          MESSAGE="${ICON} ${ITEM_TYPE} ${STATUS}: #${ITEM_NUMBER} ${ITEM_TITLE}\nAssignee: ${ASSIGNEE}\nChanged by: ${ACTOR}\n${ITEM_URL}"
+          MESSAGE="${ICON} ${ITEM_TYPE} ${STATUS}: #${ITEM_NUMBER} ${ITEM_TITLE}\n${ASSIGNEE_LABEL}: ${ASSIGNEE}\nChanged by: ${ACTOR}\n${ITEM_URL}"
 
           curl -X POST -H 'Content-type: application/json' \
             --data "$(jq -n --arg text "$MESSAGE" '{text: $text}')" \


### PR DESCRIPTION
## 📝 変更内容

- assignee 変更通知ワークフローで、`assigned` と `unassigned` の通知本文ラベルを分けるように変更
- `assigned` 時は `Assignee: <ユーザー>`、`unassigned` 時は `Unassigned: <外されたユーザー>` と表示

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

`unassigned` イベントでは `github.event.assignee.login` は外されたユーザーを示すため、通知本文の `Assignee:` 表示が文脈上わかりづらい状態だった。イベント種別に合わせたラベルへ変更し、Slack通知の意味を明確にする。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

### 動作確認

未実施

## 🔍 レビューのポイント

- `assigned` / `unassigned` それぞれで通知本文のラベルが意図通りか
- 既存のSlack通知フォーマットに不要な影響がないか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

破壊的変更、マイグレーションはありません。

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
