### PR TITLE
プロフィール画像削除を永続化

### DIFF
--- a/application/Http/Action/Identity/Command/UpdateIdentity/UpdateIdentityAction.php
+++ b/application/Http/Action/Identity/Command/UpdateIdentity/UpdateIdentityAction.php
@@ -45,6 +45,7 @@ readonly class UpdateIdentityAction
                     identityName: $request->identityName() !== null ? new IdentityName($request->identityName()) : null,
                     language: $request->language() !== null ? Language::from($request->language()) : null,
                     base64EncodedImage: $request->base64EncodedImage(),
+                    profileImageProvided: $request->exists('base64EncodedImage'),
                 );
                 $output = new UpdateIdentityOutput();
             } catch (InvalidArgumentException $e) {

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentity.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentity.php
@@ -10,6 +10,8 @@ use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Identity\Domain\Service\AuthServiceInterface;
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
 use Source\Shared\Application\Service\ImageServiceInterface;
+use Source\Shared\Domain\ValueObject\ImagePath;
+use Throwable;
 
 readonly class UpdateIdentity implements UpdateIdentityInterface
 {
@@ -36,19 +38,40 @@ readonly class UpdateIdentity implements UpdateIdentityInterface
             throw new IdentityNotFoundException('Identity not found.');
         }
 
+        $oldProfileImage = $identity->profileImage();
+
         if ($input->identityName() !== null) {
             $identity->setIdentityName($input->identityName());
         }
         if ($input->language() !== null) {
             $identity->setLanguage($input->language());
         }
-        if ($input->base64EncodedImage() !== null) {
-            $uploadResult = $this->imageService->upload($input->base64EncodedImage());
-            $identity->setProfileImage($uploadResult->resized);
+        if ($input->profileImageProvided()) {
+            if ($input->base64EncodedImage() !== null) {
+                $uploadResult = $this->imageService->upload($input->base64EncodedImage());
+                $identity->setProfileImage($uploadResult->resized);
+            } else {
+                $identity->setProfileImage(null);
+            }
         }
 
         $this->identityRepository->save($identity);
         $this->authService->refreshAuthenticatedIdentity($identity);
         $output->setIdentity($identity);
+
+        $this->deleteProfileImageBestEffort($oldProfileImage, $identity->profileImage());
+    }
+
+    private function deleteProfileImageBestEffort(?ImagePath $oldProfileImage, ?ImagePath $currentProfileImage): void
+    {
+        if ($oldProfileImage === null || (string) $oldProfileImage === (string) $currentProfileImage) {
+            return;
+        }
+
+        try {
+            $this->imageService->delete($oldProfileImage);
+        } catch (Throwable) {
+            // Old profile image deletion is best effort; profile updates must not fail because cleanup failed.
+        }
     }
 }

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInput.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInput.php
@@ -18,6 +18,7 @@ readonly class UpdateIdentityInput implements UpdateIdentityInputPort
         private ?IdentityName $identityName,
         private ?Language $language,
         private ?string $base64EncodedImage,
+        private bool $profileImageProvided,
     ) {
     }
 
@@ -49,5 +50,10 @@ readonly class UpdateIdentityInput implements UpdateIdentityInputPort
     public function base64EncodedImage(): ?string
     {
         return $this->base64EncodedImage;
+    }
+
+    public function profileImageProvided(): bool
+    {
+        return $this->profileImageProvided;
     }
 }

--- a/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputPort.php
+++ b/src/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputPort.php
@@ -22,4 +22,6 @@ interface UpdateIdentityInputPort
     public function language(): ?Language;
 
     public function base64EncodedImage(): ?string;
+
+    public function profileImageProvided(): bool;
 }

--- a/src/Identity/Domain/Entity/Identity.php
+++ b/src/Identity/Domain/Entity/Identity.php
@@ -81,7 +81,7 @@ class Identity
         return $this->profileImage;
     }
 
-    public function setProfileImage(ImagePath $image): void
+    public function setProfileImage(?ImagePath $image): void
     {
         $this->profileImage = $image;
     }

--- a/src/Shared/Application/Service/ImageServiceInterface.php
+++ b/src/Shared/Application/Service/ImageServiceInterface.php
@@ -7,6 +7,7 @@ namespace Source\Shared\Application\Service;
 use Source\Shared\Application\DTO\ImageUploadResult;
 use Source\Shared\Application\Exception\InvalidBase64ImageException;
 use Source\Shared\Application\Exception\InvalidRemoteImageException;
+use Source\Shared\Domain\ValueObject\ImagePath;
 
 interface ImageServiceInterface
 {
@@ -23,4 +24,6 @@ interface ImageServiceInterface
      * @throws InvalidRemoteImageException
      */
     public function importFromUrl(string $imageUrl): ImageUploadResult;
+
+    public function delete(ImagePath $path): bool;
 }

--- a/src/Shared/Infrastructure/Service/ImageService.php
+++ b/src/Shared/Infrastructure/Service/ImageService.php
@@ -65,6 +65,11 @@ class ImageService implements ImageServiceInterface
         return $this->storeImage($gdImage);
     }
 
+    public function delete(ImagePath $path): bool
+    {
+        return Storage::disk((string) config('filesystems.image_disk', 'public'))->delete((string) $path);
+    }
+
     private function storeImage(GdImage $gdImage): ImageUploadResult
     {
         $baseFileName = 'images/' . Str::uuid();

--- a/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputTest.php
+++ b/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityInputTest.php
@@ -30,6 +30,7 @@ class UpdateIdentityInputTest extends TestCase
             $identityName,
             $language,
             $base64EncodedImage,
+            true,
         );
 
         $this->assertSame($identityIdentifier, $input->identityIdentifier());
@@ -38,6 +39,7 @@ class UpdateIdentityInputTest extends TestCase
         $this->assertSame($identityName, $input->identityName());
         $this->assertSame($language, $input->language());
         $this->assertSame($base64EncodedImage, $input->base64EncodedImage());
+        $this->assertTrue($input->profileImageProvided());
     }
 
     public function testNullableValuesCanBeRetrieved(): void
@@ -51,6 +53,7 @@ class UpdateIdentityInputTest extends TestCase
             null,
             null,
             null,
+            false,
         );
 
         $this->assertSame($identityIdentifier, $input->identityIdentifier());
@@ -59,5 +62,24 @@ class UpdateIdentityInputTest extends TestCase
         $this->assertNull($input->identityName());
         $this->assertNull($input->language());
         $this->assertNull($input->base64EncodedImage());
+        $this->assertFalse($input->profileImageProvided());
+    }
+
+    public function testProfileImageCanBeExplicitlyProvidedAsNull(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+
+        $input = new UpdateIdentityInput(
+            $identityIdentifier,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true,
+        );
+
+        $this->assertNull($input->base64EncodedImage());
+        $this->assertTrue($input->profileImageProvided());
     }
 }

--- a/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityTest.php
+++ b/tests/Identity/Application/UseCase/Command/UpdateIdentity/UpdateIdentityTest.php
@@ -32,7 +32,10 @@ class UpdateIdentityTest extends TestCase
     public function testProcessUpdatesIdentityProfileAndRefreshesAuthenticatedIdentity(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $identity = $this->createIdentity($identityIdentifier);
+        $identity = $this->createIdentity(
+            $identityIdentifier,
+            new ImagePath('images/current_profile.webp'),
+        );
         $updatedName = new IdentityName('updated-identity');
         $base64Image = base64_encode('dummy-image');
         $resizedPath = new ImagePath('images/profile_resized.webp');
@@ -52,6 +55,10 @@ class UpdateIdentityTest extends TestCase
             ->once()
             ->with($base64Image)
             ->andReturn(new ImageUploadResult(new ImagePath('images/profile_original.webp'), $resizedPath));
+        $imageService->shouldReceive('delete')
+            ->once()
+            ->with(Mockery::on(static fn (ImagePath $path): bool => (string) $path === 'images/current_profile.webp'))
+            ->andReturnTrue();
 
         /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
         $authService = Mockery::mock(AuthServiceInterface::class);
@@ -64,6 +71,7 @@ class UpdateIdentityTest extends TestCase
             identityName: $updatedName,
             language: Language::KOREAN,
             base64EncodedImage: $base64Image,
+            profileImageProvided: true,
         );
         $output = new UpdateIdentityOutput();
 
@@ -75,6 +83,89 @@ class UpdateIdentityTest extends TestCase
         $this->assertSame('images/profile_resized.webp', $output->toArray()['profileImage']);
     }
 
+    public function testProcessDeletesProfileImageWhenImageFieldIsProvidedAsNull(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $identity = $this->createIdentity(
+            $identityIdentifier,
+            new ImagePath('images/current_profile.webp'),
+        );
+
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $repository */
+        $repository = Mockery::mock(IdentityRepositoryInterface::class);
+        $repository->shouldReceive('findById')->once()->with($identityIdentifier)->andReturn($identity);
+        $repository->shouldReceive('save')->once()->with(Mockery::on(
+            static fn (Identity $saved): bool => $saved->profileImage() === null
+        ))->andReturnNull();
+
+        /** @var ImageServiceInterface&\Mockery\MockInterface $imageService */
+        $imageService = Mockery::mock(ImageServiceInterface::class);
+        $imageService->shouldNotReceive('upload');
+        $imageService->shouldReceive('delete')
+            ->once()
+            ->with(Mockery::on(static fn (ImagePath $path): bool => (string) $path === 'images/current_profile.webp'))
+            ->andReturnTrue();
+
+        /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
+        $authService = Mockery::mock(AuthServiceInterface::class);
+        $authService->shouldReceive('refreshAuthenticatedIdentity')->once()->with($identity)->andReturnNull();
+
+        $input = new UpdateIdentityInput(
+            identityIdentifier: $identityIdentifier,
+            delegationIdentifier: null,
+            originalIdentityIdentifier: null,
+            identityName: null,
+            language: null,
+            base64EncodedImage: null,
+            profileImageProvided: true,
+        );
+        $output = new UpdateIdentityOutput();
+
+        $useCase = new UpdateIdentity($repository, $imageService, $authService);
+        $useCase->process($input, $output);
+
+        $this->assertNull($output->toArray()['profileImage']);
+    }
+
+    public function testProcessDoesNotFailWhenOldProfileImageDeletionFails(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $identity = $this->createIdentity(
+            $identityIdentifier,
+            new ImagePath('images/current_profile.webp'),
+        );
+
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $repository */
+        $repository = Mockery::mock(IdentityRepositoryInterface::class);
+        $repository->shouldReceive('findById')->once()->with($identityIdentifier)->andReturn($identity);
+        $repository->shouldReceive('save')->once()->andReturnNull();
+
+        /** @var ImageServiceInterface&\Mockery\MockInterface $imageService */
+        $imageService = Mockery::mock(ImageServiceInterface::class);
+        $imageService->shouldNotReceive('upload');
+        $imageService->shouldReceive('delete')->once()->andThrow(new \RuntimeException('delete failed'));
+
+        /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
+        $authService = Mockery::mock(AuthServiceInterface::class);
+        $authService->shouldReceive('refreshAuthenticatedIdentity')->once()->with($identity)->andReturnNull();
+
+        $input = new UpdateIdentityInput(
+            identityIdentifier: $identityIdentifier,
+            delegationIdentifier: null,
+            originalIdentityIdentifier: null,
+            identityName: null,
+            language: null,
+            base64EncodedImage: null,
+            profileImageProvided: true,
+        );
+        $output = new UpdateIdentityOutput();
+
+        $useCase = new UpdateIdentity($repository, $imageService, $authService);
+        $useCase->process($input, $output);
+
+        $this->assertNull($output->toArray()['profileImage']);
+    }
+
     public function testProcessRejectsDelegatedSession(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
@@ -83,6 +174,7 @@ class UpdateIdentityTest extends TestCase
         $repository->shouldNotReceive('findById');
         /** @var ImageServiceInterface&\Mockery\MockInterface $imageService */
         $imageService = Mockery::mock(ImageServiceInterface::class);
+        $imageService->shouldNotReceive('delete');
         /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
         $authService = Mockery::mock(AuthServiceInterface::class);
 
@@ -96,6 +188,7 @@ class UpdateIdentityTest extends TestCase
                 identityName: null,
                 language: null,
                 base64EncodedImage: null,
+                profileImageProvided: false,
             ),
             new UpdateIdentityOutput(),
         );
@@ -109,6 +202,7 @@ class UpdateIdentityTest extends TestCase
         $repository->shouldReceive('findById')->once()->with($identityIdentifier)->andReturnNull();
         /** @var ImageServiceInterface&\Mockery\MockInterface $imageService */
         $imageService = Mockery::mock(ImageServiceInterface::class);
+        $imageService->shouldNotReceive('delete');
         /** @var AuthServiceInterface&\Mockery\MockInterface $authService */
         $authService = Mockery::mock(AuthServiceInterface::class);
 
@@ -122,19 +216,22 @@ class UpdateIdentityTest extends TestCase
                 identityName: null,
                 language: null,
                 base64EncodedImage: null,
+                profileImageProvided: false,
             ),
             new UpdateIdentityOutput(),
         );
     }
 
-    private function createIdentity(IdentityIdentifier $identityIdentifier): Identity
-    {
+    private function createIdentity(
+        IdentityIdentifier $identityIdentifier,
+        ?ImagePath $profileImage = null,
+    ): Identity {
         return new Identity(
             $identityIdentifier,
             new IdentityName('identity-name'),
             new Email('identity@example.com'),
             Language::ENGLISH,
-            null,
+            $profileImage,
             HashedPassword::fromPlain(new PlainPassword('Password123!')),
             new DateTimeImmutable(),
         );


### PR DESCRIPTION
## 📝 変更内容

プロフィール更新時に `base64EncodedImage` が明示的に null で送られた場合、プロフィール画像を削除状態として保存するようにしました。

- リクエストに `base64EncodedImage` が含まれていたかを `profileImageProvided` として UseCase へ渡す
- 画像が明示的に null の場合は `Identity::profileImage` を null に更新
- 画像差し替え・削除時に旧プロフィール画像を best effort でストレージから削除
- 画像削除用の `ImageServiceInterface::delete` を追加
- プロフィール画像削除、旧画像削除失敗時の挙動、Input の明示的 null をテスト追加

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

従来は `base64EncodedImage` が null の場合、「画像項目未指定」と「画像削除の明示指定」を区別できず、プロフィール画像削除が永続化されませんでした。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

補足: 初回の `task check` は `testing_db` の名前解決エラーで失敗しましたが、再実行相当の全テストは `2731 tests, 8841 assertions` で成功しています。

## 🔍 レビューのポイント

- `base64EncodedImage` 未指定と明示的 null の区別が Action / Input / UseCase で適切に扱われているか
- 画像差し替え・削除後の旧画像削除を best effort にしている判断が妥当か
- `Identity::setProfileImage(?ImagePath $image)` の nullable 化による影響範囲

## ⚠️ 注意事項

マイグレーションや破壊的変更はありません。

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
