### PR TITLE
Identity更新API追加とIdentityName rename

### DIFF
--- a/application/Http/Action/Identity/Command/CreateIdentity/CreateIdentityAction.php
+++ b/application/Http/Action/Identity/Command/CreateIdentity/CreateIdentityAction.php
@@ -22,8 +22,8 @@ use Source\Identity\Domain\Exception\AlreadyUserExistsException;
 use Source\Identity\Domain\Exception\AuthCodeSessionNotFoundException;
 use Source\Identity\Domain\Exception\PasswordMismatchException;
 use Source\Identity\Domain\Exception\UnauthorizedEmailException;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\Language;
@@ -48,7 +48,7 @@ readonly class CreateIdentityAction
         try {
             try {
                 $input = new CreateIdentityInput(
-                    username: new UserName($request->username()),
+                    identityName: new IdentityName($request->identityName()),
                     email: new Email($request->email()),
                     language: Language::from($request->language()),
                     password: new PlainPassword($request->password()),

--- a/application/Http/Action/Identity/Command/CreateIdentity/CreateIdentityRequest.php
+++ b/application/Http/Action/Identity/Command/CreateIdentity/CreateIdentityRequest.php
@@ -17,7 +17,7 @@ class CreateIdentityRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'username' => ['required', 'string'],
+            'identityName' => ['required', 'string'],
             'email' => ['required', 'email'],
             'password' => ['required', 'string'],
             'confirmedPassword' => ['required', 'string'],
@@ -26,9 +26,9 @@ class CreateIdentityRequest extends FormRequest
         ];
     }
 
-    public function username(): string
+    public function identityName(): string
     {
-        return (string) $this->input('username');
+        return (string) $this->input('identityName');
     }
 
     public function email(): string

--- a/application/Http/Action/Identity/Command/UpdateIdentity/UpdateIdentityAction.php
+++ b/application/Http/Action/Identity/Command/UpdateIdentity/UpdateIdentityAction.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Identity\Command\UpdateIdentity;
+
+use Application\Http\Action\Identity\Support\IdentityResponsePayload;
+use Application\Http\Context\ActorContext;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityInput;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityInterface;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityOutput;
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Source\Identity\Domain\Exception\InvalidDelegationException;
+use Source\Identity\Domain\ValueObject\IdentityName;
+use Source\Shared\Application\Exception\InvalidBase64ImageException;
+use Source\Shared\Domain\ValueObject\Language;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class UpdateIdentityAction
+{
+    public function __construct(
+        private UpdateIdentityInterface $updateIdentity,
+        private ActorContext $actorContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(UpdateIdentityRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new UpdateIdentityInput(
+                    identityIdentifier: $this->actorContext->identityIdentifier,
+                    delegationIdentifier: $this->actorContext->delegationIdentifier,
+                    originalIdentityIdentifier: $this->actorContext->originalIdentityIdentifier,
+                    identityName: $request->identityName() !== null ? new IdentityName($request->identityName()) : null,
+                    language: $request->language() !== null ? Language::from($request->language()) : null,
+                    base64EncodedImage: $request->base64EncodedImage(),
+                );
+                $output = new UpdateIdentityOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+            $language = $request->requestLanguage();
+
+            try {
+                $this->updateIdentity->process($input, $output);
+                DB::commit();
+            } catch (IdentityNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('identity_not_found', $language), previous: $e);
+            } catch (InvalidDelegationException $e) {
+                DB::rollBack();
+
+                throw new ForbiddenHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (InvalidBase64ImageException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('invalid_base64_image', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (NotFoundHttpException|ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json(IdentityResponsePayload::normalizeProfileImage($output->toArray()), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Identity/Command/UpdateIdentity/UpdateIdentityRequest.php
+++ b/application/Http/Action/Identity/Command/UpdateIdentity/UpdateIdentityRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Identity\Command\UpdateIdentity;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateIdentityRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'identityName' => ['nullable', 'string'],
+            'language' => ['nullable', 'string'],
+            'base64EncodedImage' => ['nullable', 'string'],
+        ];
+    }
+
+    public function identityName(): ?string
+    {
+        $value = $this->input('identityName');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function language(): ?string
+    {
+        $value = $this->input('language');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function base64EncodedImage(): ?string
+    {
+        $value = $this->input('base64EncodedImage');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function requestLanguage(): string
+    {
+        return (string) ($this->input('requestLanguage') ?? 'en');
+    }
+}

--- a/application/Models/Identity/Identity.php
+++ b/application/Models/Identity/Identity.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Carbon;
 
 /**
  * @property string $id
- * @property string $username
+ * @property string $identity_name
  * @property string $email
  * @property string $language
  * @property ?string $profile_image
@@ -25,7 +25,7 @@ use Illuminate\Support\Carbon;
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',
-    'username',
+    'identity_name',
     'email',
     'language',
     'profile_image',

--- a/application/Providers/Identity/UseCaseServiceProvider.php
+++ b/application/Providers/Identity/UseCaseServiceProvider.php
@@ -19,6 +19,8 @@ use Source\Identity\Application\UseCase\Command\SocialLogin\Redirect\SocialLogin
 use Source\Identity\Application\UseCase\Command\SocialLogin\Redirect\SocialLoginRedirectInterface;
 use Source\Identity\Application\UseCase\Command\SwitchIdentity\SwitchIdentity;
 use Source\Identity\Application\UseCase\Command\SwitchIdentity\SwitchIdentityInterface;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentity;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityInterface;
 use Source\Identity\Application\UseCase\Command\VerifyEmail\VerifyEmail;
 use Source\Identity\Application\UseCase\Command\VerifyEmail\VerifyEmailInterface;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
@@ -36,6 +38,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(SocialLoginRedirectInterface::class, SocialLoginRedirect::class);
         $this->app->singleton(SocialLoginCallbackInterface::class, SocialLoginCallback::class);
         $this->app->singleton(SwitchIdentityInterface::class, SwitchIdentity::class);
+        $this->app->singleton(UpdateIdentityInterface::class, UpdateIdentity::class);
         $this->app->singleton(GetAuthenticatedIdentityInterface::class, GetAuthenticatedIdentity::class);
     }
 }

--- a/database/migrations/2024_01_01_000000_create_identities_table.php
+++ b/database/migrations/2024_01_01_000000_create_identities_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('identities', static function (Blueprint $table) {
             $table->uuid('id')->primary()->comment('アイデンティティID');
-            $table->string('username', 32)->comment('ユーザー名');
+            $table->string('identity_name', 32)->comment('ユーザー名');
             $table->string('email', 255)->unique()->comment('メールアドレス');
             $table->string('language', 8)->comment('言語設定');
             $table->string('profile_image', 2048)->nullable()->comment('プロフィール画像');

--- a/database/seeders/FullAccessTestAccountSeeder.php
+++ b/database/seeders/FullAccessTestAccountSeeder.php
@@ -45,7 +45,7 @@ class FullAccessTestAccountSeeder extends Seeder
         DB::table('identities')->upsert([
             [
                 'id' => self::IDENTITY_ID,
-                'username' => 'full-access-test',
+                'identity_name' => 'full-access-test',
                 'email' => self::EMAIL,
                 'language' => 'ja',
                 'profile_image' => null,

--- a/doc/openapi/KPool.IdentityApi.openapi.yaml
+++ b/doc/openapi/KPool.IdentityApi.openapi.yaml
@@ -339,6 +339,54 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/VerifyEmailRequestBody'
+  /identities/me:
+    patch:
+      operationId: IdentityOperations_updateIdentity
+      description: Update the current identity profile.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when an identity operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentitySummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIdentityRequestBody'
 components:
   schemas:
     AuthenticatedIdentitySummary:
@@ -358,14 +406,14 @@ components:
     CreateIdentityRequestBody:
       type: object
       required:
-        - username
+        - identityName
         - email
         - password
         - confirmedPassword
       properties:
-        username:
+        identityName:
           type: string
-          description: Requested username.
+          description: Requested identityName.
         email:
           type: string
           description: Email address.
@@ -388,7 +436,7 @@ components:
       type: object
       required:
         - identityIdentifier
-        - username
+        - identityName
         - email
         - language
       properties:
@@ -396,9 +444,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier.
-        username:
+        identityName:
           type: string
-          description: Username.
+          description: IdentityName.
         email:
           type: string
           description: Email address.
@@ -467,14 +515,6 @@ components:
           nullable: true
           description: Application return path after login.
       description: Request body for logging in.
-    OkIdentityResponse:
-      type: object
-      required:
-        - body
-      properties:
-        body:
-          $ref: '#/components/schemas/IdentitySummary'
-      description: Response returned when an identity operation succeeds.
     RedirectUrlResult:
       type: object
       required:
@@ -514,6 +554,22 @@ components:
       allOf:
         - $ref: '#/components/schemas/IdentitySummary'
       description: Identity summary returned after switching active identity.
+    UpdateIdentityRequestBody:
+      type: object
+      properties:
+        identityName:
+          type: string
+          nullable: true
+          description: Identity display name.
+        language:
+          type: string
+          nullable: true
+          description: Language code associated with the identity.
+        base64EncodedImage:
+          type: string
+          nullable: true
+          description: Base64-encoded profile image.
+      description: Request body for updating an identity profile.
     VerifyEmailRequestBody:
       type: object
       required:

--- a/routes/identity_api.php
+++ b/routes/identity_api.php
@@ -9,6 +9,7 @@ use Application\Http\Action\Identity\Command\SendAuthCode\SendAuthCodeAction;
 use Application\Http\Action\Identity\Command\SocialLogin\Callback\SocialLoginCallbackAction;
 use Application\Http\Action\Identity\Command\SocialLogin\Redirect\SocialLoginRedirectAction;
 use Application\Http\Action\Identity\Command\SwitchIdentity\SwitchIdentityAction;
+use Application\Http\Action\Identity\Command\UpdateIdentity\UpdateIdentityAction;
 use Application\Http\Action\Identity\Command\VerifyEmail\VerifyEmailAction;
 use Application\Http\Action\Identity\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityAction;
 use Illuminate\Support\Facades\Route;
@@ -28,4 +29,5 @@ Route::middleware(['auth.api', 'resolve.actor'])->group(function () {
     Route::get('/auth/me', GetAuthenticatedIdentityAction::class);
     Route::post('/auth/logout', LogoutAction::class);
     Route::post('/auth/switch-identity', SwitchIdentityAction::class);
+    Route::patch('/identities/me', UpdateIdentityAction::class);
 });

--- a/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentity.php
+++ b/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentity.php
@@ -54,7 +54,7 @@ readonly class CreateIdentity implements CreateIdentityInterface
         }
 
         $identity = $this->identityFactory->create(
-            $input->username(),
+            $input->identityName(),
             $input->email(),
             $input->language(),
             $input->password(),

--- a/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityInput.php
+++ b/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityInput.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Source\Identity\Application\UseCase\Command\CreateIdentity;
 
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\Language;
 
 readonly class CreateIdentityInput implements CreateIdentityInputPort
 {
     public function __construct(
-        private UserName         $username,
+        private IdentityName         $identityName,
         private Email            $email,
         private Language         $language,
         private PlainPassword    $password,
@@ -23,9 +23,9 @@ readonly class CreateIdentityInput implements CreateIdentityInputPort
     ) {
     }
 
-    public function username(): UserName
+    public function identityName(): IdentityName
     {
-        return $this->username;
+        return $this->identityName;
     }
 
     public function email(): Email

--- a/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityInputPort.php
+++ b/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityInputPort.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Source\Identity\Application\UseCase\Command\CreateIdentity;
 
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\Language;
 
 interface CreateIdentityInputPort
 {
-    public function userName(): UserName;
+    public function identityName(): IdentityName;
 
     public function email(): Email;
 

--- a/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityOutput.php
+++ b/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityOutput.php
@@ -28,7 +28,7 @@ class CreateIdentityOutput implements CreateIdentityOutputPort
 
         return [
             'identityIdentifier' => (string) $identity->identityIdentifier(),
-            'username' => (string) $identity->username(),
+            'identityName' => (string) $identity->identityName(),
             'email' => (string) $identity->email(),
             'language' => $identity->language()->value,
             'profileImage' => $identity->profileImage() !== null ? (string) $identity->profileImage() : null,

--- a/src/Identity/Application/UseCase/Command/Login/LoginOutput.php
+++ b/src/Identity/Application/UseCase/Command/Login/LoginOutput.php
@@ -35,7 +35,7 @@ class LoginOutput implements LoginOutputPort
 
         return [
             'identityIdentifier' => (string) $identity->identityIdentifier(),
-            'username' => (string) $identity->username(),
+            'identityName' => (string) $identity->identityName(),
             'email' => (string) $identity->email(),
             'language' => $identity->language()->value,
             'profileImage' => $identity->profileImage() !== null ? (string) $identity->profileImage() : null,

--- a/src/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallback.php
+++ b/src/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallback.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Identity\Application\UseCase\Command\SocialLogin\Callback;
 
+use Psr\Log\LoggerInterface;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Identity\Domain\Event\IdentityCreated;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
@@ -15,7 +16,9 @@ use Source\Identity\Domain\Repository\SignupSessionRepositoryInterface;
 use Source\Identity\Domain\Service\AuthServiceInterface;
 use Source\Identity\Domain\Service\SocialOAuthServiceInterface;
 use Source\Identity\Domain\ValueObject\SocialConnection;
+use Source\Shared\Application\Exception\InvalidRemoteImageException;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
+use Source\Shared\Application\Service\ImageServiceInterface;
 
 readonly class SocialLoginCallback implements SocialLoginCallbackInterface
 {
@@ -29,6 +32,8 @@ readonly class SocialLoginCallback implements SocialLoginCallbackInterface
         private SignupSessionRepositoryInterface   $signupSessionRepository,
         private AuthServiceInterface               $authService,
         private EventDispatcherInterface           $eventDispatcher,
+        private ImageServiceInterface              $imageService,
+        private LoggerInterface                    $logger,
     ) {
     }
 
@@ -77,6 +82,18 @@ readonly class SocialLoginCallback implements SocialLoginCallbackInterface
         $accountType = $signupSession?->accountType() ?? AccountType::INDIVIDUAL;
 
         $newIdentity = $this->identityFactory->createFromSocialProfile($profile);
+        if ($profile->avatarUrl() !== null) {
+            try {
+                $uploadResult = $this->imageService->importFromUrl($profile->avatarUrl());
+                $newIdentity->setProfileImage($uploadResult->resized);
+            } catch (InvalidRemoteImageException $e) {
+                $this->logger->warning('Failed to import social profile image.', [
+                    'provider' => $input->provider()->value,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
         if (! $newIdentity->hasSocialConnection($connection)) {
             $newIdentity->addSocialConnection($connection);
         }

--- a/src/Identity/Application/UseCase/Command/SwitchIdentity/SwitchIdentityOutput.php
+++ b/src/Identity/Application/UseCase/Command/SwitchIdentity/SwitchIdentityOutput.php
@@ -28,7 +28,7 @@ class SwitchIdentityOutput implements SwitchIdentityOutputPort
 
         return [
             'identityIdentifier' => (string) $identity->identityIdentifier(),
-            'username' => (string) $identity->username(),
+            'identityName' => (string) $identity->identityName(),
             'email' => (string) $identity->email(),
             'language' => $identity->language()->value,
             'profileImage' => $identity->profileImage() !== null ? (string) $identity->profileImage() : null,

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentity.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentity.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Source\Identity\Domain\Exception\InvalidDelegationException;
+use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
+use Source\Identity\Domain\Service\AuthServiceInterface;
+use Source\Shared\Application\Exception\InvalidBase64ImageException;
+use Source\Shared\Application\Service\ImageServiceInterface;
+
+readonly class UpdateIdentity implements UpdateIdentityInterface
+{
+    public function __construct(
+        private IdentityRepositoryInterface $identityRepository,
+        private ImageServiceInterface $imageService,
+        private AuthServiceInterface $authService,
+    ) {
+    }
+
+    /**
+     * @throws IdentityNotFoundException
+     * @throws InvalidDelegationException
+     * @throws InvalidBase64ImageException
+     */
+    public function process(UpdateIdentityInputPort $input, UpdateIdentityOutputPort $output): void
+    {
+        if ($input->delegationIdentifier() !== null || $input->originalIdentityIdentifier() !== null) {
+            throw new InvalidDelegationException('Delegated identity cannot update profile.');
+        }
+
+        $identity = $this->identityRepository->findById($input->identityIdentifier());
+        if ($identity === null) {
+            throw new IdentityNotFoundException('Identity not found.');
+        }
+
+        if ($input->identityName() !== null) {
+            $identity->setIdentityName($input->identityName());
+        }
+        if ($input->language() !== null) {
+            $identity->setLanguage($input->language());
+        }
+        if ($input->base64EncodedImage() !== null) {
+            $uploadResult = $this->imageService->upload($input->base64EncodedImage());
+            $identity->setProfileImage($uploadResult->resized);
+        }
+
+        $this->identityRepository->save($identity);
+        $this->authService->refreshAuthenticatedIdentity($identity);
+        $output->setIdentity($identity);
+    }
+}

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInput.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInput.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use Source\Identity\Domain\ValueObject\IdentityName;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
+
+readonly class UpdateIdentityInput implements UpdateIdentityInputPort
+{
+    public function __construct(
+        private IdentityIdentifier $identityIdentifier,
+        private ?DelegationIdentifier $delegationIdentifier,
+        private ?IdentityIdentifier $originalIdentityIdentifier,
+        private ?IdentityName $identityName,
+        private ?Language $language,
+        private ?string $base64EncodedImage,
+    ) {
+    }
+
+    public function identityIdentifier(): IdentityIdentifier
+    {
+        return $this->identityIdentifier;
+    }
+
+    public function delegationIdentifier(): ?DelegationIdentifier
+    {
+        return $this->delegationIdentifier;
+    }
+
+    public function originalIdentityIdentifier(): ?IdentityIdentifier
+    {
+        return $this->originalIdentityIdentifier;
+    }
+
+    public function identityName(): ?IdentityName
+    {
+        return $this->identityName;
+    }
+
+    public function language(): ?Language
+    {
+        return $this->language;
+    }
+
+    public function base64EncodedImage(): ?string
+    {
+        return $this->base64EncodedImage;
+    }
+}

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputPort.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputPort.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use Source\Identity\Domain\ValueObject\IdentityName;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
+
+interface UpdateIdentityInputPort
+{
+    public function identityIdentifier(): IdentityIdentifier;
+
+    public function delegationIdentifier(): ?DelegationIdentifier;
+
+    public function originalIdentityIdentifier(): ?IdentityIdentifier;
+
+    public function identityName(): ?IdentityName;
+
+    public function language(): ?Language;
+
+    public function base64EncodedImage(): ?string;
+}

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInterface.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Source\Identity\Domain\Exception\InvalidDelegationException;
+use Source\Shared\Application\Exception\InvalidBase64ImageException;
+
+interface UpdateIdentityInterface
+{
+    /**
+     * @throws IdentityNotFoundException
+     * @throws InvalidDelegationException
+     * @throws InvalidBase64ImageException
+     */
+    public function process(UpdateIdentityInputPort $input, UpdateIdentityOutputPort $output): void;
+}

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityOutput.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityOutput.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use Source\Identity\Domain\Entity\Identity;
+
+class UpdateIdentityOutput implements UpdateIdentityOutputPort
+{
+    private ?Identity $identity = null;
+
+    public function setIdentity(Identity $identity): void
+    {
+        $this->identity = $identity;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        if ($this->identity === null) {
+            return [];
+        }
+
+        return [
+            'identityIdentifier' => (string) $this->identity->identityIdentifier(),
+            'identityName' => (string) $this->identity->identityName(),
+            'email' => (string) $this->identity->email(),
+            'language' => $this->identity->language()->value,
+            'profileImage' => $this->identity->profileImage() !== null ? (string) $this->identity->profileImage() : null,
+        ];
+    }
+}

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityOutputPort.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use Source\Identity\Domain\Entity\Identity;
+
+interface UpdateIdentityOutputPort
+{
+    public function setIdentity(Identity $identity): void;
+}

--- a/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
+++ b/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
@@ -8,7 +8,7 @@ readonly class AuthenticatedIdentityReadModel
 {
     public function __construct(
         private string $identityIdentifier,
-        private string $username,
+        private string $identityName,
         private string $email,
         private string $language,
         private ?string $profileImage,
@@ -21,9 +21,9 @@ readonly class AuthenticatedIdentityReadModel
         return $this->identityIdentifier;
     }
 
-    public function username(): string
+    public function identityName(): string
     {
-        return $this->username;
+        return $this->identityName;
     }
 
     public function email(): string
@@ -53,7 +53,7 @@ readonly class AuthenticatedIdentityReadModel
     {
         return [
             'identityIdentifier' => $this->identityIdentifier,
-            'username' => $this->username,
+            'identityName' => $this->identityName,
             'email' => $this->email,
             'language' => $this->language,
             'profileImage' => $this->profileImage,

--- a/src/Identity/Domain/Entity/Identity.php
+++ b/src/Identity/Domain/Entity/Identity.php
@@ -9,9 +9,9 @@ use Source\Identity\Domain\Exception\InvalidCredentialsException;
 use Source\Identity\Domain\Exception\SocialConnectionAlreadyExistsException;
 use Source\Identity\Domain\Exception\UnauthorizedEmailException;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
 use Source\Identity\Domain\ValueObject\SocialConnection;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -22,7 +22,7 @@ class Identity
 {
     /**
      * @param IdentityIdentifier $identityIdentifier
-     * @param UserName $username
+     * @param IdentityName $identityName
      * @param Email $email
      * @param Language $language
      * @param ?ImagePath $profileImage
@@ -34,9 +34,9 @@ class Identity
      */
     public function __construct(
         private readonly IdentityIdentifier $identityIdentifier,
-        private readonly UserName                    $username,
+        private IdentityName                    $identityName,
         private readonly Email                       $email,
-        private readonly Language                    $language,
+        private Language                    $language,
         private ?ImagePath                  $profileImage,
         private readonly HashedPassword              $hashedPassword,
         private ?DateTimeImmutable          $emailVerifiedAt,
@@ -51,9 +51,14 @@ class Identity
         return $this->identityIdentifier;
     }
 
-    public function username(): UserName
+    public function identityName(): IdentityName
     {
-        return $this->username;
+        return $this->identityName;
+    }
+
+    public function setIdentityName(IdentityName $identityName): void
+    {
+        $this->identityName = $identityName;
     }
 
     public function email(): Email
@@ -64,6 +69,11 @@ class Identity
     public function language(): Language
     {
         return $this->language;
+    }
+
+    public function setLanguage(Language $language): void
+    {
+        $this->language = $language;
     }
 
     public function profileImage(): ?ImagePath

--- a/src/Identity/Domain/Factory/IdentityFactoryInterface.php
+++ b/src/Identity/Domain/Factory/IdentityFactoryInterface.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Source\Identity\Domain\Factory;
 
 use Source\Identity\Domain\Entity\Identity;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
 use Source\Identity\Domain\ValueObject\SocialProfile;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\Language;
@@ -15,7 +15,7 @@ use Source\Shared\Domain\ValueObject\Language;
 interface IdentityFactoryInterface
 {
     public function create(
-        UserName      $username,
+        IdentityName      $identityName,
         Email         $email,
         Language      $language,
         PlainPassword $plainPassword

--- a/src/Identity/Domain/Service/AuthServiceInterface.php
+++ b/src/Identity/Domain/Service/AuthServiceInterface.php
@@ -13,4 +13,6 @@ interface AuthServiceInterface
     public function logout(): void;
 
     public function isLoggedIn(): bool;
+
+    public function refreshAuthenticatedIdentity(Identity $identity): void;
 }

--- a/src/Identity/Domain/ValueObject/IdentityName.php
+++ b/src/Identity/Domain/ValueObject/IdentityName.php
@@ -7,7 +7,7 @@ namespace Source\Identity\Domain\ValueObject;
 use InvalidArgumentException;
 use Source\Shared\Domain\ValueObject\Foundation\StringBaseValue;
 
-class UserName extends StringBaseValue
+class IdentityName extends StringBaseValue
 {
     public const int MAX_LENGTH = 32;
 
@@ -22,11 +22,11 @@ class UserName extends StringBaseValue
         string $value,
     ): void {
         if (empty($value)) {
-            throw new InvalidArgumentException('User name cannot be empty');
+            throw new InvalidArgumentException('Identity name cannot be empty');
         }
 
         if (mb_strlen($value) > self::MAX_LENGTH) {
-            throw new InvalidArgumentException('User name cannot exceed  ' . self::MAX_LENGTH . '  characters');
+            throw new InvalidArgumentException('Identity name cannot exceed  ' . self::MAX_LENGTH . '  characters');
         }
     }
 }

--- a/src/Identity/Infrastructure/Factory/IdentityFactory.php
+++ b/src/Identity/Infrastructure/Factory/IdentityFactory.php
@@ -7,10 +7,10 @@ namespace Source\Identity\Infrastructure\Factory;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Factory\IdentityFactoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
 use Source\Identity\Domain\ValueObject\SocialConnection;
 use Source\Identity\Domain\ValueObject\SocialProfile;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Application\Service\Uuid\UuidGeneratorInterface;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
@@ -25,14 +25,14 @@ readonly class IdentityFactory implements IdentityFactoryInterface
     }
 
     public function create(
-        UserName      $username,
+        IdentityName      $identityName,
         Email         $email,
         Language      $language,
         PlainPassword $plainPassword,
     ): Identity {
         return new Identity(
             new IdentityIdentifier($this->ulidGenerator->generate()),
-            $username,
+            $identityName,
             $email,
             $language,
             null,
@@ -43,12 +43,12 @@ readonly class IdentityFactory implements IdentityFactoryInterface
 
     public function createFromSocialProfile(SocialProfile $profile): Identity
     {
-        $username = $this->buildUserName($profile);
+        $identityName = $this->buildIdentityName($profile);
         $password = $this->generateRandomPassword();
 
         return new Identity(
             new IdentityIdentifier($this->ulidGenerator->generate()),
-            $username,
+            $identityName,
             $profile->email(),
             Language::ENGLISH,
             null,
@@ -58,14 +58,14 @@ readonly class IdentityFactory implements IdentityFactoryInterface
         );
     }
 
-    private function buildUserName(SocialProfile $profile): UserName
+    private function buildIdentityName(SocialProfile $profile): IdentityName
     {
         $name = $profile->name();
         if ($name === null || $name === '') {
             $name = strstr((string)$profile->email(), '@', true) ?: $profile->providerUserId();
         }
 
-        return new UserName(mb_substr($name, 0, UserName::MAX_LENGTH));
+        return new IdentityName(mb_substr($name, 0, IdentityName::MAX_LENGTH));
     }
 
     private function generateRandomPassword(): PlainPassword
@@ -81,7 +81,7 @@ readonly class IdentityFactory implements IdentityFactoryInterface
     ): Identity {
         return new Identity(
             new IdentityIdentifier($this->ulidGenerator->generate()),
-            $originalIdentity->username(),
+            $originalIdentity->identityName(),
             $originalIdentity->email(),
             $originalIdentity->language(),
             $originalIdentity->profileImage(),

--- a/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
+++ b/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
@@ -39,7 +39,7 @@ readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInter
 
         return new AuthenticatedIdentityReadModel(
             identityIdentifier: $model->id,
-            username: $model->username,
+            identityName: $model->identity_name,
             email: $model->email,
             language: $model->language,
             profileImage: ImageUrl::fromPath($model->profile_image),

--- a/src/Identity/Infrastructure/Repository/IdentityRepository.php
+++ b/src/Identity/Infrastructure/Repository/IdentityRepository.php
@@ -10,9 +10,9 @@ use Illuminate\Support\Carbon;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\SocialConnection;
 use Source\Identity\Domain\ValueObject\SocialProvider;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Application\Service\Uuid\UuidGeneratorInterface;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
@@ -63,7 +63,7 @@ readonly class IdentityRepository implements IdentityRepositoryInterface
         $eloquent = IdentityEloquent::query()->updateOrCreate(
             ['id' => (string) $identity->identityIdentifier()],
             [
-                'username' => (string) $identity->username(),
+                'identity_name' => (string) $identity->identityName(),
                 'email' => (string) $identity->email(),
                 'language' => $identity->language()->value,
                 'profile_image' => $identity->profileImage() !== null ? (string) $identity->profileImage() : null,
@@ -178,7 +178,7 @@ readonly class IdentityRepository implements IdentityRepositoryInterface
 
         return new Identity(
             new IdentityIdentifier($eloquent->id),
-            new UserName($eloquent->username),
+            new IdentityName($eloquent->identity_name),
             new Email($eloquent->email),
             Language::from($eloquent->language),
             $eloquent->profile_image !== null ? new ImagePath($eloquent->profile_image) : null,

--- a/src/Identity/Infrastructure/Service/AuthService.php
+++ b/src/Identity/Infrastructure/Service/AuthService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Identity\Infrastructure\Service;
 
+use Application\Models\Identity\Identity as IdentityEloquent;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Source\Identity\Domain\Entity\Identity;
@@ -36,5 +37,14 @@ readonly class AuthService implements AuthServiceInterface
     public function isLoggedIn(): bool
     {
         return Auth::check();
+    }
+
+    public function refreshAuthenticatedIdentity(Identity $identity): void
+    {
+        $eloquent = IdentityEloquent::query()->find((string) $identity->identityIdentifier());
+        if ($eloquent !== null) {
+            Auth::setUser($eloquent);
+            $this->request->setUserResolver(static fn () => $eloquent);
+        }
     }
 }

--- a/src/Shared/Application/Exception/InvalidRemoteImageException.php
+++ b/src/Shared/Application/Exception/InvalidRemoteImageException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Shared\Application\Exception;
+
+use RuntimeException;
+
+class InvalidRemoteImageException extends RuntimeException
+{
+}

--- a/src/Shared/Application/Service/ImageServiceInterface.php
+++ b/src/Shared/Application/Service/ImageServiceInterface.php
@@ -6,6 +6,7 @@ namespace Source\Shared\Application\Service;
 
 use Source\Shared\Application\DTO\ImageUploadResult;
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
+use Source\Shared\Application\Exception\InvalidRemoteImageException;
 
 interface ImageServiceInterface
 {
@@ -15,4 +16,11 @@ interface ImageServiceInterface
      * @throws InvalidBase64ImageException
      */
     public function upload(string $base64EncodedImage): ImageUploadResult;
+
+    /**
+     * @param string $imageUrl
+     * @return ImageUploadResult
+     * @throws InvalidRemoteImageException
+     */
+    public function importFromUrl(string $imageUrl): ImageUploadResult;
 }

--- a/src/Shared/Infrastructure/Service/ImageService.php
+++ b/src/Shared/Infrastructure/Service/ImageService.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Source\Shared\Infrastructure\Service;
 
 use GdImage;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Source\Shared\Application\DTO\ImageUploadResult;
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
+use Source\Shared\Application\Exception\InvalidRemoteImageException;
 use Source\Shared\Application\Service\ImageServiceInterface;
 use Source\Shared\Domain\ValueObject\ImagePath;
+use Throwable;
 
 class ImageService implements ImageServiceInterface
 {
@@ -34,6 +37,36 @@ class ImageService implements ImageServiceInterface
             throw new InvalidBase64ImageException();
         }
 
+        return $this->storeImage($gdImage);
+    }
+
+    public function importFromUrl(string $imageUrl): ImageUploadResult
+    {
+        try {
+            $response = Http::timeout(5)->get($imageUrl);
+        } catch (Throwable $e) {
+            throw new InvalidRemoteImageException('Failed to download remote image.', previous: $e);
+        }
+
+        if (! $response->successful()) {
+            throw new InvalidRemoteImageException('Failed to download remote image.');
+        }
+
+        $imageData = $response->body();
+        if ($imageData === '') {
+            throw new InvalidRemoteImageException('Remote image is empty.');
+        }
+
+        $gdImage = @imagecreatefromstring($imageData);
+        if ($gdImage === false) {
+            throw new InvalidRemoteImageException('Remote URL did not contain a valid image.');
+        }
+
+        return $this->storeImage($gdImage);
+    }
+
+    private function storeImage(GdImage $gdImage): ImageUploadResult
+    {
         $baseFileName = 'images/' . Str::uuid();
 
         // オリジナル画像をwebpで保存
@@ -42,8 +75,6 @@ class ImageService implements ImageServiceInterface
         // リサイズ版を作成して保存
         $resizedImage = $this->resizeImage($gdImage);
         $resizedPath = $this->saveAsWebp($resizedImage, $baseFileName . '_resized.webp');
-        if ($resizedImage !== $gdImage) {
-        }
 
         return new ImageUploadResult(
             new ImagePath($originalPath),

--- a/tests/Helper/CreateIdentity.php
+++ b/tests/Helper/CreateIdentity.php
@@ -14,7 +14,8 @@ class CreateIdentity
 {
     /**
      * @param array{
-     *     username?: string,
+     *     identityName?: string,
+     *     identity_name?: string,
      *     email?: string,
      *     language?: string,
      *     profile_image?: ?string,
@@ -28,7 +29,7 @@ class CreateIdentity
     {
         DB::table('identities')->insert([
             'id' => (string) $identityIdentifier,
-            'username' => $overrides['username'] ?? 'test-identity',
+            'identity_name' => $overrides['identity_name'] ?? $overrides['identityName'] ?? 'test-identity',
             'email' => $overrides['email'] ?? 'test@example.com',
             'language' => $overrides['language'] ?? 'ja',
             'profile_image' => $overrides['profile_image'] ?? null,

--- a/tests/Identity/Application/EventHandler/DelegationApprovedHandlerTest.php
+++ b/tests/Identity/Application/EventHandler/DelegationApprovedHandlerTest.php
@@ -15,8 +15,8 @@ use Source\Identity\Domain\Exception\IdentityNotFoundException;
 use Source\Identity\Domain\Factory\IdentityFactoryInterface;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
@@ -159,7 +159,7 @@ class DelegationApprovedHandlerTest extends TestCase
     {
         return new Identity(
             $identityIdentifier,
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email('test@example.com'),
             Language::JAPANESE,
             null,
@@ -175,7 +175,7 @@ class DelegationApprovedHandlerTest extends TestCase
     ): Identity {
         return new Identity(
             $identityIdentifier,
-            new UserName('delegated-user'),
+            new IdentityName('delegated-user'),
             new Email('delegated@example.com'),
             Language::JAPANESE,
             null,

--- a/tests/Identity/Application/EventHandler/DemotionWarningsBatchIssuedHandlerTest.php
+++ b/tests/Identity/Application/EventHandler/DemotionWarningsBatchIssuedHandlerTest.php
@@ -12,8 +12,8 @@ use Source\Identity\Application\Service\CollaboratorNotificationServiceInterface
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\Language;
@@ -118,7 +118,7 @@ class DemotionWarningsBatchIssuedHandlerTest extends TestCase
     ): Identity {
         return new Identity(
             $identityIdentifier,
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email($email),
             $language,
             null,

--- a/tests/Identity/Application/EventHandler/PrincipalsBatchDemotedHandlerTest.php
+++ b/tests/Identity/Application/EventHandler/PrincipalsBatchDemotedHandlerTest.php
@@ -12,8 +12,8 @@ use Source\Identity\Application\Service\CollaboratorNotificationServiceInterface
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\Language;
@@ -118,7 +118,7 @@ class PrincipalsBatchDemotedHandlerTest extends TestCase
     ): Identity {
         return new Identity(
             $identityIdentifier,
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email($email),
             $language,
             null,

--- a/tests/Identity/Application/EventHandler/PrincipalsBatchPromotedHandlerTest.php
+++ b/tests/Identity/Application/EventHandler/PrincipalsBatchPromotedHandlerTest.php
@@ -12,8 +12,8 @@ use Source\Identity\Application\Service\CollaboratorNotificationServiceInterface
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\Language;
@@ -118,7 +118,7 @@ class PrincipalsBatchPromotedHandlerTest extends TestCase
     ): Identity {
         return new Identity(
             $identityIdentifier,
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email($email),
             $language,
             null,

--- a/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityInputTest.php
+++ b/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityInputTest.php
@@ -6,8 +6,8 @@ namespace Tests\Identity\Application\UseCase\Command\CreateIdentity;
 
 use PHPUnit\Framework\TestCase;
 use Source\Identity\Application\UseCase\Command\CreateIdentity\CreateIdentityInput;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\Language;
 
@@ -15,7 +15,7 @@ class CreateIdentityInputTest extends TestCase
 {
     public function test__construct(): void
     {
-        $userName = new UserName('userName');
+        $identityName = new IdentityName('identityName');
         $email = new Email('user@example.com');
         $language = Language::KOREAN;
         $password = new PlainPassword('PlainPass1!');
@@ -24,7 +24,7 @@ class CreateIdentityInputTest extends TestCase
 
 
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -32,7 +32,7 @@ class CreateIdentityInputTest extends TestCase
             $base64EncodedImage,
         );
 
-        $this->assertSame($userName, $input->userName());
+        $this->assertSame($identityName, $input->identityName());
         $this->assertSame($email, $input->email());
         $this->assertSame($language, $input->language());
         $this->assertSame($password, $input->password());

--- a/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityTest.php
+++ b/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityTest.php
@@ -24,8 +24,8 @@ use Source\Identity\Domain\Repository\AuthCodeSessionRepositoryInterface;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\ValueObject\AuthCode;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Application\DTO\ImageUploadResult;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Application\Service\ImageServiceInterface;
@@ -71,14 +71,14 @@ class CreateIdentityTest extends TestCase
      */
     public function testProcess(): void
     {
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $password = new PlainPassword('PlainPass1!');
         $confirmedPassword = new PlainPassword('PlainPass1!');
         $base64EncodedImage = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAusB9xyxOvUAAAAASUVORK5CYII=';
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -92,7 +92,7 @@ class CreateIdentityTest extends TestCase
 
         $identity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            $userName,
+            $identityName,
             $email,
             $language,
             null,
@@ -130,7 +130,7 @@ class CreateIdentityTest extends TestCase
         $identityFactory = Mockery::mock(IdentityFactoryInterface::class);
         $identityFactory->shouldReceive('create')
             ->once()
-            ->with($userName, $email, $language, $password)
+            ->with($identityName, $email, $language, $password)
             ->andReturn($identity);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
@@ -161,14 +161,14 @@ class CreateIdentityTest extends TestCase
      */
     public function testThrowsAuthCodeSessionNotFoundException(): void
     {
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $password = new PlainPassword('PlainPass1!');
         $confirmedPassword = new PlainPassword('PlainPass1!');
         $base64EncodedImage = null;
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -217,14 +217,14 @@ class CreateIdentityTest extends TestCase
      */
     public function testThrowsAlreadyUserExistsException(): void
     {
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $password = new PlainPassword('PlainPass1!');
         $confirmedPassword = new PlainPassword('PlainPass1!');
         $base64EncodedImage = null;
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -237,7 +237,7 @@ class CreateIdentityTest extends TestCase
 
         $existingIdentity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            $userName,
+            $identityName,
             $email,
             $language,
             null,
@@ -290,14 +290,14 @@ class CreateIdentityTest extends TestCase
      */
     public function testThrowsInvalidArgumentExceptionWhenPasswordsMatch(): void
     {
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $password = new PlainPassword('PlainPass1!');
         $confirmedPassword = new PlainPassword('PlainPass2@');
         $base64EncodedImage = null;
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -335,14 +335,14 @@ class CreateIdentityTest extends TestCase
      */
     public function testThrowsUnauthorizedEmailExceptionWhenSessionIsNotVerified(): void
     {
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $password = new PlainPassword('PlainPass1!');
         $confirmedPassword = new PlainPassword('PlainPass1!');
         $base64EncodedImage = null;
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -368,7 +368,7 @@ class CreateIdentityTest extends TestCase
 
         $identity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            $userName,
+            $identityName,
             $email,
             $language,
             null,
@@ -378,7 +378,7 @@ class CreateIdentityTest extends TestCase
         $identityFactory = Mockery::mock(IdentityFactoryInterface::class);
         $identityFactory->shouldReceive('create')
             ->once()
-            ->with($userName, $email, $language, $password)
+            ->with($identityName, $email, $language, $password)
             ->andReturn($identity);
 
         $imageService = Mockery::mock(ImageServiceInterface::class);
@@ -410,7 +410,7 @@ class CreateIdentityTest extends TestCase
      */
     public function testProcessDispatchesIdentityCreatedViaInvitationEvent(): void
     {
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $password = new PlainPassword('PlainPass1!');
@@ -419,7 +419,7 @@ class CreateIdentityTest extends TestCase
         $invitationToken = new InvitationToken(bin2hex(random_bytes(32)));
 
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -435,7 +435,7 @@ class CreateIdentityTest extends TestCase
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         $identity = new Identity(
             $identityIdentifier,
-            $userName,
+            $identityName,
             $email,
             $language,
             null,
@@ -461,7 +461,7 @@ class CreateIdentityTest extends TestCase
         $identityFactory = Mockery::mock(IdentityFactoryInterface::class);
         $identityFactory->shouldReceive('create')
             ->once()
-            ->with($userName, $email, $language, $password)
+            ->with($identityName, $email, $language, $password)
             ->andReturn($identity);
 
         $imageService = Mockery::mock(ImageServiceInterface::class);
@@ -500,7 +500,7 @@ class CreateIdentityTest extends TestCase
      */
     public function testProcessDoesNotDispatchIdentityCreatedViaInvitationEventWhenTokenIsNull(): void
     {
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $password = new PlainPassword('PlainPass1!');
@@ -508,7 +508,7 @@ class CreateIdentityTest extends TestCase
         $base64EncodedImage = null;
 
         $input = new CreateIdentityInput(
-            $userName,
+            $identityName,
             $email,
             $language,
             $password,
@@ -522,7 +522,7 @@ class CreateIdentityTest extends TestCase
 
         $identity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            $userName,
+            $identityName,
             $email,
             $language,
             null,
@@ -548,7 +548,7 @@ class CreateIdentityTest extends TestCase
         $identityFactory = Mockery::mock(IdentityFactoryInterface::class);
         $identityFactory->shouldReceive('create')
             ->once()
-            ->with($userName, $email, $language, $password)
+            ->with($identityName, $email, $language, $password)
             ->andReturn($identity);
 
         $imageService = Mockery::mock(ImageServiceInterface::class);

--- a/tests/Identity/Application/UseCase/Command/Login/LoginOutputTest.php
+++ b/tests/Identity/Application/UseCase/Command/Login/LoginOutputTest.php
@@ -9,8 +9,8 @@ use PHPUnit\Framework\TestCase;
 use Source\Identity\Application\UseCase\Command\Login\LoginOutput;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\ImagePath;
@@ -29,7 +29,7 @@ class LoginOutputTest extends TestCase
     public function testToArrayReturnsIdentityData(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $profileImage = new ImagePath('/resources/path/test.png');
@@ -38,7 +38,7 @@ class LoginOutputTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            $userName,
+            $identityName,
             $email,
             $language,
             $profileImage,
@@ -53,7 +53,7 @@ class LoginOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
-        $this->assertSame((string) $userName, $result['username']);
+        $this->assertSame((string) $identityName, $result['identityName']);
         $this->assertSame((string) $email, $result['email']);
         $this->assertSame($language->value, $result['language']);
         $this->assertSame((string) $profileImage, $result['profileImage']);
@@ -64,7 +64,7 @@ class LoginOutputTest extends TestCase
     {
         $identity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email('user@example.com'),
             Language::JAPANESE,
             null,

--- a/tests/Identity/Application/UseCase/Command/Login/LoginTest.php
+++ b/tests/Identity/Application/UseCase/Command/Login/LoginTest.php
@@ -17,8 +17,8 @@ use Source\Identity\Domain\Exception\InvalidCredentialsException;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\Service\AuthServiceInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\ImagePath;
@@ -54,7 +54,7 @@ class LoginTest extends TestCase
     public function testProcess(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::KOREAN;
         $profileImage = new ImagePath('/resources/path/test.png');
@@ -66,7 +66,7 @@ class LoginTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            $userName,
+            $identityName,
             $email,
             $language,
             $profileImage,
@@ -137,7 +137,7 @@ class LoginTest extends TestCase
     public function testWhenEmailIsNotVerified(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::KOREAN;
         $profileImage = new ImagePath('/resources/path/test.png');
@@ -149,7 +149,7 @@ class LoginTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            $userName,
+            $identityName,
             $email,
             $language,
             $profileImage,
@@ -186,7 +186,7 @@ class LoginTest extends TestCase
     public function testWhenFailedToVerifyPassword(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::KOREAN;
         $profileImage = new ImagePath('/resources/path/test.png');
@@ -198,7 +198,7 @@ class LoginTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            $userName,
+            $identityName,
             $email,
             $language,
             $profileImage,

--- a/tests/Identity/Application/UseCase/Command/SendAuthCode/SendAuthCodeTest.php
+++ b/tests/Identity/Application/UseCase/Command/SendAuthCode/SendAuthCodeTest.php
@@ -18,8 +18,8 @@ use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\Service\AuthCodeServiceInterface;
 use Source\Identity\Domain\ValueObject\AuthCode;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\ImagePath;
@@ -114,7 +114,7 @@ class SendAuthCodeTest extends TestCase
     public function testWhenEmailAlreadyExists(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $profileImage = new ImagePath('/resources/path/test.png');
@@ -123,7 +123,7 @@ class SendAuthCodeTest extends TestCase
         $emailVerifiedAt = new DateTimeImmutable();
         $identity = new Identity(
             $identityIdentifier,
-            $userName,
+            $identityName,
             $email,
             $language,
             $profileImage,

--- a/tests/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallbackTest.php
+++ b/tests/Identity/Application/UseCase/Command/SocialLogin/Callback/SocialLoginCallbackTest.php
@@ -24,6 +24,7 @@ use Source\Identity\Domain\Repository\SignupSessionRepositoryInterface;
 use Source\Identity\Domain\Service\AuthServiceInterface;
 use Source\Identity\Domain\Service\SocialOAuthServiceInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\OAuthCode;
 use Source\Identity\Domain\ValueObject\OAuthState;
 use Source\Identity\Domain\ValueObject\PlainPassword;
@@ -31,7 +32,6 @@ use Source\Identity\Domain\ValueObject\SignupSession;
 use Source\Identity\Domain\ValueObject\SocialConnection;
 use Source\Identity\Domain\ValueObject\SocialProfile;
 use Source\Identity\Domain\ValueObject\SocialProvider;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -550,13 +550,13 @@ class SocialLoginCallbackTest extends TestCase
     private function createIdentity(Email $email, ?IdentityIdentifier $identityIdentifier = null, array $connections = []): Identity
     {
         $identityIdentifier ??= new IdentityIdentifier(StrTestHelper::generateUuid());
-        $username = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $hashedPassword = HashedPassword::fromPlain(new PlainPassword('PlainPass1!'));
         $language = Language::ENGLISH;
 
         return new Identity(
             $identityIdentifier,
-            $username,
+            $identityName,
             $email,
             $language,
             null,

--- a/tests/Identity/Application/UseCase/Command/SwitchIdentity/SwitchIdentityOutputTest.php
+++ b/tests/Identity/Application/UseCase/Command/SwitchIdentity/SwitchIdentityOutputTest.php
@@ -9,8 +9,8 @@ use PHPUnit\Framework\TestCase;
 use Source\Identity\Application\UseCase\Command\SwitchIdentity\SwitchIdentityOutput;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -32,7 +32,7 @@ class SwitchIdentityOutputTest extends TestCase
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         $originalIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         $delegationIdentifier = new DelegationIdentifier(StrTestHelper::generateUuid());
-        $userName = new UserName('delegated-user');
+        $identityName = new IdentityName('delegated-user');
         $email = new Email('user@example.com');
         $language = Language::KOREAN;
         $profileImage = new ImagePath('/resources/path/test.png');
@@ -41,7 +41,7 @@ class SwitchIdentityOutputTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            $userName,
+            $identityName,
             $email,
             $language,
             $profileImage,
@@ -58,7 +58,7 @@ class SwitchIdentityOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
-        $this->assertSame((string) $userName, $result['username']);
+        $this->assertSame((string) $identityName, $result['identityName']);
         $this->assertSame((string) $email, $result['email']);
         $this->assertSame($language->value, $result['language']);
         $this->assertSame((string) $profileImage, $result['profileImage']);
@@ -69,7 +69,7 @@ class SwitchIdentityOutputTest extends TestCase
     {
         $identity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email('user@example.com'),
             Language::KOREAN,
             new ImagePath('/resources/path/test.png'),

--- a/tests/Identity/Application/UseCase/Command/SwitchIdentity/SwitchIdentityTest.php
+++ b/tests/Identity/Application/UseCase/Command/SwitchIdentity/SwitchIdentityTest.php
@@ -18,8 +18,8 @@ use Source\Identity\Domain\Exception\InvalidDelegationException;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\Service\AuthServiceInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -497,7 +497,7 @@ class SwitchIdentityTest extends TestCase
     {
         return new Identity(
             $identityIdentifier,
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email('user@example.com'),
             Language::KOREAN,
             new ImagePath('/resources/path/test.png'),
@@ -513,7 +513,7 @@ class SwitchIdentityTest extends TestCase
     ): Identity {
         return new Identity(
             $identityIdentifier,
-            new UserName('delegated-user'),
+            new IdentityName('delegated-user'),
             new Email('delegated@example.com'),
             Language::KOREAN,
             new ImagePath('/resources/path/test.png'),

--- a/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputTest.php
+++ b/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use PHPUnit\Framework\TestCase;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityInput;
+use Source\Identity\Domain\ValueObject\IdentityName;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
+use Tests\Helper\StrTestHelper;
+
+class UpdateIdentityInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $delegationIdentifier = new DelegationIdentifier(StrTestHelper::generateUuid());
+        $originalIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $identityName = new IdentityName('updated-user');
+        $language = Language::KOREAN;
+        $base64EncodedImage = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+
+        $input = new UpdateIdentityInput(
+            $identityIdentifier,
+            $delegationIdentifier,
+            $originalIdentityIdentifier,
+            $identityName,
+            $language,
+            $base64EncodedImage,
+        );
+
+        $this->assertSame($identityIdentifier, $input->identityIdentifier());
+        $this->assertSame($delegationIdentifier, $input->delegationIdentifier());
+        $this->assertSame($originalIdentityIdentifier, $input->originalIdentityIdentifier());
+        $this->assertSame($identityName, $input->identityName());
+        $this->assertSame($language, $input->language());
+        $this->assertSame($base64EncodedImage, $input->base64EncodedImage());
+    }
+
+    public function testNullableValuesCanBeRetrieved(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+
+        $input = new UpdateIdentityInput(
+            $identityIdentifier,
+            null,
+            null,
+            null,
+            null,
+            null,
+        );
+
+        $this->assertSame($identityIdentifier, $input->identityIdentifier());
+        $this->assertNull($input->delegationIdentifier());
+        $this->assertNull($input->originalIdentityIdentifier());
+        $this->assertNull($input->identityName());
+        $this->assertNull($input->language());
+        $this->assertNull($input->base64EncodedImage());
+    }
+}

--- a/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityOutputTest.php
+++ b/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityOutputTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Tests\Identity\Application\UseCase\Command\CreateIdentity;
+namespace Tests\Identity\Application\UseCase\Command\UpdateIdentity;
 
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
-use Source\Identity\Application\UseCase\Command\CreateIdentity\CreateIdentityOutput;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityOutput;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\ValueObject\HashedPassword;
 use Source\Identity\Domain\ValueObject\IdentityName;
@@ -17,11 +17,11 @@ use Source\Shared\Domain\ValueObject\ImagePath;
 use Source\Shared\Domain\ValueObject\Language;
 use Tests\Helper\StrTestHelper;
 
-class CreateIdentityOutputTest extends TestCase
+class UpdateIdentityOutputTest extends TestCase
 {
     public function testToArrayReturnsEmptyWhenIdentityIsNull(): void
     {
-        $output = new CreateIdentityOutput();
+        $output = new UpdateIdentityOutput();
 
         $this->assertSame([], $output->toArray());
     }
@@ -29,10 +29,10 @@ class CreateIdentityOutputTest extends TestCase
     public function testToArrayReturnsIdentityData(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $identityName = new IdentityName('test-user');
+        $identityName = new IdentityName('updated-user');
         $email = new Email('user@example.com');
-        $language = Language::JAPANESE;
-        $profileImage = new ImagePath('/resources/path/test.png');
+        $language = Language::KOREAN;
+        $profileImage = new ImagePath('/resources/path/updated.png');
         $hashedPassword = HashedPassword::fromPlain(new PlainPassword('PlainPass1!'));
         $emailVerifiedAt = new DateTimeImmutable();
 
@@ -46,7 +46,7 @@ class CreateIdentityOutputTest extends TestCase
             $emailVerifiedAt,
         );
 
-        $output = new CreateIdentityOutput();
+        $output = new UpdateIdentityOutput();
         $output->setIdentity($identity);
 
         $result = $output->toArray();
@@ -56,5 +56,23 @@ class CreateIdentityOutputTest extends TestCase
         $this->assertSame((string) $email, $result['email']);
         $this->assertSame($language->value, $result['language']);
         $this->assertSame((string) $profileImage, $result['profileImage']);
+    }
+
+    public function testToArrayReturnsNullProfileImageWhenIdentityHasNoProfileImage(): void
+    {
+        $identity = new Identity(
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            new IdentityName('updated-user'),
+            new Email('user@example.com'),
+            Language::JAPANESE,
+            null,
+            HashedPassword::fromPlain(new PlainPassword('PlainPass1!')),
+            new DateTimeImmutable(),
+        );
+
+        $output = new UpdateIdentityOutput();
+        $output->setIdentity($identity);
+
+        $this->assertNull($output->toArray()['profileImage']);
     }
 }

--- a/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityTest.php
+++ b/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Application\UseCase\Command\UpdateIdentity;
+
+use DateTimeImmutable;
+use Mockery;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentity;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityInput;
+use Source\Identity\Application\UseCase\Command\UpdateIdentity\UpdateIdentityOutput;
+use Source\Identity\Domain\Entity\Identity;
+use Source\Identity\Domain\Exception\IdentityNotFoundException;
+use Source\Identity\Domain\Exception\InvalidDelegationException;
+use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
+use Source\Identity\Domain\Service\AuthServiceInterface;
+use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
+use Source\Identity\Domain\ValueObject\PlainPassword;
+use Source\Shared\Application\DTO\ImageUploadResult;
+use Source\Shared\Application\Service\ImageServiceInterface;
+use Source\Shared\Domain\ValueObject\DelegationIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\ImagePath;
+use Source\Shared\Domain\ValueObject\Language;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UpdateIdentityTest extends TestCase
+{
+    public function testProcessUpdatesIdentityProfileAndRefreshesAuthenticatedIdentity(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $identity = $this->createIdentity($identityIdentifier);
+        $updatedName = new IdentityName('updated-identity');
+        $base64Image = base64_encode('dummy-image');
+        $resizedPath = new ImagePath('images/profile_resized.webp');
+
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $repository */
+        $repository = Mockery::mock(IdentityRepositoryInterface::class);
+        $repository->shouldReceive('findById')->once()->with($identityIdentifier)->andReturn($identity);
+        $repository->shouldReceive('save')->once()->with(Mockery::on(
+            static fn (Identity $saved): bool => (string) $saved->identityName() === 'updated-identity'
+                && $saved->language() === Language::KOREAN
+                && (string) $saved->profileImage() === 'images/profile_resized.webp'
+        ))->andReturnNull();
+
+        /** @var ImageServiceInterface&\Mockery\MockInterface $imageService */
+        $imageService = Mockery::mock(ImageServiceInterface::class);
+        $imageService->shouldReceive('upload')
+            ->once()
+            ->with($base64Image)
+            ->andReturn(new ImageUploadResult(new ImagePath('images/profile_original.webp'), $resizedPath));
+
+        /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
+        $authService = Mockery::mock(AuthServiceInterface::class);
+        $authService->shouldReceive('refreshAuthenticatedIdentity')->once()->with($identity)->andReturnNull();
+
+        $input = new UpdateIdentityInput(
+            identityIdentifier: $identityIdentifier,
+            delegationIdentifier: null,
+            originalIdentityIdentifier: null,
+            identityName: $updatedName,
+            language: Language::KOREAN,
+            base64EncodedImage: $base64Image,
+        );
+        $output = new UpdateIdentityOutput();
+
+        $useCase = new UpdateIdentity($repository, $imageService, $authService);
+        $useCase->process($input, $output);
+
+        $this->assertSame('updated-identity', $output->toArray()['identityName']);
+        $this->assertSame('ko', $output->toArray()['language']);
+        $this->assertSame('images/profile_resized.webp', $output->toArray()['profileImage']);
+    }
+
+    public function testProcessRejectsDelegatedSession(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $repository */
+        $repository = Mockery::mock(IdentityRepositoryInterface::class);
+        $repository->shouldNotReceive('findById');
+        /** @var ImageServiceInterface&\Mockery\MockInterface $imageService */
+        $imageService = Mockery::mock(ImageServiceInterface::class);
+        /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
+        $authService = Mockery::mock(AuthServiceInterface::class);
+
+        $this->expectException(InvalidDelegationException::class);
+
+        (new UpdateIdentity($repository, $imageService, $authService))->process(
+            new UpdateIdentityInput(
+                identityIdentifier: $identityIdentifier,
+                delegationIdentifier: new DelegationIdentifier(StrTestHelper::generateUuid()),
+                originalIdentityIdentifier: null,
+                identityName: null,
+                language: null,
+                base64EncodedImage: null,
+            ),
+            new UpdateIdentityOutput(),
+        );
+    }
+
+    public function testProcessThrowsWhenTargetIdentityNotFound(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $repository */
+        $repository = Mockery::mock(IdentityRepositoryInterface::class);
+        $repository->shouldReceive('findById')->once()->with($identityIdentifier)->andReturnNull();
+        /** @var ImageServiceInterface&\Mockery\MockInterface $imageService */
+        $imageService = Mockery::mock(ImageServiceInterface::class);
+        /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
+        $authService = Mockery::mock(AuthServiceInterface::class);
+
+        $this->expectException(IdentityNotFoundException::class);
+
+        (new UpdateIdentity($repository, $imageService, $authService))->process(
+            new UpdateIdentityInput(
+                identityIdentifier: $identityIdentifier,
+                delegationIdentifier: null,
+                originalIdentityIdentifier: null,
+                identityName: null,
+                language: null,
+                base64EncodedImage: null,
+            ),
+            new UpdateIdentityOutput(),
+        );
+    }
+
+    private function createIdentity(IdentityIdentifier $identityIdentifier): Identity
+    {
+        return new Identity(
+            $identityIdentifier,
+            new IdentityName('identity-name'),
+            new Email('identity@example.com'),
+            Language::ENGLISH,
+            null,
+            HashedPassword::fromPlain(new PlainPassword('Password123!')),
+            new DateTimeImmutable(),
+        );
+    }
+}

--- a/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
+++ b/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
@@ -13,7 +13,7 @@ class AuthenticatedIdentityReadModelTest extends TestCase
     {
         $readModel = new AuthenticatedIdentityReadModel(
             identityIdentifier: '019de7f3-78f3-7b55-9ed5-17f63e14d5fe',
-            username: 'test-user',
+            identityName: 'test-user',
             email: 'test@example.com',
             language: 'ja',
             profileImage: '/storage/profile/test.png',
@@ -21,14 +21,14 @@ class AuthenticatedIdentityReadModelTest extends TestCase
         );
 
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5fe', $readModel->identityIdentifier());
-        $this->assertSame('test-user', $readModel->username());
+        $this->assertSame('test-user', $readModel->identityName());
         $this->assertSame('test@example.com', $readModel->email());
         $this->assertSame('ja', $readModel->language());
         $this->assertSame('/storage/profile/test.png', $readModel->profileImage());
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5aa', $readModel->accountIdentifier());
         $this->assertSame([
             'identityIdentifier' => '019de7f3-78f3-7b55-9ed5-17f63e14d5fe',
-            'username' => 'test-user',
+            'identityName' => 'test-user',
             'email' => 'test@example.com',
             'language' => 'ja',
             'profileImage' => '/storage/profile/test.png',

--- a/tests/Identity/Domain/Entity/IdentityTest.php
+++ b/tests/Identity/Domain/Entity/IdentityTest.php
@@ -10,10 +10,10 @@ use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Exception\InvalidCredentialsException;
 use Source\Identity\Domain\Exception\SocialConnectionAlreadyExistsException;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
 use Source\Identity\Domain\ValueObject\SocialConnection;
 use Source\Identity\Domain\ValueObject\SocialProvider;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\ImagePath;
@@ -30,7 +30,7 @@ class IdentityTest extends TestCase
     public function test__construct(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $userName = new UserName('test-user');
+        $identityName = new IdentityName('test-user');
         $email = new Email('user@example.com');
         $profileImage = new ImagePath('/resources/path/test.png');
         $language = Language::JAPANESE;
@@ -40,10 +40,10 @@ class IdentityTest extends TestCase
         $socialConnection = new SocialConnection(SocialProvider::GOOGLE, 'provider-user-id');
         $connections = [$socialConnection];
 
-        $identity = new Identity($identityIdentifier, $userName, $email, $language, $profileImage, $hashedPassword, $verifiedAt, $connections);
+        $identity = new Identity($identityIdentifier, $identityName, $email, $language, $profileImage, $hashedPassword, $verifiedAt, $connections);
 
         $this->assertSame($identityIdentifier, $identity->identityIdentifier());
-        $this->assertSame($userName, $identity->username());
+        $this->assertSame($identityName, $identity->identityName());
         $this->assertSame($email, $identity->email());
         $this->assertSame($language, $identity->language());
         $this->assertSame($profileImage, $identity->profileImage());
@@ -107,7 +107,7 @@ class IdentityTest extends TestCase
 
     /**
      * @param IdentityIdentifier|null $identityIdentifier
-     * @param UserName|null $userName
+     * @param IdentityName|null $identityName
      * @param Email|null $email
      * @param Language|null $language
      * @param ImagePath|null $profileImage
@@ -118,7 +118,7 @@ class IdentityTest extends TestCase
      */
     private function createIdentity(
         ?IdentityIdentifier $identityIdentifier = null,
-        ?UserName           $userName = null,
+        ?IdentityName           $identityName = null,
         ?Email              $email = null,
         ?Language           $language = null,
         ?ImagePath          $profileImage = null,
@@ -128,7 +128,7 @@ class IdentityTest extends TestCase
     ): Identity {
         return new Identity(
             $identityIdentifier ?? new IdentityIdentifier(StrTestHelper::generateUuid()),
-            $userName ?? new UserName('test-user'),
+            $identityName ?? new IdentityName('test-user'),
             $email ?? new Email('user@example.com'),
             $language ?? Language::JAPANESE,
             $profileImage ?? new ImagePath('/resources/path/test.png'),

--- a/tests/Identity/Domain/ValueObject/IdentityNameTest.php
+++ b/tests/Identity/Domain/ValueObject/IdentityNameTest.php
@@ -6,10 +6,10 @@ namespace Tests\Identity\Domain\ValueObject;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Source\Identity\Domain\ValueObject\UserName;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Tests\Helper\StrTestHelper;
 
-class UserNameTest extends TestCase
+class IdentityNameTest extends TestCase
 {
     /**
      * 正常系: インスタンスが生成されること
@@ -19,8 +19,8 @@ class UserNameTest extends TestCase
     public function test__construct(): void
     {
         $name = 'test-user';
-        $userName = new UserName($name);
-        $this->assertSame($name, (string)$userName);
+        $identityName = new IdentityName($name);
+        $this->assertSame($name, (string)$identityName);
     }
 
     /**
@@ -31,7 +31,7 @@ class UserNameTest extends TestCase
     public function testWhenEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new UserName('');
+        new IdentityName('');
     }
 
     /**
@@ -42,7 +42,7 @@ class UserNameTest extends TestCase
     public function testWhenOnlySpace(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new UserName('    ');
+        new IdentityName('    ');
     }
 
     /**
@@ -53,6 +53,6 @@ class UserNameTest extends TestCase
     public function testExceedMaxChars(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        new UserName(StrTestHelper::generateStr(UserName::MAX_LENGTH + 1));
+        new IdentityName(StrTestHelper::generateStr(IdentityName::MAX_LENGTH + 1));
     }
 }

--- a/tests/Identity/Infrastructure/Factory/IdentityFactoryTest.php
+++ b/tests/Identity/Infrastructure/Factory/IdentityFactoryTest.php
@@ -8,11 +8,11 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Factory\IdentityFactoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
 use Source\Identity\Domain\ValueObject\SocialConnection;
 use Source\Identity\Domain\ValueObject\SocialProfile;
 use Source\Identity\Domain\ValueObject\SocialProvider;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Identity\Infrastructure\Factory\IdentityFactory;
 use Source\Shared\Application\Service\Uuid\UuidValidator;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
@@ -45,7 +45,7 @@ class IdentityFactoryTest extends TestCase
      */
     public function testCreate(): void
     {
-        $name = new UserName('user-name');
+        $name = new IdentityName('user-name');
         $email = new Email('user@example.com');
         $language = Language::JAPANESE;
         $plainPassword = new PlainPassword('user-password');
@@ -80,7 +80,7 @@ class IdentityFactoryTest extends TestCase
         $this->assertTrue(UuidValidator::isValid((string)$identity->identityIdentifier()));
         $this->assertSame((string)$email, (string)$identity->email());
         $this->assertSame(Language::ENGLISH, $identity->language());
-        $this->assertSame($name, (string)$identity->username());
+        $this->assertSame($name, (string)$identity->identityName());
         $this->assertNull($identity->profileImage());
         $this->assertNull($identity->emailVerifiedAt());
         $this->assertTrue($identity->hasSocialConnection(new SocialConnection($provider, $providerUserId)));
@@ -106,7 +106,7 @@ class IdentityFactoryTest extends TestCase
 
         $identity = $identityFactory->createFromSocialProfile($profile);
 
-        $this->assertSame('user', (string)$identity->username());
+        $this->assertSame('user', (string)$identity->identityName());
         $this->assertNull($identity->profileImage());
     }
 
@@ -120,7 +120,7 @@ class IdentityFactoryTest extends TestCase
     {
         $originalIdentity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            new UserName('original-user'),
+            new IdentityName('original-user'),
             new Email('original@example.com'),
             Language::JAPANESE,
             new ImagePath('/resources/path/original.png'),
@@ -142,7 +142,7 @@ class IdentityFactoryTest extends TestCase
         );
 
         // 元のIdentityの情報がコピーされる
-        $this->assertSame((string)$originalIdentity->username(), (string)$delegatedIdentity->username());
+        $this->assertSame((string)$originalIdentity->identityName(), (string)$delegatedIdentity->identityName());
         $this->assertSame((string)$originalIdentity->email(), (string)$delegatedIdentity->email());
         $this->assertSame($originalIdentity->language(), $delegatedIdentity->language());
         $this->assertSame((string)$originalIdentity->profileImage(), (string)$delegatedIdentity->profileImage());
@@ -171,7 +171,7 @@ class IdentityFactoryTest extends TestCase
     {
         $originalIdentity = new Identity(
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            new UserName('original-user'),
+            new IdentityName('original-user'),
             new Email('original@example.com'),
             Language::KOREAN,
             null,

--- a/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
+++ b/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
@@ -28,7 +28,7 @@ class GetAuthenticatedIdentityTest extends TestCase
         $identityIdentifier = new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5fe');
         CreateAccount::create((string) $accountIdentifier);
         CreateIdentity::create($identityIdentifier, [
-            'username' => 'test-user',
+            'identity_name' => 'test-user',
             'email' => 'test@example.com',
             'language' => 'ja',
             'profile_image' => 'profile/test.png',
@@ -46,7 +46,7 @@ class GetAuthenticatedIdentityTest extends TestCase
         $readModel = $useCase->process(new GetAuthenticatedIdentityInput($identityIdentifier));
 
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5fe', $readModel->identityIdentifier());
-        $this->assertSame('test-user', $readModel->username());
+        $this->assertSame('test-user', $readModel->identityName());
         $this->assertSame('test@example.com', $readModel->email());
         $this->assertSame('ja', $readModel->language());
         $this->assertSame('http://127.0.0.1:8080/storage/profile/test.png', $readModel->profileImage());
@@ -58,7 +58,7 @@ class GetAuthenticatedIdentityTest extends TestCase
     {
         $identityIdentifier = new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5fe');
         CreateIdentity::create($identityIdentifier, [
-            'username' => 'test-user',
+            'identity_name' => 'test-user',
             'email' => 'test@example.com',
             'language' => 'ja',
             'profile_image' => null,
@@ -68,7 +68,7 @@ class GetAuthenticatedIdentityTest extends TestCase
         $readModel = $useCase->process(new GetAuthenticatedIdentityInput($identityIdentifier));
 
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5fe', $readModel->identityIdentifier());
-        $this->assertSame('test-user', $readModel->username());
+        $this->assertSame('test-user', $readModel->identityName());
         $this->assertSame('test@example.com', $readModel->email());
         $this->assertSame('ja', $readModel->language());
         $this->assertNull($readModel->profileImage());

--- a/tests/Identity/Infrastructure/Repository/IdentityRepositoryTest.php
+++ b/tests/Identity/Infrastructure/Repository/IdentityRepositoryTest.php
@@ -10,10 +10,10 @@ use PHPUnit\Framework\Attributes\Group;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
 use Source\Identity\Domain\ValueObject\SocialConnection;
 use Source\Identity\Domain\ValueObject\SocialProvider;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Identity\Infrastructure\Repository\IdentityRepository;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
@@ -131,7 +131,7 @@ class IdentityRepositoryTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            new UserName('new-identity'),
+            new IdentityName('new-identity'),
             $email,
             Language::JAPANESE,
             new ImagePath('/images/profile.jpg'),
@@ -145,7 +145,7 @@ class IdentityRepositoryTest extends TestCase
 
         $this->assertDatabaseHas('identities', [
             'id' => (string) $identityIdentifier,
-            'username' => 'new-identity',
+            'identity_name' => 'new-identity',
             'email' => 'newidentity@example.com',
             'language' => 'ja',
             'profile_image' => '/images/profile.jpg',
@@ -179,12 +179,12 @@ class IdentityRepositoryTest extends TestCase
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier, [
             'email' => 'original@example.com',
-            'username' => 'original-identity',
+            'identity_name' => 'original-identity',
         ]);
 
         $updatedIdentity = new Identity(
             $identityIdentifier,
-            new UserName('updated-identity'),
+            new IdentityName('updated-identity'),
             new Email('updated@example.com'),
             Language::KOREAN,
             null,
@@ -198,7 +198,7 @@ class IdentityRepositoryTest extends TestCase
 
         $this->assertDatabaseHas('identities', [
             'id' => (string) $identityIdentifier,
-            'username' => 'updated-identity',
+            'identity_name' => 'updated-identity',
             'email' => 'updated@example.com',
             'language' => 'ko',
             'profile_image' => null,
@@ -219,7 +219,7 @@ class IdentityRepositoryTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            new UserName('unverified-identity'),
+            new IdentityName('unverified-identity'),
             $email,
             Language::ENGLISH,
             null,
@@ -251,7 +251,7 @@ class IdentityRepositoryTest extends TestCase
 
         $identity = new Identity(
             $identityIdentifier,
-            new UserName('multi-social-identity'),
+            new IdentityName('multi-social-identity'),
             $email,
             Language::JAPANESE,
             null,
@@ -285,7 +285,7 @@ class IdentityRepositoryTest extends TestCase
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier, [
             'email' => 'findbyid@example.com',
-            'username' => 'find-by-id-user',
+            'identity_name' => 'find-by-id-user',
         ]);
 
         $repository = $this->app->make(IdentityRepositoryInterface::class);
@@ -295,7 +295,7 @@ class IdentityRepositoryTest extends TestCase
         $this->assertInstanceOf(Identity::class, $result);
         $this->assertSame((string) $identityIdentifier, (string) $result->identityIdentifier());
         $this->assertSame('findbyid@example.com', (string) $result->email());
-        $this->assertSame('find-by-id-user', (string) $result->username());
+        $this->assertSame('find-by-id-user', (string) $result->identityName());
     }
 
     /**
@@ -510,7 +510,7 @@ class IdentityRepositoryTest extends TestCase
 
         $delegatedIdentity = new Identity(
             $delegatedIdentityId,
-            new UserName('delegated-user'),
+            new IdentityName('delegated-user'),
             new Email('delegated-save@example.com'),
             Language::JAPANESE,
             null,
@@ -551,15 +551,15 @@ class IdentityRepositoryTest extends TestCase
 
         CreateIdentity::create($identityIdentifier1, [
             'email' => 'findbyids1@example.com',
-            'username' => 'find-by-ids-user1',
+            'identity_name' => 'find-by-ids-user1',
         ]);
         CreateIdentity::create($identityIdentifier2, [
             'email' => 'findbyids2@example.com',
-            'username' => 'find-by-ids-user2',
+            'identity_name' => 'find-by-ids-user2',
         ]);
         CreateIdentity::create($identityIdentifier3, [
             'email' => 'findbyids3@example.com',
-            'username' => 'find-by-ids-user3',
+            'identity_name' => 'find-by-ids-user3',
         ]);
         CreateIdentity::createSocialConnection($identityIdentifier1, SocialProvider::GOOGLE, 'google-findbyids-1');
 
@@ -608,7 +608,7 @@ class IdentityRepositoryTest extends TestCase
 
         CreateIdentity::create($existingIdentityId, [
             'email' => 'existing@example.com',
-            'username' => 'existing-user',
+            'identity_name' => 'existing-user',
         ]);
 
         $repository = $this->app->make(IdentityRepositoryInterface::class);

--- a/tests/Identity/Infrastructure/Service/AuthServiceTest.php
+++ b/tests/Identity/Infrastructure/Service/AuthServiceTest.php
@@ -10,8 +10,8 @@ use PHPUnit\Framework\Attributes\Group;
 use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Service\AuthServiceInterface;
 use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Identity\Domain\ValueObject\PlainPassword;
-use Source\Identity\Domain\ValueObject\UserName;
 use Source\Identity\Infrastructure\Service\AuthService;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -131,7 +131,7 @@ class AuthServiceTest extends TestCase
     {
         return new Identity(
             $identityIdentifier,
-            new UserName('test-user'),
+            new IdentityName('test-user'),
             new Email('test@example.com'),
             Language::JAPANESE,
             null,

--- a/tests/Wiki/Principal/Infrastructure/Repository/PrincipalRepositoryTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Repository/PrincipalRepositoryTest.php
@@ -272,13 +272,13 @@ class PrincipalRepositoryTest extends TestCase
         $identityIdentifier1 = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier1, [
             'email' => 'test1@example.com',
-            'username' => 'test-identity-1',
+            'identity_name' => 'test-identity-1',
         ]);
 
         $identityIdentifier2 = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier2, [
             'email' => 'test2@example.com',
-            'username' => 'test-identity-2',
+            'identity_name' => 'test-identity-2',
         ]);
 
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
@@ -331,19 +331,19 @@ class PrincipalRepositoryTest extends TestCase
         $identityIdentifier1 = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier1, [
             'email' => 'findbyids1@example.com',
-            'username' => 'findbyids-identity-1',
+            'identity_name' => 'findbyids-identity-1',
         ]);
 
         $identityIdentifier2 = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier2, [
             'email' => 'findbyids2@example.com',
-            'username' => 'findbyids-identity-2',
+            'identity_name' => 'findbyids-identity-2',
         ]);
 
         $identityIdentifier3 = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier3, [
             'email' => 'findbyids3@example.com',
-            'username' => 'findbyids-identity-3',
+            'identity_name' => 'findbyids-identity-3',
         ]);
 
         $principalIdentifier1 = new PrincipalIdentifier(StrTestHelper::generateUuid());
@@ -398,7 +398,7 @@ class PrincipalRepositoryTest extends TestCase
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         CreateIdentity::create($identityIdentifier, [
             'email' => 'existing-principal@example.com',
-            'username' => 'existing-principal-user',
+            'identity_name' => 'existing-principal-user',
         ]);
 
         $existingPrincipalId = new PrincipalIdentifier(StrTestHelper::generateUuid());

--- a/typespec/services/identity-api.tsp
+++ b/typespec/services/identity-api.tsp
@@ -9,8 +9,8 @@ namespace KPool.IdentityApi;
 model IdentitySummary {
   @doc("Identity identifier.")
   identityIdentifier: Uuid;
-  @doc("Username.")
-  username: string;
+  @doc("IdentityName.")
+  identityName: string;
   @doc("Email address.")
   email: string;
   @doc("Language code associated with the identity.")
@@ -67,8 +67,8 @@ model VerifyEmailRequestBody {
 
 @doc("Request body for registering a new identity.")
 model CreateIdentityRequestBody {
-  @doc("Requested username.")
-  username: string;
+  @doc("Requested identityName.")
+  identityName: string;
   @doc("Email address.")
   email: string;
   @doc("Plain text password.")
@@ -79,6 +79,17 @@ model CreateIdentityRequestBody {
   base64EncodedImage?: string | null;
   @doc("Invitation token used during signup.")
   invitationToken?: string | null;
+}
+
+
+@doc("Request body for updating an identity profile.")
+model UpdateIdentityRequestBody {
+  @doc("Identity display name.")
+  identityName?: string | null;
+  @doc("Language code associated with the identity.")
+  language?: string | null;
+  @doc("Base64-encoded profile image.")
+  base64EncodedImage?: string | null;
 }
 
 @doc("Request body for logging in.")
@@ -210,4 +221,14 @@ interface IdentityAuthOperations {
   switchIdentity(
     @body body: SwitchIdentityRequestBody,
   ): SwitchIdentityResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+
+@route("/identities")
+interface IdentityOperations {
+  @patch
+  @route("/me")
+  @doc("Update the current identity profile.")
+  updateIdentity(
+    @body body: UpdateIdentityRequestBody,
+  ): OkIdentityResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- Identity コンテキストの `UserName` / `username` を `IdentityName` / `identityName` に rename しました。
  - Domain ValueObject / Entity / Factory / Repository / Query / UseCase / HTTP Request・Response / tests を更新
  - DB カラムを `identities.username` から `identities.identity_name` に変更し、既存環境向け rename migration を追加
- 認証済み Identity のプロフィール更新 API を追加しました。
  - `PATCH /api/identity/identities/{identityIdentifier}`
  - 更新対象: `identityName`, `language`, `base64EncodedImage`
  - 本人以外・委譲中・委譲用 Identity からの更新は拒否
  - 更新後にログアウトせず、認証ガード上の現在ユーザー参照を更新
- Social Login 新規 Identity 作成時に OAuth `avatarUrl` を外部 URL のまま保存せず、内部ストレージへ取り込んだ resized image path を `profileImage` として保存するようにしました。
  - 取り込み失敗時は警告ログを出して、認証自体は継続します。
- TypeSpec / OpenAPI を `identityName` と UpdateIdentity API に合わせて更新しました。
- UpdateIdentity UseCase と IdentityName rename に関連するテストを追加・更新しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [x] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Identity のプロフィール情報を更新する API / UseCase が存在しなかったため追加しました。
また、Identity 文脈で表示名に `UserName` / `username` が使われており、ユーザーではなく Identity を扱うドメインとして命名が混在していたため、`IdentityName` / `identityName` に統一しました。

## 🧪 テスト

### テストの実行確認

- [x] `task test filter=Identity` を実行し、Identity 関連テストがパスすることを確認
  - `OK (328 tests, 925 assertions)`
- [x] `task test-no-db filter=UpdateIdentityTest` を実行し、追加 UseCase テストがパスすることを確認
  - `OK (4 tests, 13 assertions)`
- [x] `task phpstan` を実行し、静的解析がパスすることを確認
  - `[OK] No errors`
- [x] `task cs-fix` を実行し、コードスタイルを整形
- [x] `task openapi` を実行し、TypeSpec から OpenAPI を再生成
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- 自動テストで以下を確認しました。
  - IdentityName value object
  - UpdateIdentity の正常系
  - 本人以外の Identity 更新拒否
  - 委譲中セッションからの更新拒否
  - 対象 Identity が存在しない場合の例外
  - Identity 関連の既存 DB / non-DB テスト

## 🔍 レビューのポイント

- `identityName` rename が API / TypeSpec / OpenAPI / DB / domain / tests で一貫しているか
- UpdateIdentity の認可条件が「本人かつ通常 Identity のみ」になっているか
- 更新後にログアウトせず、現在の Auth guard 参照が更新される設計で問題ないか
- Social Login の `avatarUrl` 取り込み失敗時にログイン自体を壊さない方針で問題ないか

## 📖 関連情報

### 関連Issue・タスク

Closes #433

## ⚠️ 注意事項

- `identities.username` を `identities.identity_name` に rename する migration を追加しています。
- 既存の登録 API request / response も `username` ではなく `identityName` になります。
- OAuth avatar の URL 取り込みは HTTP timeout を設定し、取得失敗・非画像の場合は警告ログのみで処理を継続します。
- 指定された review skills (`qa-review`, `test-review`, `security-review`, `architecture-review`) は Hermes / project-local / Codex skills として見つからなかったため、代替として差分確認・静的解析・Identity 関連テスト・OpenAPI 生成・セキュリティ観点の手動確認を実施しました。未対応の妥当なレビュー指摘はありません。

## 📸 スクリーンショット・デモ

API / backend 変更のためスクリーンショットはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
