### PR TITLE
add: PHPStanで例外処理と依存方向の制約を追加

### DIFF
--- a/application/Http/Action/Monetization/Settlement/Command/ExecuteTransfer/ExecuteTransferAction.php
+++ b/application/Http/Action/Monetization/Settlement/Command/ExecuteTransfer/ExecuteTransferAction.php
@@ -11,6 +11,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Source\Monetization\Account\Domain\Exception\CapabilityNotGrantedException;
 use Source\Monetization\Account\Domain\Exception\MonetizationAccountNotFoundException;
 use Source\Monetization\Settlement\Application\UseCase\Command\ExecuteTransfer\ExecuteTransferInput;
 use Source\Monetization\Settlement\Application\UseCase\Command\ExecuteTransfer\ExecuteTransferInterface;
@@ -58,6 +59,10 @@ readonly class ExecuteTransferAction
                 DB::rollBack();
 
                 throw new NotFoundHttpException(detail: error_message('monetization_account_not_found', $language), previous: $e);
+            } catch (CapabilityNotGrantedException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('capability_not_granted', $language), previous: $e);
             } catch (Throwable $e) {
                 DB::rollBack();
 

--- a/application/Http/Action/Webhook/Stripe/StripeWebhookAction.php
+++ b/application/Http/Action/Webhook/Stripe/StripeWebhookAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Webhook\Stripe;
 
+use Application\Http\Exceptions\BadRequestHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
 use Application\Jobs\SyncPayoutAccountJob;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -12,6 +14,7 @@ use Stripe\BankAccount;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\Webhook;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 readonly class StripeWebhookAction
 {
@@ -28,48 +31,58 @@ readonly class StripeWebhookAction
 
     public function __invoke(Request $request): JsonResponse
     {
-        $payload = $request->getContent();
-        $sigHeader = $request->header('Stripe-Signature', '');
-
-        /** @var string $webhookSecret */
-        $webhookSecret = config('services.stripe.webhook_secret', '');
-
         try {
-            $event = Webhook::constructEvent($payload, $sigHeader, $webhookSecret);
-        } catch (SignatureVerificationException $e) {
-            $this->logger->warning('Stripe webhook signature verification failed', [
-                'error' => $e->getMessage(),
+            $payload = $request->getContent();
+            $sigHeader = $request->header('Stripe-Signature', '');
+
+            /** @var string $webhookSecret */
+            $webhookSecret = config('services.stripe.webhook_secret', '');
+
+            try {
+                $event = Webhook::constructEvent($payload, $sigHeader, $webhookSecret);
+            } catch (SignatureVerificationException $e) {
+                $this->logger->warning('Stripe webhook signature verification failed', [
+                    'error' => $e->getMessage(),
+                ]);
+
+                throw new BadRequestHttpException(detail: 'Invalid signature', previous: $e);
+            }
+
+            if (! in_array($event->type, self::SUPPORTED_EVENTS, true)) {
+                return response()->json(['status' => 'ignored'], Response::HTTP_OK);
+            }
+
+            $connectedAccountId = $event->account;
+            /** @var BankAccount $externalAccount */
+            $externalAccount = $event->data->object;
+
+            $this->logger->info('Stripe webhook received', [
+                'event_type' => $event->type,
+                'connected_account_id' => $connectedAccountId,
+                'external_account_id' => $externalAccount->id ?? null,
             ]);
 
-            return response()->json(['error' => 'Invalid signature'], Response::HTTP_BAD_REQUEST);
+            SyncPayoutAccountJob::dispatch(
+                connectedAccountId: $connectedAccountId,
+                externalAccountId: $externalAccount->id,
+                eventType: $event->type,
+                bankName: $externalAccount->bank_name ?? null,
+                last4: $externalAccount->last4 ?? null,
+                country: $externalAccount->country ?? null,
+                currency: $externalAccount->currency ?? null,
+                accountHolderType: $externalAccount->account_holder_type ?? null,
+                isDefault: ($externalAccount->default_for_currency ?? false) === true,
+            );
+
+            return response()->json(['status' => 'accepted'], Response::HTTP_OK);
+        } catch (BadRequestHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
         }
-
-        if (! in_array($event->type, self::SUPPORTED_EVENTS, true)) {
-            return response()->json(['status' => 'ignored'], Response::HTTP_OK);
-        }
-
-        $connectedAccountId = $event->account;
-        /** @var BankAccount $externalAccount */
-        $externalAccount = $event->data->object;
-
-        $this->logger->info('Stripe webhook received', [
-            'event_type' => $event->type,
-            'connected_account_id' => $connectedAccountId,
-            'external_account_id' => $externalAccount->id ?? null,
-        ]);
-
-        SyncPayoutAccountJob::dispatch(
-            connectedAccountId: $connectedAccountId,
-            externalAccountId: $externalAccount->id,
-            eventType: $event->type,
-            bankName: $externalAccount->bank_name ?? null,
-            last4: $externalAccount->last4 ?? null,
-            country: $externalAccount->country ?? null,
-            currency: $externalAccount->currency ?? null,
-            accountHolderType: $externalAccount->account_holder_type ?? null,
-            isDefault: ($externalAccount->default_for_currency ?? false) === true,
-        );
-
-        return response()->json(['status' => 'accepted'], Response::HTTP_OK);
     }
 }

--- a/application/Http/Action/Wiki/Image/Query/ListUploadedImages/ListUploadedImagesAction.php
+++ b/application/Http/Action/Wiki/Image/Query/ListUploadedImages/ListUploadedImagesAction.php
@@ -18,6 +18,8 @@ readonly class ListUploadedImagesAction
 {
     public function __construct(
         private ListUploadedImagesInterface $listUploadedImages,
+        // 防御的catch内でのみ利用され、PHPStanのchecked exception解析では未到達扱いになるため。
+        // @phpstan-ignore property.onlyWritten
         private LoggerInterface $logger,
     ) {
     }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Kpool\\PHPStan\\Rules\\": "phpstan/Rules/",
             "Tests\\": "tests/"
         }
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -43,3 +43,22 @@ services:
             httpExceptionClass: Application\Http\Exceptions\HttpException
         tags:
             - phpstan.rules.rule
+    -
+        class: Kpool\PHPStan\Rules\ActionHttpExceptionResponseRule
+        arguments:
+            targetClassNamePattern: '#^Application\\Http\\Action\\.*Action$#'
+            targetMethodNames:
+                - __invoke
+            broadCatchTypes:
+                - Throwable
+                - Exception
+            clientErrorHttpExceptionClasses:
+                - Application\Http\Exceptions\BadRequestHttpException
+                - Application\Http\Exceptions\UnauthorizedHttpException
+                - Application\Http\Exceptions\ForbiddenHttpException
+                - Application\Http\Exceptions\NotFoundHttpException
+                - Application\Http\Exceptions\ConflictHttpException
+                - Application\Http\Exceptions\UnprocessableEntityHttpException
+            internalServerErrorHttpExceptionClass: Application\Http\Exceptions\InternalServerErrorHttpException
+        tags:
+            - phpstan.rules.rule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,6 +29,41 @@ parameters:
     reportUnmatchedIgnoredErrors: true
 services:
     -
+        class: Kpool\PHPStan\Rules\ForbiddenExternalLibraryInDomainAndUseCaseRule
+        arguments:
+            targetFilePathPatterns:
+                - '#/src/(?:[^/]+/)*Domain/#'
+                - '#/src/(?:[^/]+/)*Application/UseCase/#'
+            forbiddenClassNamePatterns:
+                - '#^Source\\(?:[^\\]+\\)*Infrastructure\\#'
+            allowedNamespacePrefixes:
+                - Source\
+                - Random\
+            allowedClassNames:
+                - ArrayAccess
+                - ArrayIterator
+                - BackedEnum
+                - Closure
+                - Countable
+                - DateTimeImmutable
+                - DateTimeInterface
+                - DomainException
+                - Exception
+                - Generator
+                - InvalidArgumentException
+                - IteratorAggregate
+                - JsonSerializable
+                - LogicException
+                - Psr\Log\LoggerInterface
+                - RuntimeException
+                - Stringable
+                - Throwable
+                - Traversable
+                - UnitEnum
+                - ValueError
+        tags:
+            - phpstan.rules.rule
+    -
         class: Kpool\PHPStan\Rules\SourceExceptionRequiresHttpConversionRule
         arguments:
             targetClassNamePattern: '#^Application\\Http\\Action\\.*Action$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,7 @@ parameters:
     level: 6
     paths:
         - src
+        - application/Http/Action
         - tests
     excludePaths:
         - vendor/*
@@ -26,3 +27,19 @@ parameters:
     checkUninitializedProperties: true
     checkDynamicProperties: true
     reportUnmatchedIgnoredErrors: true
+services:
+    -
+        class: Kpool\PHPStan\Rules\SourceExceptionRequiresHttpConversionRule
+        arguments:
+            targetClassNamePattern: '#^Application\\Http\\Action\\.*Action$#'
+            targetMethodNames:
+                - __invoke
+            broadCatchTypes:
+                - Throwable
+                - Exception
+            sourceExceptionRegexes:
+                - '#^Source\\(?:[^\\]+\\)*Application\\Exception\\[^\\]+Exception$#'
+                - '#^Source\\(?:[^\\]+\\)*Domain\\Exception\\[^\\]+Exception$#'
+            httpExceptionClass: Application\Http\Exceptions\HttpException
+        tags:
+            - phpstan.rules.rule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,18 @@ parameters:
         - vendor/*
     ignoreErrors:
         - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+    exceptions:
+        implicitThrows: false
+        reportUncheckedExceptionDeadCatch: false
+        uncheckedExceptionClasses:
+            - Throwable
+        checkedExceptionRegexes:
+            - '#^Source\\(?:[^\\]+\\)*Application\\Exception\\[^\\]+Exception$#'
+            - '#^Source\\(?:[^\\]+\\)*Domain\\Exception\\[^\\]+Exception$#'
+        check:
+            missingCheckedExceptionInThrows: true
+            tooWideThrowType: true
+            throwTypeCovariance: true
     treatPhpDocTypesAsCertain: false
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
     checkUninitializedProperties: true

--- a/phpstan/Rules/ActionHttpExceptionResponseRule.php
+++ b/phpstan/Rules/ActionHttpExceptionResponseRule.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kpool\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Cast\String_;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\TryCatch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+final class ActionHttpExceptionResponseRule implements Rule
+{
+    /**
+     * @param list<string> $targetMethodNames Empty list means all methods.
+     * @param list<string> $broadCatchTypes
+     * @param list<string> $clientErrorHttpExceptionClasses
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly string $targetClassNamePattern,
+        private readonly array $targetMethodNames,
+        private readonly array $broadCatchTypes,
+        private readonly array $clientErrorHttpExceptionClasses,
+        private readonly string $internalServerErrorHttpExceptionClass
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @param Scope $scope
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$this->isTargetMethod($node, $scope)) {
+            return [];
+        }
+
+        $outerTryCatches = $this->outerTryCatches($node->stmts ?? []);
+
+        if ($outerTryCatches === []) {
+            return [
+                RuleErrorBuilder::message('Action __invoke must wrap processing in try/catch and end with defensive Throwable catch.')
+                    ->identifier('actionHttpExceptionResponse.missingTryCatch')
+                    ->line($node->getStartLine())
+                    ->build(),
+            ];
+        }
+
+        $errors = [];
+
+        foreach ($outerTryCatches as $tryCatch) {
+            foreach ($tryCatch->catches as $catch) {
+                if (!$this->catchesClientErrorHttpException($catch, $scope)) {
+                    continue;
+                }
+
+                if (!$this->catchLogsException($catch)) {
+                    $errors[] = RuleErrorBuilder::message('4xx HTTP exception catches in Actions must log with $this->logger->error((string) $e).')
+                        ->identifier('actionHttpExceptionResponse.clientErrorNotLogged')
+                        ->line($catch->getStartLine())
+                        ->build();
+                }
+
+                if (!$this->catchReturnsProblemDetailsJson($catch)) {
+                    $errors[] = RuleErrorBuilder::message('4xx HTTP exception catches in Actions must return response()->json($e->toProblemDetails(), $e->getHttpStatus()).')
+                        ->identifier('actionHttpExceptionResponse.clientErrorNotReturnedAsProblemDetails')
+                        ->line($catch->getStartLine())
+                        ->build();
+                }
+            }
+
+            $lastCatch = $tryCatch->catches[array_key_last($tryCatch->catches)] ?? null;
+
+            if (!$lastCatch instanceof Catch_ || !$this->catchesBroadException($lastCatch, $scope)) {
+                $errors[] = RuleErrorBuilder::message('Action try/catch must end with a defensive Throwable catch.')
+                    ->identifier('actionHttpExceptionResponse.missingFinalThrowableCatch')
+                    ->line($tryCatch->getStartLine())
+                    ->build();
+
+                continue;
+            }
+
+            if (!$this->catchLogsException($lastCatch)) {
+                $errors[] = RuleErrorBuilder::message('Final Throwable catches in Actions must log with $this->logger->error((string) $e).')
+                    ->identifier('actionHttpExceptionResponse.throwableNotLogged')
+                    ->line($lastCatch->getStartLine())
+                    ->build();
+            }
+
+            if (!$this->catchThrowsInternalServerError($lastCatch, $scope)) {
+                $errors[] = RuleErrorBuilder::message(sprintf(
+                    'Final Throwable catches in Actions must throw %s.',
+                    $this->internalServerErrorHttpExceptionClass
+                ))
+                    ->identifier('actionHttpExceptionResponse.throwableNotConvertedToInternalServerError')
+                    ->line($lastCatch->getStartLine())
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+
+    private function isTargetMethod(ClassMethod $method, Scope $scope): bool
+    {
+        if ($this->targetMethodNames !== [] && !in_array($method->name->toString(), $this->targetMethodNames, true)) {
+            return false;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return false;
+        }
+
+        $className = $classReflection->getName();
+
+        return $this->targetClassNamePattern === '' || preg_match($this->targetClassNamePattern, $className) === 1;
+    }
+
+    /**
+     * @param array<Node> $nodes
+     * @return list<TryCatch>
+     */
+    private function outerTryCatches(array $nodes): array
+    {
+        $tryCatches = [];
+
+        foreach ($nodes as $node) {
+            if ($node instanceof TryCatch) {
+                $tryCatches[] = $node;
+                continue;
+            }
+
+            if (RuleSupport::isNestedExecutableScope($node)) {
+                continue;
+            }
+
+            foreach ($node->getSubNodeNames() as $subNodeName) {
+                $subNode = $node->{$subNodeName};
+
+                if ($subNode instanceof Node) {
+                    foreach ($this->outerTryCatches([$subNode]) as $tryCatch) {
+                        $tryCatches[] = $tryCatch;
+                    }
+                }
+
+                if (!is_array($subNode)) {
+                    continue;
+                }
+
+                foreach ($subNode as $item) {
+                    if (!$item instanceof Node) {
+                        continue;
+                    }
+
+                    foreach ($this->outerTryCatches([$item]) as $tryCatch) {
+                        $tryCatches[] = $tryCatch;
+                    }
+                }
+            }
+        }
+
+        return $tryCatches;
+    }
+
+    private function catchesClientErrorHttpException(Catch_ $catch, Scope $scope): bool
+    {
+        foreach (RuleSupport::catchTypes($catch, $scope) as $catchType) {
+            foreach ($this->clientErrorHttpExceptionClasses as $clientErrorHttpExceptionClass) {
+                if ($catchType === mb_ltrim($clientErrorHttpExceptionClass, '\\')) {
+                    return true;
+                }
+
+                if (RuleSupport::shortName($catchType) === RuleSupport::shortName($clientErrorHttpExceptionClass)) {
+                    return true;
+                }
+
+                if (RuleSupport::isTypeOf($catchType, $clientErrorHttpExceptionClass, $this->reflectionProvider)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function catchesBroadException(Catch_ $catch, Scope $scope): bool
+    {
+        foreach (RuleSupport::catchTypes($catch, $scope) as $catchType) {
+            if (RuleSupport::isConfiguredType($catchType, $this->broadCatchTypes)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function catchLogsException(Catch_ $catch): bool
+    {
+        $variableName = $this->catchVariableName($catch);
+
+        if ($variableName === null) {
+            return false;
+        }
+
+        foreach ($this->nodes($catch->stmts) as $node) {
+            if (!$node instanceof MethodCall) {
+                continue;
+            }
+
+            if (!$this->isIdentifier($node->name, 'error')) {
+                continue;
+            }
+
+            if (!$node->var instanceof PropertyFetch || !$this->isIdentifier($node->var->name, 'logger')) {
+                continue;
+            }
+
+            if (!$node->var->var instanceof Variable || $node->var->var->name !== 'this') {
+                continue;
+            }
+
+            $firstArg = $node->args[0] ?? null;
+
+            if (!$firstArg instanceof Arg || !$firstArg->value instanceof String_) {
+                continue;
+            }
+
+            if ($this->isVariableNamed($firstArg->value->expr, $variableName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function catchReturnsProblemDetailsJson(Catch_ $catch): bool
+    {
+        $variableName = $this->catchVariableName($catch);
+
+        if ($variableName === null) {
+            return false;
+        }
+
+        foreach ($this->nodes($catch->stmts) as $node) {
+            if (!$node instanceof Return_ || !$node->expr instanceof MethodCall) {
+                continue;
+            }
+
+            $jsonCall = $node->expr;
+
+            if (!$this->isIdentifier($jsonCall->name, 'json')) {
+                continue;
+            }
+
+            if (!$jsonCall->var instanceof FuncCall || !$jsonCall->var->name instanceof Name) {
+                continue;
+            }
+
+            if ($jsonCall->var->name->toString() !== 'response') {
+                continue;
+            }
+
+            $bodyArg = $jsonCall->args[0] ?? null;
+            $statusArg = $jsonCall->args[1] ?? null;
+
+            if (!$bodyArg instanceof Arg || !$statusArg instanceof Arg) {
+                continue;
+            }
+
+            if (!$this->isMethodCallOnVariable($bodyArg->value, $variableName, 'toProblemDetails')) {
+                continue;
+            }
+
+            if ($this->isMethodCallOnVariable($statusArg->value, $variableName, 'getHttpStatus')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function catchThrowsInternalServerError(Catch_ $catch, Scope $scope): bool
+    {
+        foreach ($this->nodes($catch->stmts) as $node) {
+            if (!$node instanceof Throw_ || !$node->expr instanceof New_) {
+                continue;
+            }
+
+            $new = $node->expr;
+
+            if (!$new->class instanceof Name) {
+                continue;
+            }
+
+            $exceptionClass = RuleSupport::resolveName($new->class, $scope);
+
+            if (
+                $exceptionClass !== $this->internalServerErrorHttpExceptionClass
+                && RuleSupport::shortName($exceptionClass) !== RuleSupport::shortName($this->internalServerErrorHttpExceptionClass)
+                && !RuleSupport::isTypeOf($exceptionClass, $this->internalServerErrorHttpExceptionClass, $this->reflectionProvider)
+            ) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<Node> $nodes
+     * @return list<Node>
+     */
+    private function nodes(array $nodes): array
+    {
+        $collected = [];
+
+        foreach ($nodes as $node) {
+            if (RuleSupport::isNestedExecutableScope($node)) {
+                continue;
+            }
+
+            $collected[] = $node;
+
+            foreach ($node->getSubNodeNames() as $subNodeName) {
+                $subNode = $node->{$subNodeName};
+
+                if ($subNode instanceof Node) {
+                    foreach ($this->nodes([$subNode]) as $child) {
+                        $collected[] = $child;
+                    }
+                }
+
+                if (!is_array($subNode)) {
+                    continue;
+                }
+
+                foreach ($subNode as $item) {
+                    if (!$item instanceof Node) {
+                        continue;
+                    }
+
+                    foreach ($this->nodes([$item]) as $child) {
+                        $collected[] = $child;
+                    }
+                }
+            }
+        }
+
+        return $collected;
+    }
+
+    private function catchVariableName(Catch_ $catch): ?string
+    {
+        if (!$catch->var instanceof Variable || !is_string($catch->var->name)) {
+            return null;
+        }
+
+        return $catch->var->name;
+    }
+
+    private function isIdentifier(Node|string $node, string $name): bool
+    {
+        return $node instanceof Identifier && $node->toString() === $name;
+    }
+
+    private function isMethodCallOnVariable(Expr $expr, string $variableName, string $methodName): bool
+    {
+        return $expr instanceof MethodCall
+            && $this->isIdentifier($expr->name, $methodName)
+            && $this->isVariableNamed($expr->var, $variableName);
+    }
+
+    private function isVariableNamed(Expr $expr, string $variableName): bool
+    {
+        return $expr instanceof Variable && $expr->name === $variableName;
+    }
+}

--- a/phpstan/Rules/ForbiddenExternalLibraryInDomainAndUseCaseRule.php
+++ b/phpstan/Rules/ForbiddenExternalLibraryInDomainAndUseCaseRule.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kpool\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Name>
+ */
+final class ForbiddenExternalLibraryInDomainAndUseCaseRule implements Rule
+{
+    /**
+     * @param list<string> $targetFilePathPatterns
+     * @param list<string> $forbiddenClassNamePatterns
+     * @param list<string> $allowedNamespacePrefixes
+     * @param list<string> $allowedClassNames
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly array $targetFilePathPatterns,
+        private readonly array $forbiddenClassNamePatterns,
+        private readonly array $allowedNamespacePrefixes,
+        private readonly array $allowedClassNames,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Name::class;
+    }
+
+    /**
+     * @param Name $node
+     * @param Scope $scope
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$this->isTargetFile($scope->getFile())) {
+            return [];
+        }
+
+        $className = RuleSupport::resolveName($node, $scope);
+
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        if ($this->isForbiddenClass($className)) {
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'Domain layer and use cases must not depend on infrastructure layer: %s.',
+                    $className,
+                ))
+                    ->identifier('kpool.infrastructureDependencyInDomainOrUseCase')
+                    ->build(),
+            ];
+        }
+
+        if ($this->isAllowedClass($className)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Domain layer and use cases must not depend on external libraries: %s.',
+                $className,
+            ))
+                ->identifier('kpool.externalLibraryInDomainOrUseCase')
+                ->build(),
+        ];
+    }
+
+    private function isTargetFile(string $file): bool
+    {
+        foreach ($this->targetFilePathPatterns as $targetFilePathPattern) {
+            if (preg_match($targetFilePathPattern, $file) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isForbiddenClass(string $className): bool
+    {
+        foreach ($this->forbiddenClassNamePatterns as $forbiddenClassNamePattern) {
+            if (preg_match($forbiddenClassNamePattern, $className) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isAllowedClass(string $className): bool
+    {
+        if (in_array($className, $this->allowedClassNames, true)) {
+            return true;
+        }
+
+        foreach ($this->allowedNamespacePrefixes as $allowedNamespacePrefix) {
+            if (str_starts_with($className, $allowedNamespacePrefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/phpstan/Rules/RuleSupport.php
+++ b/phpstan/Rules/RuleSupport.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kpool\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+
+final class RuleSupport
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param list<string> $targetMethodNames
+     */
+    public static function isTargetScope(Scope $scope, string $targetClassNamePattern, array $targetMethodNames): bool
+    {
+        if ($targetMethodNames !== [] && !in_array($scope->getFunctionName(), $targetMethodNames, true)) {
+            return false;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return false;
+        }
+
+        $className = $classReflection->getName();
+
+        return $targetClassNamePattern === '' || preg_match($targetClassNamePattern, $className) === 1;
+    }
+
+    public static function resolveName(Name $name, Scope $scope): string
+    {
+        return mb_ltrim($scope->resolveName($name), '\\');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function catchTypes(Catch_ $catch, Scope $scope): array
+    {
+        $catchTypes = [];
+
+        foreach ($catch->types as $type) {
+            $catchTypes[] = self::resolveName($type, $scope);
+        }
+
+        return $catchTypes;
+    }
+
+    /**
+     * @param list<string> $configuredTypes
+     */
+    public static function isConfiguredType(string $type, array $configuredTypes): bool
+    {
+        $normalizedType = mb_ltrim(mb_trim($type), '\\');
+
+        foreach ($configuredTypes as $configuredType) {
+            $normalizedConfiguredType = mb_ltrim(mb_trim($configuredType), '\\');
+
+            if ($normalizedType === $normalizedConfiguredType || $normalizedType === self::shortName($normalizedConfiguredType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function shortName(string $className): string
+    {
+        $classNameParts = explode('\\', $className);
+
+        return end($classNameParts) ?: $className;
+    }
+
+    public static function isNestedExecutableScope(Node $node): bool
+    {
+        return $node instanceof Class_
+            || $node instanceof ClassMethod
+            || $node instanceof Function_
+            || $node instanceof Interface_
+            || $node instanceof Node\Expr\Closure
+            || $node instanceof Node\Expr\ArrowFunction
+            || $node instanceof Trait_;
+    }
+
+    public static function isTypeOf(string $className, string $parentClassName, ReflectionProvider $reflectionProvider): bool
+    {
+        if (!$reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        if (!$reflectionProvider->hasClass($parentClassName)) {
+            return false;
+        }
+
+        return (new ObjectType($parentClassName))->isSuperTypeOf(new ObjectType($className))->yes();
+    }
+}

--- a/phpstan/Rules/SourceExceptionRequiresHttpConversionRule.php
+++ b/phpstan/Rules/SourceExceptionRequiresHttpConversionRule.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kpool\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\Node\Stmt\TryCatch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<TryCatch>
+ */
+final class SourceExceptionRequiresHttpConversionRule implements Rule
+{
+    /**
+     * @param list<string> $targetMethodNames Empty list means all methods.
+     * @param list<string> $broadCatchTypes
+     * @param list<string> $sourceExceptionRegexes
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly string $targetClassNamePattern,
+        private readonly array $targetMethodNames,
+        private readonly array $broadCatchTypes,
+        private readonly array $sourceExceptionRegexes,
+        private readonly string $httpExceptionClass
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return TryCatch::class;
+    }
+
+    /**
+     * @param TryCatch $node
+     * @param Scope $scope
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!RuleSupport::isTargetScope($scope, $this->targetClassNamePattern, $this->targetMethodNames)) {
+            return [];
+        }
+
+        $broadCatch = $this->firstBroadCatch($node, $scope);
+
+        if ($broadCatch === null) {
+            return [];
+        }
+
+        $missingTypes = [];
+
+        foreach ($this->sourceExceptionTypesThrownByNodes($node->stmts, $scope) as $exceptionType) {
+            if ($this->isConvertedByCatchBefore($node, $broadCatch, $exceptionType, $scope)) {
+                continue;
+            }
+
+            $missingTypes[] = $exceptionType;
+        }
+
+        $missingTypes = array_values(array_unique($missingTypes));
+
+        if ($missingTypes === []) {
+            return [];
+        }
+
+        sort($missingTypes);
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Source application/domain exceptions must be caught and converted to %s before broad catch: %s.',
+                $this->httpExceptionClass,
+                implode(', ', $missingTypes)
+            ))
+                ->identifier('catch.sourceExceptionNotConvertedToHttp')
+                ->line($broadCatch->getStartLine())
+                ->build(),
+        ];
+    }
+
+    private function firstBroadCatch(TryCatch $tryCatch, Scope $scope): ?Catch_
+    {
+        foreach ($tryCatch->catches as $catch) {
+            foreach (RuleSupport::catchTypes($catch, $scope) as $catchType) {
+                if (RuleSupport::isConfiguredType($catchType, $this->broadCatchTypes)) {
+                    return $catch;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function isConvertedByCatchBefore(TryCatch $tryCatch, Catch_ $broadCatch, string $exceptionType, Scope $scope): bool
+    {
+        foreach ($tryCatch->catches as $catch) {
+            if ($catch === $broadCatch) {
+                return false;
+            }
+
+            if (!$this->isCoveredByCatch($exceptionType, RuleSupport::catchTypes($catch, $scope))) {
+                continue;
+            }
+
+            return $this->catchThrowsHttpException($catch, $scope);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $catchTypes
+     */
+    private function isCoveredByCatch(string $exceptionType, array $catchTypes): bool
+    {
+        foreach ($catchTypes as $catchType) {
+            if ($exceptionType === $catchType) {
+                return true;
+            }
+
+            if (RuleSupport::shortName($exceptionType) === RuleSupport::shortName($catchType)) {
+                return true;
+            }
+
+            if (RuleSupport::isTypeOf($exceptionType, $catchType, $this->reflectionProvider)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function catchThrowsHttpException(Catch_ $catch, Scope $scope): bool
+    {
+        foreach ($this->newThrows($catch->stmts) as $throw) {
+            $new = $throw->expr;
+
+            if (!$new instanceof New_ || !$new->class instanceof Name) {
+                continue;
+            }
+
+            $exceptionClass = RuleSupport::resolveName($new->class, $scope);
+
+            if ($exceptionClass === $this->httpExceptionClass) {
+                return true;
+            }
+
+            if (RuleSupport::isTypeOf($exceptionClass, $this->httpExceptionClass, $this->reflectionProvider)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<Node> $nodes
+     * @return list<string>
+     */
+    private function sourceExceptionTypesThrownByNodes(array $nodes, Scope $scope): array
+    {
+        $exceptionTypes = [];
+
+        foreach ($nodes as $node) {
+            foreach ($this->sourceExceptionTypesThrownByNode($node, $scope) as $exceptionType) {
+                $exceptionTypes[] = $exceptionType;
+            }
+        }
+
+        return array_values(array_unique($exceptionTypes));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sourceExceptionTypesThrownByNode(Node $node, Scope $scope): array
+    {
+        if ($node instanceof TryCatch) {
+            return $this->sourceExceptionTypesEscapingTryCatch($node, $scope);
+        }
+
+        if (RuleSupport::isNestedExecutableScope($node)) {
+            return [];
+        }
+
+        $exceptionTypes = [];
+
+        if ($node instanceof MethodCall) {
+            foreach ($this->methodCallThrowTypes($node, $scope) as $exceptionType) {
+                if ($this->isSourceException($exceptionType)) {
+                    $exceptionTypes[] = $exceptionType;
+                }
+            }
+        }
+
+        if ($node instanceof Throw_) {
+            foreach ($this->directThrowTypes($node, $scope) as $exceptionType) {
+                if ($this->isSourceException($exceptionType)) {
+                    $exceptionTypes[] = $exceptionType;
+                }
+            }
+        }
+
+        foreach ($node->getSubNodeNames() as $subNodeName) {
+            $subNode = $node->{$subNodeName};
+
+            if ($subNode instanceof Node) {
+                foreach ($this->sourceExceptionTypesThrownByNode($subNode, $scope) as $exceptionType) {
+                    $exceptionTypes[] = $exceptionType;
+                }
+            }
+
+            if (!is_array($subNode)) {
+                continue;
+            }
+
+            foreach ($subNode as $item) {
+                if (!$item instanceof Node) {
+                    continue;
+                }
+
+                foreach ($this->sourceExceptionTypesThrownByNode($item, $scope) as $exceptionType) {
+                    $exceptionTypes[] = $exceptionType;
+                }
+            }
+        }
+
+        return array_values(array_unique($exceptionTypes));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sourceExceptionTypesEscapingTryCatch(TryCatch $tryCatch, Scope $scope): array
+    {
+        $escapingTryTypes = $this->sourceExceptionTypesThrownByNodes($tryCatch->stmts, $scope);
+        $escapingCatchTypes = [];
+
+        foreach ($tryCatch->catches as $catch) {
+            $catchTypes = RuleSupport::catchTypes($catch, $scope);
+            $escapingTryTypes = array_values(array_filter(
+                $escapingTryTypes,
+                fn (string $exceptionType): bool => !$this->isCoveredByCatch($exceptionType, $catchTypes)
+            ));
+
+            foreach ($this->sourceExceptionTypesThrownByNodes($catch->stmts, $scope) as $exceptionType) {
+                $escapingCatchTypes[] = $exceptionType;
+            }
+        }
+
+        $escapingFinallyTypes = $tryCatch->finally === null
+            ? []
+            : $this->sourceExceptionTypesThrownByNodes($tryCatch->finally->stmts, $scope);
+
+        return array_values(array_unique([
+            ...$escapingTryTypes,
+            ...$escapingCatchTypes,
+            ...$escapingFinallyTypes,
+        ]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function methodCallThrowTypes(MethodCall $methodCall, Scope $scope): array
+    {
+        if (!$methodCall->name instanceof Identifier) {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($methodCall->var);
+        $methodName = $methodCall->name->toString();
+
+        if (!$calledOnType->hasMethod($methodName)->yes()) {
+            return [];
+        }
+
+        $throwType = $calledOnType->getMethod($methodName, $scope)->getThrowType();
+
+        if ($throwType === null) {
+            return [];
+        }
+
+        return $throwType->getObjectClassNames();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function directThrowTypes(Throw_ $throw, Scope $scope): array
+    {
+        if (!$throw->expr instanceof New_) {
+            return [];
+        }
+
+        if (!$throw->expr->class instanceof Name) {
+            return [];
+        }
+
+        return [RuleSupport::resolveName($throw->expr->class, $scope)];
+    }
+
+    /**
+     * @param array<Node> $nodes
+     * @return list<Throw_>
+     */
+    private function newThrows(array $nodes): array
+    {
+        $throws = [];
+
+        foreach ($nodes as $node) {
+            if (RuleSupport::isNestedExecutableScope($node)) {
+                continue;
+            }
+
+            if ($node instanceof Throw_ && $node->expr instanceof New_) {
+                $throws[] = $node;
+                continue;
+            }
+
+            foreach ($node->getSubNodeNames() as $subNodeName) {
+                $subNode = $node->{$subNodeName};
+
+                if ($subNode instanceof Node) {
+                    foreach ($this->newThrows([$subNode]) as $throw) {
+                        $throws[] = $throw;
+                    }
+                }
+
+                if (!is_array($subNode)) {
+                    continue;
+                }
+
+                foreach ($subNode as $item) {
+                    if (!$item instanceof Node) {
+                        continue;
+                    }
+
+                    foreach ($this->newThrows([$item]) as $throw) {
+                        $throws[] = $throw;
+                    }
+                }
+            }
+        }
+
+        return $throws;
+    }
+
+    private function isSourceException(string $exceptionType): bool
+    {
+        $normalizedType = mb_ltrim($exceptionType, '\\');
+
+        foreach ($this->sourceExceptionRegexes as $sourceExceptionRegex) {
+            if (preg_match($sourceExceptionRegex, $normalizedType) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -19,6 +19,7 @@ return [
     'monetization_account_not_found' => 'The specified monetization account was not found.',
     'monetization_account_already_exists' => 'The monetization account already exists.',
     'capability_already_granted' => 'The specified capability has already been granted.',
+    'capability_not_granted' => 'The required capability has not been granted.',
     'stripe_connect_error' => 'A Stripe Connect error has occurred.',
     'empty_invoice_lines' => 'At least one product line is required.',
     'invalid_invoice_amounts' => 'The invoice amounts are invalid.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -19,6 +19,7 @@ return [
     'monetization_account_not_found' => 'No se encontró la cuenta de monetización especificada.',
     'monetization_account_already_exists' => 'La cuenta de monetización ya existe.',
     'capability_already_granted' => 'La capacidad especificada ya ha sido otorgada.',
+    'capability_not_granted' => 'La capacidad requerida no ha sido otorgada.',
     'stripe_connect_error' => 'Se ha producido un error en Stripe Connect.',
     'empty_invoice_lines' => 'Se requiere al menos una línea de producto.',
     'invalid_invoice_amounts' => 'Los montos de la factura no son válidos.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -19,6 +19,7 @@ return [
     'monetization_account_not_found' => '指定されたマネタイズアカウントが見つかりません。',
     'monetization_account_already_exists' => 'マネタイズアカウントは既に存在します。',
     'capability_already_granted' => '指定された権限は既に付与されています。',
+    'capability_not_granted' => '必要な権限が付与されていません。',
     'stripe_connect_error' => 'Stripe Connectエラーが発生しました。',
     'empty_invoice_lines' => '少なくとも1つの商品明細が必要です。',
     'invalid_invoice_amounts' => '請求書の金額が無効です。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -19,6 +19,7 @@ return [
     'monetization_account_not_found' => '지정된 수익화 계정을 찾을 수 없습니다.',
     'monetization_account_already_exists' => '수익화 계정이 이미 존재합니다.',
     'capability_already_granted' => '지정된 권한은 이미 부여되었습니다.',
+    'capability_not_granted' => '필요한 권한이 부여되지 않았습니다.',
     'stripe_connect_error' => 'Stripe Connect 오류가 발생했습니다.',
     'empty_invoice_lines' => '최소 하나의 상품 항목이 필요합니다.',
     'invalid_invoice_amounts' => '청구서 금액이 유효하지 않습니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -19,6 +19,7 @@ return [
     'monetization_account_not_found' => '找不到指定的收益化账户。',
     'monetization_account_already_exists' => '收益化账户已存在。',
     'capability_already_granted' => '指定的权限已被授予。',
+    'capability_not_granted' => '尚未授予所需权限。',
     'stripe_connect_error' => 'Stripe Connect发生错误。',
     'empty_invoice_lines' => '至少需要一个商品明细。',
     'invalid_invoice_amounts' => '发票金额无效。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -19,6 +19,7 @@ return [
     'monetization_account_not_found' => '找不到指定的收益化帳戶。',
     'monetization_account_already_exists' => '收益化帳戶已存在。',
     'capability_already_granted' => '指定的權限已被授予。',
+    'capability_not_granted' => '尚未授予所需權限。',
     'stripe_connect_error' => 'Stripe Connect發生錯誤。',
     'empty_invoice_lines' => '至少需要一個商品明細。',
     'invalid_invoice_amounts' => '發票金額無效。',

--- a/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionInterface.php
+++ b/src/Account/DelegationPermission/Application/UseCase/Command/GrantDelegationPermission/GrantDelegationPermissionInterface.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Source\Account\DelegationPermission\Application\UseCase\Command\GrantDelegationPermission;
 
+use Source\Account\IdentityGroup\Application\Exception\IdentityGroupNotFoundException;
+
 interface GrantDelegationPermissionInterface
 {
+    /**
+     * @throws IdentityGroupNotFoundException
+     */
     public function process(GrantDelegationPermissionInputPort $input, GrantDelegationPermissionOutputPort $output): void;
 }

--- a/src/Account/DelegationPermission/Application/UseCase/Command/RevokeDelegationPermission/RevokeDelegationPermissionInterface.php
+++ b/src/Account/DelegationPermission/Application/UseCase/Command/RevokeDelegationPermission/RevokeDelegationPermissionInterface.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Source\Account\DelegationPermission\Application\UseCase\Command\RevokeDelegationPermission;
 
+use Source\Account\DelegationPermission\Application\Exception\DelegationPermissionNotFoundException;
+
 interface RevokeDelegationPermissionInterface
 {
+    /**
+     * @throws DelegationPermissionNotFoundException
+     */
     public function process(RevokeDelegationPermissionInputPort $input): void;
 }

--- a/src/Account/IdentityGroup/Application/UseCase/Command/AddIdentityToIdentityGroup/AddIdentityToIdentityGroupInterface.php
+++ b/src/Account/IdentityGroup/Application/UseCase/Command/AddIdentityToIdentityGroup/AddIdentityToIdentityGroupInterface.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Source\Account\IdentityGroup\Application\UseCase\Command\AddIdentityToIdentityGroup;
 
+use Source\Account\IdentityGroup\Application\Exception\IdentityGroupNotFoundException;
+
 interface AddIdentityToIdentityGroupInterface
 {
+    /**
+     * @throws IdentityGroupNotFoundException
+     */
     public function process(AddIdentityToIdentityGroupInputPort $input, AddIdentityToIdentityGroupOutputPort $output): void;
 }

--- a/src/Account/IdentityGroup/Application/UseCase/Command/DeleteIdentityGroup/DeleteIdentityGroupInterface.php
+++ b/src/Account/IdentityGroup/Application/UseCase/Command/DeleteIdentityGroup/DeleteIdentityGroupInterface.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 namespace Source\Account\IdentityGroup\Application\UseCase\Command\DeleteIdentityGroup;
 
+use Source\Account\IdentityGroup\Application\Exception\CannotDeleteDefaultIdentityGroupException;
+use Source\Account\IdentityGroup\Application\Exception\CannotDeleteLastOwnerGroupException;
+use Source\Account\IdentityGroup\Application\Exception\IdentityGroupNotFoundException;
+
 interface DeleteIdentityGroupInterface
 {
+    /**
+     * @throws CannotDeleteDefaultIdentityGroupException
+     * @throws CannotDeleteLastOwnerGroupException
+     * @throws IdentityGroupNotFoundException
+     */
     public function process(DeleteIdentityGroupInputPort $input): void;
 }

--- a/src/Account/IdentityGroup/Application/UseCase/Command/RemoveIdentityFromIdentityGroup/RemoveIdentityFromIdentityGroupInterface.php
+++ b/src/Account/IdentityGroup/Application/UseCase/Command/RemoveIdentityFromIdentityGroup/RemoveIdentityFromIdentityGroupInterface.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Account\IdentityGroup\Application\UseCase\Command\RemoveIdentityFromIdentityGroup;
 
+use Source\Account\IdentityGroup\Application\Exception\CannotRemoveLastOwnerException;
+use Source\Account\IdentityGroup\Application\Exception\IdentityGroupNotFoundException;
+
 interface RemoveIdentityFromIdentityGroupInterface
 {
+    /**
+     * @throws CannotRemoveLastOwnerException
+     * @throws IdentityGroupNotFoundException
+     */
     public function process(RemoveIdentityFromIdentityGroupInputPort $input, RemoveIdentityFromIdentityGroupOutputPort $output): void;
 }

--- a/src/Identity/Application/UseCase/Command/SocialLogin/Redirect/SocialLoginRedirectInterface.php
+++ b/src/Identity/Application/UseCase/Command/SocialLogin/Redirect/SocialLoginRedirectInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Identity\Application\UseCase\Command\SocialLogin\Redirect;
 
 use Random\RandomException;
+use Source\Identity\Domain\Exception\InvalidOAuthStateException;
 
 interface SocialLoginRedirectInterface
 {
@@ -12,6 +13,7 @@ interface SocialLoginRedirectInterface
      * @param SocialLoginRedirectInputPort $input
      * @param SocialLoginRedirectOutputPort $output
      * @return void
+     * @throws InvalidOAuthStateException
      * @throws RandomException
      */
     public function process(SocialLoginRedirectInputPort $input, SocialLoginRedirectOutputPort $output): void;

--- a/src/Identity/Domain/Service/SocialOAuthServiceInterface.php
+++ b/src/Identity/Domain/Service/SocialOAuthServiceInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Service;
 
+use Source\Identity\Domain\Exception\SocialOAuthException;
 use Source\Identity\Domain\ValueObject\OAuthCode;
 use Source\Identity\Domain\ValueObject\OAuthState;
 use Source\Identity\Domain\ValueObject\SocialProfile;
@@ -13,5 +14,8 @@ interface SocialOAuthServiceInterface
 {
     public function buildRedirectUrl(SocialProvider $provider, OAuthState $state): string;
 
+    /**
+     * @throws SocialOAuthException
+     */
     public function fetchProfile(SocialProvider $provider, OAuthCode $code): SocialProfile;
 }

--- a/src/Monetization/Account/Application/UseCase/Command/SyncPayoutAccount/SyncPayoutAccountInterface.php
+++ b/src/Monetization/Account/Application/UseCase/Command/SyncPayoutAccount/SyncPayoutAccountInterface.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Account\Application\UseCase\Command\SyncPayoutAccount;
 
+use Source\Monetization\Account\Domain\Exception\MonetizationAccountNotFoundException;
+
 interface SyncPayoutAccountInterface
 {
+    /**
+     * @throws MonetizationAccountNotFoundException
+     */
     public function process(SyncPayoutAccountInputPort $input): void;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiInterface.php
@@ -9,6 +9,7 @@ use Source\Wiki\Shared\Domain\Exception\DisallowedException;
 use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Wiki\Application\Exception\ExistsApprovedDraftWikiException;
+use Source\Wiki\Wiki\Application\Exception\InconsistentVersionException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 
 interface ApproveWikiInterface
@@ -20,6 +21,7 @@ interface ApproveWikiInterface
      * @throws WikiNotFoundException
      * @throws ExistsApprovedDraftWikiException
      * @throws InvalidStatusException
+     * @throws InconsistentVersionException
      * @throws DisallowedException
      * @throws DuplicateSlugException
      * @throws PrincipalNotFoundException

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Application\UseCase\Command\EditWiki;
 
 use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\InvalidStatusException;
 use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
 use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 
@@ -15,6 +16,7 @@ interface EditWikiInterface
      * @param EditWikiOutputPort $output
      * @return void
      * @throws WikiNotFoundException
+     * @throws InvalidStatusException
      * @throws DisallowedException
      * @throws PrincipalNotFoundException
      */

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyDraftWiki/GetAgencyDraftWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyDraftWiki/GetAgencyDraftWikiInterface.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyDraftWiki;
 
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Query\DraftWikiReadModel;
 
 interface GetAgencyDraftWikiInterface
 {
+    /**
+     * @throws WikiNotFoundException
+     */
     public function process(GetAgencyDraftWikiInputPort $input): DraftWikiReadModel;
 }

--- a/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInterface.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/GetAgencyWiki/GetAgencyWikiInterface.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Wiki\Application\UseCase\Query\GetAgencyWiki;
 
+use Source\Wiki\Wiki\Application\Exception\WikiNotFoundException;
 use Source\Wiki\Wiki\Application\UseCase\Query\WikiReadModel;
 
 interface GetAgencyWikiInterface
 {
+    /**
+     * @throws WikiNotFoundException
+     */
     public function process(GetAgencyWikiInputPort $input): WikiReadModel;
 }

--- a/tests/Monetization/Shared/Service/PaymentMatcherServiceTest.php
+++ b/tests/Monetization/Shared/Service/PaymentMatcherServiceTest.php
@@ -120,9 +120,6 @@ class PaymentMatcherServiceTest extends TestCase
         $matcher->match($invoice, $payment, new DateTimeImmutable());
     }
 
-    /**
-     * @throws Exception
-     */
     private function createInvoice(OrderIdentifier $orderIdentifier): Invoice
     {
         $issuedAt = new DateTimeImmutable('2024-01-01');


### PR DESCRIPTION
## 📝 変更内容

PHPStan の設定を拡張し、以下のカスタムルールを追加しました。

- Action の例外処理が Problem Details JSON と InternalServerErrorHttpException へ統一されていることを検査
- Source 配下の Application/Domain 例外が broad catch 前に HTTP 例外へ変換されていることを検査
- Domain 層と UseCase が Infrastructure や外部ライブラリへ依存しないことを検査
- checked exception の PHPDoc 検査を有効化し、既存 UseCase interface の `@throws` を補完
- 既存 Action の例外変換・ログ出力を新ルールに合わせて調整

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

例外変換漏れやレイヤー境界違反をレビューや実行時まで持ち越さず、静的解析で継続的に検出できるようにするためです。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`
  - PHPStan: No errors
  - PHPUnit: OK (2699 tests, 8715 assertions)

## 🔍 レビューのポイント

- 追加した PHPStan カスタムルールの検出条件が過剰・不足になっていないか
- Action の例外レスポンス形式が既存方針と整合しているか
- Domain 層と UseCase の許可依存リストが妥当か

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

破壊的変更・マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した