### PR TITLE
feature: Wiki一覧APIにトップページ用ソートを追加

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Query/ListWikis/ListWikisRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Query/ListWikis/ListWikisRequest.php
@@ -36,7 +36,7 @@ class ListWikisRequest extends FormRequest
                 ResourceType::SONG->value,
             ])],
             'keyword' => ['nullable', 'string'],
-            'sort' => ['nullable', 'string', Rule::in(['updatedAt', 'name'])],
+            'sort' => ['nullable', 'string', Rule::in(['updatedAt', 'name', 'createdAt', 'version'])],
             'order' => ['nullable', 'string', Rule::in(['asc', 'desc'])],
         ];
     }

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2436,8 +2436,15 @@ paths:
         - name: sort
           in: query
           required: false
+          description: Sort field. Use createdAt for newly created wikis and version for most frequently updated wikis.
           schema:
             type: string
+            enum:
+              - updatedAt
+              - name
+              - createdAt
+              - version
+            nullable: true
           explode: false
         - name: order
           in: query

--- a/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
@@ -101,12 +101,20 @@ readonly class ListWikis implements ListWikisInterface
     {
         if ($sort === 'name') {
             $query->orderBy(DB::raw($this->nameSortExpression()), $order)
-                ->orderBy('wikis.updated_at', 'desc');
+                ->orderBy('wikis.updated_at', 'desc')
+                ->orderBy('wikis.id');
 
             return;
         }
 
-        $query->orderBy('wikis.updated_at', $order);
+        $sortColumns = [
+            'createdAt' => 'wikis.created_at',
+            'updatedAt' => 'wikis.updated_at',
+            'version' => 'wikis.version',
+        ];
+
+        $query->orderBy($sortColumns[$sort], $order)
+            ->orderBy('wikis.id');
     }
 
     private function nameSortExpression(): string

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListWikisTest.php
@@ -114,6 +114,55 @@ class ListWikisTest extends TestCase
     }
 
     #[Group('useDb')]
+    public function testProcessSortsByCreatedAtAscending(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f611', 'talent', 'tl-alpha', 'Alpha', 'alpha', '2026-05-03 00:00:00', createdAt: '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f612', 'group', 'gr-beta', 'Beta', 'beta', '2026-05-01 00:00:00', createdAt: '2026-05-02 00:00:00');
+
+        $payload = $this->process(new ListWikisInput(language: Language::KOREAN, sort: 'createdAt', order: 'asc'))->toArray();
+
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f611',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f612',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessSortsByCreatedAtDescending(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f621', 'talent', 'tl-alpha', 'Alpha', 'alpha', '2026-05-03 00:00:00', createdAt: '2026-05-01 00:00:00');
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f622', 'group', 'gr-beta', 'Beta', 'beta', '2026-05-01 00:00:00', createdAt: '2026-05-02 00:00:00');
+
+        $payload = $this->process(new ListWikisInput(language: Language::KOREAN, sort: 'createdAt', order: 'desc'))->toArray();
+
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f622',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f621',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessSortsByVersionDescendingWithResourceType(): void
+    {
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f631', 'talent', 'tl-alpha', 'Alpha', 'alpha', '2026-05-01 00:00:00', version: 2);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f632', 'talent', 'tl-beta', 'Beta', 'beta', '2026-05-02 00:00:00', version: 5);
+        $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f633', 'group', 'gr-gamma', 'Gamma', 'gamma', '2026-05-03 00:00:00', version: 9);
+
+        $payload = $this->process(new ListWikisInput(
+            language: Language::KOREAN,
+            resourceType: ResourceType::TALENT,
+            sort: 'version',
+            order: 'desc',
+        ))->toArray();
+
+        $this->assertSame(2, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f632',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f631',
+        ], array_column($payload['wikis'], 'wikiIdentifier'));
+    }
+
+    #[Group('useDb')]
     public function testProcessFiltersByLanguage(): void
     {
         $this->createWiki('01965bb2-bcc9-7c6f-8b90-89f7f217f701', 'talent', 'tl-alpha-ko', 'Alpha KO', 'alpha', '2026-05-01 00:00:00', 'ko');
@@ -187,6 +236,8 @@ class ListWikisTest extends TestCase
         string $updatedAt,
         string $language = 'ko',
         ?string $imageIdentifier = null,
+        ?string $createdAt = null,
+        int $version = 1,
     ): void {
         CreateWiki::create(
             $wikiId,
@@ -199,6 +250,7 @@ class ListWikisTest extends TestCase
                 'title' => "{$name} Wiki",
                 'meta_description' => "{$name} profile.",
                 'keywords' => json_encode([$name, $resourceType]),
+                'version' => $version,
             ],
             [
                 'name' => $name,
@@ -210,7 +262,7 @@ class ListWikisTest extends TestCase
             ->where('id', $wikiId)
             ->update([
                 'updated_at' => $updatedAt,
-                'created_at' => $updatedAt,
+                'created_at' => $createdAt ?? $updatedAt,
             ]);
     }
 }

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -369,7 +369,8 @@ interface WikiListOperations {
     @query perPage?: int32,
     @query resourceType?: string,
     @query keyword?: string,
-    @query sort?: string,
+    @doc("Sort field. Use createdAt for newly created wikis and version for most frequently updated wikis.")
+    @query sort?: "updatedAt" | "name" | "createdAt" | "version" | null,
     @query order?: string,
   ): ListWikisResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- Wiki一覧APIの `sort` query validation に `createdAt` / `version` を追加しました。
- `ListWikis::applySort()` で以下のソートを追加しました。
  - `createdAt`: `wikis.created_at`
  - `version`: `wikis.version`
- 既存の `updatedAt` / `name` ソートを維持しつつ、同値時の安定ソートとして `wikis.id` を追加しました。
- TypeSpec / 生成OpenAPIに `GET /wikis/{language}` の `sort` enum を反映しました。
- `createdAt` 昇順・降順、`version` 降順 + `resourceType` 併用、request validation のテストを追加しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

公開トップページで「新着Wiki」と「更新回数の多いWiki」を表示するため、既存の `GET /wikis/{language}` で指定できるソート条件を拡張する必要がありました。更新回数は現行DBの `wikis.version` を利用します。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
  - PHP CS Fixer: Fixed 0 of 2257 files
  - PHPStan: No errors
  - PHPUnit: OK (2718 tests, 8786 assertions)
- [x] 新しく追加した機能に対するテストを作成
  - `ListWikisTest`: `createdAt` 昇順・降順、`version` 降順 + `resourceType` 併用
  - `ListWikisRequestTest`: `updatedAt` / `name` / `createdAt` / `version` 許可、未知sort拒否
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task test filter=ListWikis keepdb=1`: OK (16 tests, 60 assertions)
- `task test-no-db filter=ListWikisRequest`: OK (2 tests, 6 assertions)
- `task openapi`: TypeSpec compile / OpenAPI generation completed successfully

## 🔍 レビューのポイント

- `sort` query validation と `applySort()` の対応が一致しているか
- `createdAt` が `wikis.created_at`、`version` が `wikis.version` に正しく対応しているか
- `resourceType` 絞り込みと新ソート条件の併用で意図通りの順序になるか
- `updatedAt` / `name` の既存挙動に互換性があるか
- 同値時の `wikis.id` による安定ソートが妥当か

## 📖 関連情報

### 関連Issue・タスク

Closes #431

## ⚠️ 注意事項

- DBマイグレーションはありません。
- 「更新回数」は Issue 指示通り `wikis.version` を使用しています。
- プロジェクトスキル `qa-review`, `test-review`, `security-review`, `architecture-review` は Hermes/Codex/リポジトリ内で定義ファイルを検出できなかったため、同名観点で代替レビューを実施しました。未対応の妥当な指摘はありません。

## 📸 スクリーンショット・デモ

API変更のみのため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
