### PR TITLE
Wikiテーマ設定に文字スタイルを追加する

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiAction.php
@@ -26,6 +26,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\Color;
 use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -59,6 +60,7 @@ readonly class CreateWikiAction
                     $basic,
                     $sections,
                     themeColor: $request->themeColor() !== null ? new Color($request->themeColor()) : null,
+                    fontStyle: $request->fontStyle() !== null ? WikiFontStyle::from($request->fontStyle()) : null,
                     slug: new Slug($request->slug()),
                     principalIdentifier: $this->wikiContext->principalIdentifier,
                     agencyIdentifier: $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,

--- a/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/CreateWiki/CreateWikiRequest.php
@@ -6,6 +6,8 @@ namespace Application\Http\Action\Wiki\Wiki\Command\CreateWiki;
 
 use Application\Http\Action\Concerns\ResolvesLanguage;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 
 class CreateWikiRequest extends FormRequest
 {
@@ -23,6 +25,7 @@ class CreateWikiRequest extends FormRequest
             'basic' => ['required', 'array'],
             'sections' => ['nullable', 'array'],
             'themeColor' => ['nullable', 'string'],
+            'fontStyle' => ['nullable', 'string', Rule::in(WikiFontStyle::values())],
             'imageIdentifier' => ['nullable', 'uuid'],
             'title' => ['nullable', 'string', 'max:40'],
             'metaDescription' => ['nullable', 'string', 'max:140'],
@@ -74,6 +77,13 @@ class CreateWikiRequest extends FormRequest
     public function themeColor(): ?string
     {
         $value = $this->input('themeColor');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function fontStyle(): ?string
+    {
+        $value = $this->input('fontStyle');
 
         return $value !== null ? (string) $value : null;
     }

--- a/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiAction.php
@@ -29,6 +29,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -60,6 +61,7 @@ readonly class EditWikiAction
                     $basic,
                     $sections,
                     themeColor: $request->themeColor() !== null ? new Color($request->themeColor()) : null,
+                    fontStyle: $request->fontStyle() !== null ? WikiFontStyle::from($request->fontStyle()) : null,
                     principalIdentifier: $this->wikiContext->principalIdentifier,
                     resourceType: $resourceType,
                     agencyIdentifier: $request->agencyIdentifier() !== null ? new WikiIdentifier($request->agencyIdentifier()) : null,

--- a/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/EditWiki/EditWikiRequest.php
@@ -6,6 +6,8 @@ namespace Application\Http\Action\Wiki\Wiki\Command\EditWiki;
 
 use Application\Http\Action\Concerns\ResolvesLanguage;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 
 class EditWikiRequest extends FormRequest
 {
@@ -33,6 +35,7 @@ class EditWikiRequest extends FormRequest
             'basic' => ['required', 'array'],
             'sections' => ['nullable', 'array'],
             'themeColor' => ['nullable', 'string'],
+            'fontStyle' => ['nullable', 'string', Rule::in(WikiFontStyle::values())],
             'imageIdentifier' => ['nullable', 'uuid'],
             'title' => ['nullable', 'string', 'max:40'],
             'metaDescription' => ['nullable', 'string', 'max:140'],
@@ -75,6 +78,13 @@ class EditWikiRequest extends FormRequest
     public function themeColor(): ?string
     {
         $value = $this->input('themeColor');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function fontStyle(): ?string
+    {
+        $value = $this->input('fontStyle');
 
         return $value !== null ? (string) $value : null;
     }

--- a/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiAction.php
+++ b/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiAction.php
@@ -28,6 +28,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -59,6 +60,7 @@ readonly class MergeWikiAction
                     $basic,
                     $sections,
                     themeColor: $request->themeColor() !== null ? new Color($request->themeColor()) : null,
+                    fontStyle: $request->fontStyle() !== null ? WikiFontStyle::from($request->fontStyle()) : null,
                     principalIdentifier: $this->wikiContext->principalIdentifier,
                     resourceType: $resourceType,
                     mergedAt: new DateTimeImmutable(),

--- a/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiRequest.php
+++ b/application/Http/Action/Wiki/Wiki/Command/MergeWiki/MergeWikiRequest.php
@@ -6,6 +6,8 @@ namespace Application\Http\Action\Wiki\Wiki\Command\MergeWiki;
 
 use Application\Http\Action\Concerns\ResolvesLanguage;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 
 class MergeWikiRequest extends FormRequest
 {
@@ -33,6 +35,7 @@ class MergeWikiRequest extends FormRequest
             'basic' => ['required', 'array'],
             'sections' => ['nullable', 'array'],
             'themeColor' => ['nullable', 'string'],
+            'fontStyle' => ['nullable', 'string', Rule::in(WikiFontStyle::values())],
             'imageIdentifier' => ['nullable', 'uuid'],
             'title' => ['nullable', 'string', 'max:40'],
             'metaDescription' => ['nullable', 'string', 'max:140'],
@@ -75,6 +78,13 @@ class MergeWikiRequest extends FormRequest
     public function themeColor(): ?string
     {
         $value = $this->input('themeColor');
+
+        return $value !== null ? (string) $value : null;
+    }
+
+    public function fontStyle(): ?string
+    {
+        $value = $this->input('fontStyle');
 
         return $value !== null ? (string) $value : null;
     }

--- a/application/Models/Wiki/DraftWiki.php
+++ b/application/Models/Wiki/DraftWiki.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Carbon;
  * @property ?string $image_identifier
  * @property array<array<string, mixed>> $sections
  * @property ?string $theme_color
+ * @property ?string $font_style
  * @property ?string $title
  * @property ?string $meta_description
  * @property list<string>|null $keywords
@@ -50,6 +51,7 @@ use Illuminate\Support\Carbon;
     'image_identifier',
     'sections',
     'theme_color',
+    'font_style',
     'title',
     'meta_description',
     'keywords',

--- a/application/Models/Wiki/Wiki.php
+++ b/application/Models/Wiki/Wiki.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Carbon;
  * @property ?string $image_identifier
  * @property array<array<string, mixed>> $sections
  * @property ?string $theme_color
+ * @property ?string $font_style
  * @property ?string $title
  * @property ?string $meta_description
  * @property list<string>|null $keywords
@@ -44,6 +45,7 @@ use Illuminate\Support\Carbon;
     'image_identifier',
     'sections',
     'theme_color',
+    'font_style',
     'title',
     'meta_description',
     'keywords',

--- a/application/Models/Wiki/WikiSnapshot.php
+++ b/application/Models/Wiki/WikiSnapshot.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Carbon;
  * @property ?string $image_identifier
  * @property array<array<string, mixed>> $sections
  * @property ?string $theme_color
+ * @property ?string $font_style
  * @property ?string $title
  * @property ?string $meta_description
  * @property list<string>|null $keywords
@@ -45,6 +46,7 @@ use Illuminate\Support\Carbon;
     'image_identifier',
     'sections',
     'theme_color',
+    'font_style',
     'title',
     'meta_description',
     'keywords',

--- a/database/migrations/2024_01_01_000046_create_wikis_table.php
+++ b/database/migrations/2024_01_01_000046_create_wikis_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->uuid('image_identifier')->nullable()->comment('代表画像識別子');
             $table->jsonb('sections')->default('[]')->comment('セクションコレクション');
             $table->string('theme_color', 7)->nullable()->comment('テーマカラー (#RRGGBB)');
+            $table->string('font_style', 32)->nullable()->comment('文字スタイル識別子');
             $table->string('title', 40)->nullable()->comment('SEOタイトル');
             $table->string('meta_description', 140)->nullable()->comment('SEOメタディスクリプション');
             $table->jsonb('keywords')->nullable()->comment('SEOキーワード');
@@ -50,6 +51,7 @@ return new class extends Migration
             $table->uuid('image_identifier')->nullable()->comment('代表画像識別子');
             $table->jsonb('sections')->default('[]')->comment('セクションコレクション');
             $table->string('theme_color', 7)->nullable()->comment('テーマカラー (#RRGGBB)');
+            $table->string('font_style', 32)->nullable()->comment('文字スタイル識別子');
             $table->string('title', 40)->nullable()->comment('SEOタイトル');
             $table->string('meta_description', 140)->nullable()->comment('SEOメタディスクリプション');
             $table->jsonb('keywords')->nullable()->comment('SEOキーワード');
@@ -86,6 +88,7 @@ return new class extends Migration
             $table->uuid('image_identifier')->nullable()->comment('代表画像識別子');
             $table->jsonb('sections')->default('[]')->comment('セクションコレクション');
             $table->string('theme_color', 7)->nullable()->comment('テーマカラー');
+            $table->string('font_style', 32)->nullable()->comment('文字スタイル識別子');
             $table->string('title', 40)->nullable()->comment('SEOタイトル');
             $table->string('meta_description', 140)->nullable()->comment('SEOメタディスクリプション');
             $table->jsonb('keywords')->nullable()->comment('SEOキーワード');

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2587,6 +2587,7 @@ components:
         - status
         - rejectionReason
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -2624,6 +2625,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -2666,6 +2672,7 @@ components:
         - resourceType
         - version
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -2698,6 +2705,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -2882,7 +2894,13 @@ components:
           description: Section content payloads.
         themeColor:
           type: string
+          nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -3033,6 +3051,7 @@ components:
         - status
         - rejectionReason
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -3070,6 +3089,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -3134,6 +3158,7 @@ components:
         - language
         - resourceType
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -3176,6 +3201,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -4114,6 +4144,7 @@ components:
         - status
         - rejectionReason
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -4151,6 +4182,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -4362,6 +4398,7 @@ components:
         - resourceType
         - version
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -4394,6 +4431,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -4528,6 +4570,7 @@ components:
         - status
         - rejectionReason
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -4565,6 +4608,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -4685,6 +4733,7 @@ components:
         - resourceType
         - version
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -4717,6 +4766,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -4783,7 +4837,13 @@ components:
           description: Section content payloads.
         themeColor:
           type: string
+          nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -4983,6 +5043,7 @@ components:
         - resourceType
         - version
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -5015,6 +5076,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:
@@ -5047,6 +5113,25 @@ components:
           items: {}
           description: Section content payloads.
       description: Detailed published group wiki payload.
+    WikiFontStyle:
+      type: string
+      enum:
+        - ja_pop
+        - ja_gothic
+        - ja_mincho
+        - ja_artistic
+        - ja_handwritten
+        - ko_rounded
+        - ko_gothic
+        - ko_myungjo
+        - ko_modern
+        - ko_handwritten
+        - en_sans
+        - en_serif
+        - en_display
+        - en_modern
+        - en_handwritten
+      description: Stable Wiki font style identifiers supported by the backend contract.
     WikiListItem:
       type: object
       required:
@@ -5057,6 +5142,7 @@ components:
         - resourceType
         - version
         - themeColor
+        - fontStyle
         - title
         - metaDescription
         - keywords
@@ -5093,6 +5179,11 @@ components:
           type: string
           nullable: true
           description: Theme color applied to the wiki.
+        fontStyle:
+          allOf:
+            - $ref: '#/components/schemas/WikiFontStyle'
+          nullable: true
+          description: Stable font style identifier applied to the wiki.
         title:
           type: string
           allOf:

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWiki.php
@@ -75,6 +75,7 @@ readonly class CreateWiki implements CreateWikiInterface
 
         $wiki->setSections($input->sections());
         $wiki->setThemeColor($input->themeColor());
+        $wiki->setFontStyle($input->fontStyle());
         $wiki->setImageIdentifier($input->imageIdentifier());
         $wiki->setTitle($input->title());
         $wiki->setMetaDescription($input->metaDescription());

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInput.php
@@ -15,6 +15,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 readonly class CreateWikiInput implements CreateWikiInputPort
@@ -26,6 +27,7 @@ readonly class CreateWikiInput implements CreateWikiInputPort
      * @param BasicInterface $basic
      * @param SectionContentCollection $sections
      * @param Color|null $themeColor
+     * @param WikiFontStyle|null $fontStyle
      * @param ImageIdentifier|null $imageIdentifier
      * @param SeoKeywords|null $keywords
      * @param Slug $slug
@@ -50,6 +52,7 @@ readonly class CreateWikiInput implements CreateWikiInputPort
         private ?SeoTitle                $title = null,
         private ?MetaDescription         $metaDescription = null,
         private ?SeoKeywords             $keywords = null,
+        private ?WikiFontStyle           $fontStyle = null,
     ) {
     }
 
@@ -81,6 +84,11 @@ readonly class CreateWikiInput implements CreateWikiInputPort
     public function themeColor(): ?Color
     {
         return $this->themeColor;
+    }
+
+    public function fontStyle(): ?WikiFontStyle
+    {
+        return $this->fontStyle;
     }
 
     public function imageIdentifier(): ?ImageIdentifier

--- a/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInputPort.php
@@ -15,6 +15,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 interface CreateWikiInputPort
@@ -30,6 +31,8 @@ interface CreateWikiInputPort
     public function sections(): SectionContentCollection;
 
     public function themeColor(): ?Color;
+
+    public function fontStyle(): ?WikiFontStyle;
 
     public function imageIdentifier(): ?ImageIdentifier;
 

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWiki.php
@@ -73,6 +73,7 @@ readonly class EditWiki implements EditWikiInterface
         $wiki->setBasic($input->basic());
         $wiki->setSections($input->sections());
         $wiki->setThemeColor($input->themeColor());
+        $wiki->setFontStyle($input->fontStyle());
         $wiki->setImageIdentifier($input->imageIdentifier());
         $wiki->setTitle($input->title());
         $wiki->setMetaDescription($input->metaDescription());

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInput.php
@@ -14,6 +14,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 readonly class EditWikiInput implements EditWikiInputPort
@@ -23,6 +24,7 @@ readonly class EditWikiInput implements EditWikiInputPort
      * @param BasicInterface $basic
      * @param SectionContentCollection $sections
      * @param Color|null $themeColor
+     * @param WikiFontStyle|null $fontStyle
      * @param ImageIdentifier|null $imageIdentifier
      * @param SeoKeywords|null $keywords
      * @param PrincipalIdentifier $principalIdentifier
@@ -45,6 +47,7 @@ readonly class EditWikiInput implements EditWikiInputPort
         private ?SeoTitle                $title = null,
         private ?MetaDescription         $metaDescription = null,
         private ?SeoKeywords             $keywords = null,
+        private ?WikiFontStyle           $fontStyle = null,
     ) {
     }
 
@@ -66,6 +69,11 @@ readonly class EditWikiInput implements EditWikiInputPort
     public function themeColor(): ?Color
     {
         return $this->themeColor;
+    }
+
+    public function fontStyle(): ?WikiFontStyle
+    {
+        return $this->fontStyle;
     }
 
     public function imageIdentifier(): ?ImageIdentifier

--- a/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInputPort.php
@@ -14,6 +14,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 interface EditWikiInputPort
@@ -25,6 +26,8 @@ interface EditWikiInputPort
     public function sections(): SectionContentCollection;
 
     public function themeColor(): ?Color;
+
+    public function fontStyle(): ?WikiFontStyle;
 
     public function imageIdentifier(): ?ImageIdentifier;
 

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWiki.php
@@ -64,6 +64,7 @@ readonly class MergeWiki implements MergeWikiInterface
         $wiki->setBasic($input->basic());
         $wiki->setSections($input->sections());
         $wiki->setThemeColor($input->themeColor());
+        $wiki->setFontStyle($input->fontStyle());
         $wiki->setImageIdentifier($input->imageIdentifier());
         $wiki->setTitle($input->title());
         $wiki->setMetaDescription($input->metaDescription());

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInput.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInput.php
@@ -15,6 +15,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 readonly class MergeWikiInput implements MergeWikiInputPort
@@ -24,6 +25,7 @@ readonly class MergeWikiInput implements MergeWikiInputPort
      * @param BasicInterface $basic
      * @param SectionContentCollection $sections
      * @param Color|null $themeColor
+     * @param WikiFontStyle|null $fontStyle
      * @param ImageIdentifier|null $imageIdentifier
      * @param SeoKeywords|null $keywords
      * @param PrincipalIdentifier $principalIdentifier
@@ -48,6 +50,7 @@ readonly class MergeWikiInput implements MergeWikiInputPort
         private ?SeoTitle                $title = null,
         private ?MetaDescription         $metaDescription = null,
         private ?SeoKeywords             $keywords = null,
+        private ?WikiFontStyle           $fontStyle = null,
     ) {
     }
 
@@ -69,6 +72,11 @@ readonly class MergeWikiInput implements MergeWikiInputPort
     public function themeColor(): ?Color
     {
         return $this->themeColor;
+    }
+
+    public function fontStyle(): ?WikiFontStyle
+    {
+        return $this->fontStyle;
     }
 
     public function imageIdentifier(): ?ImageIdentifier

--- a/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInputPort.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInputPort.php
@@ -15,6 +15,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 interface MergeWikiInputPort
@@ -26,6 +27,8 @@ interface MergeWikiInputPort
     public function sections(): SectionContentCollection;
 
     public function themeColor(): ?Color;
+
+    public function fontStyle(): ?WikiFontStyle;
 
     public function imageIdentifier(): ?ImageIdentifier;
 

--- a/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWiki.php
@@ -118,6 +118,7 @@ readonly class PublishWiki implements PublishWikiInterface
         }
         $publishedWiki->setSections($wiki->sections());
         $publishedWiki->setThemeColor($wiki->themeColor());
+        $publishedWiki->setFontStyle($wiki->fontStyle());
         $publishedWiki->setImageIdentifier($wiki->imageIdentifier());
         $publishedWiki->setTitle($wiki->title());
         $publishedWiki->setMetaDescription($wiki->metaDescription());

--- a/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWiki.php
@@ -120,6 +120,7 @@ readonly class RollbackWiki implements RollbackWikiInterface
             $w->setBasic($snapshot->basic());
             $w->setSections($snapshot->sections());
             $w->setThemeColor($snapshot->themeColor());
+            $w->setFontStyle($snapshot->fontStyle());
             $w->setImageIdentifier($snapshot->imageIdentifier());
             $w->setTitle($snapshot->title());
             $w->setMetaDescription($snapshot->metaDescription());

--- a/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
+++ b/src/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWiki.php
@@ -94,6 +94,7 @@ readonly class TranslateWiki implements TranslateWikiInterface
 
             $wikiDraft->setSections($translatedData->translatedSections());
             $wikiDraft->setThemeColor($wiki->themeColor());
+            $wikiDraft->setFontStyle($wiki->fontStyle());
             $wikiDraft->setImageIdentifier($wiki->imageIdentifier());
             $wikiDraft->setTitle($wiki->title());
             $wikiDraft->setMetaDescription($wiki->metaDescription());

--- a/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModel.php
@@ -29,6 +29,7 @@ readonly class DraftWikiListItemReadModel
         private ?string $metaDescription = null,
         /** @var list<string>|null */
         private ?array $keywords = null,
+        private ?string $fontStyle = null,
     ) {
     }
 
@@ -45,6 +46,7 @@ readonly class DraftWikiListItemReadModel
             'language' => $this->language,
             'resourceType' => $this->resourceType,
             'themeColor' => $this->themeColor,
+            'fontStyle' => $this->fontStyle,
             'title' => $this->title,
             'metaDescription' => $this->metaDescription,
             'keywords' => $this->keywords,

--- a/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModel.php
@@ -14,6 +14,7 @@ readonly class DraftWikiReadModel
     private ?string $status;
     private ?string $rejectionReason;
     private ?string $themeColor;
+    private ?string $fontStyle;
     private ?string $title;
     private ?string $metaDescription;
     /** @var list<string>|null */
@@ -45,6 +46,7 @@ readonly class DraftWikiReadModel
         ?string $title = null,
         ?string $metaDescription = null,
         ?array $keywords = null,
+        ?string $fontStyle = null,
     ) {
         $this->wikiIdentifier = $wikiIdentifier;
         $this->translationSetIdentifier = $translationSetIdentifier;
@@ -54,6 +56,7 @@ readonly class DraftWikiReadModel
         $this->status = $status;
         $this->rejectionReason = $rejectionReason;
         $this->themeColor = $themeColor;
+        $this->fontStyle = $fontStyle;
         $this->title = $title;
         $this->metaDescription = $metaDescription;
         $this->keywords = $keywords;
@@ -106,6 +109,11 @@ readonly class DraftWikiReadModel
     public function themeColor(): ?string
     {
         return $this->themeColor;
+    }
+
+    public function fontStyle(): ?string
+    {
+        return $this->fontStyle;
     }
 
     public function title(): ?string
@@ -163,6 +171,7 @@ readonly class DraftWikiReadModel
             'status' => $this->status,
             'rejectionReason' => $this->rejectionReason,
             'themeColor' => $this->themeColor,
+            'fontStyle' => $this->fontStyle,
             'title' => $this->title,
             'metaDescription' => $this->metaDescription,
             'keywords' => $this->keywords,

--- a/src/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModel.php
@@ -25,6 +25,7 @@ readonly class WikiListItemReadModel
         private ?string $metaDescription = null,
         /** @var list<string>|null */
         private ?array $keywords = null,
+        private ?string $fontStyle = null,
     ) {
     }
 
@@ -51,6 +52,7 @@ readonly class WikiListItemReadModel
             'resourceType' => $this->resourceType,
             'version' => $this->version,
             'themeColor' => $this->themeColor,
+            'fontStyle' => $this->fontStyle,
             'title' => $this->title,
             'metaDescription' => $this->metaDescription,
             'keywords' => $this->keywords,

--- a/src/Wiki/Wiki/Application/UseCase/Query/WikiReadModel.php
+++ b/src/Wiki/Wiki/Application/UseCase/Query/WikiReadModel.php
@@ -13,6 +13,7 @@ readonly class WikiReadModel
     private string $resourceType;
     private int $version;
     private ?string $themeColor;
+    private ?string $fontStyle;
     private ?string $title;
     private ?string $metaDescription;
     /** @var list<string>|null */
@@ -43,6 +44,7 @@ readonly class WikiReadModel
         ?string $title = null,
         ?string $metaDescription = null,
         ?array $keywords = null,
+        ?string $fontStyle = null,
     ) {
         $this->wikiIdentifier = $wikiIdentifier;
         $this->translationSetIdentifier = $translationSetIdentifier;
@@ -51,6 +53,7 @@ readonly class WikiReadModel
         $this->resourceType = $resourceType;
         $this->version = $version;
         $this->themeColor = $themeColor;
+        $this->fontStyle = $fontStyle;
         $this->title = $title;
         $this->metaDescription = $metaDescription;
         $this->keywords = $keywords;
@@ -98,6 +101,11 @@ readonly class WikiReadModel
     public function themeColor(): ?string
     {
         return $this->themeColor;
+    }
+
+    public function fontStyle(): ?string
+    {
+        return $this->fontStyle;
     }
 
     public function title(): ?string
@@ -154,6 +162,7 @@ readonly class WikiReadModel
             'resourceType' => $this->resourceType,
             'version' => $this->version,
             'themeColor' => $this->themeColor,
+            'fontStyle' => $this->fontStyle,
             'title' => $this->title,
             'metaDescription' => $this->metaDescription,
             'keywords' => $this->keywords,

--- a/src/Wiki/Wiki/Domain/Entity/DraftWiki.php
+++ b/src/Wiki/Wiki/Domain/Entity/DraftWiki.php
@@ -20,6 +20,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 class DraftWiki
@@ -48,6 +49,7 @@ class DraftWiki
         private ?MetaDescription $metaDescription = null,
         private ?SeoKeywords $keywords = null,
         private ?DraftWikiRejectionReason $rejectionReason = null,
+        private ?WikiFontStyle $fontStyle = null,
     ) {
     }
 
@@ -114,6 +116,16 @@ class DraftWiki
     public function setThemeColor(?Color $themeColor): void
     {
         $this->themeColor = $themeColor;
+    }
+
+    public function fontStyle(): ?WikiFontStyle
+    {
+        return $this->fontStyle;
+    }
+
+    public function setFontStyle(?WikiFontStyle $fontStyle): void
+    {
+        $this->fontStyle = $fontStyle;
     }
 
     public function title(): ?SeoTitle

--- a/src/Wiki/Wiki/Domain/Entity/Wiki.php
+++ b/src/Wiki/Wiki/Domain/Entity/Wiki.php
@@ -19,6 +19,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 class Wiki
@@ -46,6 +47,7 @@ class Wiki
         private ?MetaDescription $metaDescription = null,
         private ?SeoKeywords $keywords = null,
         private ?DateTimeImmutable $publishedAt = null,
+        private ?WikiFontStyle $fontStyle = null,
     ) {
     }
 
@@ -102,6 +104,16 @@ class Wiki
     public function setThemeColor(?Color $themeColor): void
     {
         $this->themeColor = $themeColor;
+    }
+
+    public function fontStyle(): ?WikiFontStyle
+    {
+        return $this->fontStyle;
+    }
+
+    public function setFontStyle(?WikiFontStyle $fontStyle): void
+    {
+        $this->fontStyle = $fontStyle;
     }
 
     public function title(): ?SeoTitle

--- a/src/Wiki/Wiki/Domain/Entity/WikiSnapshot.php
+++ b/src/Wiki/Wiki/Domain/Entity/WikiSnapshot.php
@@ -18,6 +18,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiSnapshotIdentifier;
 
@@ -46,6 +47,7 @@ readonly class WikiSnapshot
         private ?SeoTitle                $title = null,
         private ?MetaDescription         $metaDescription = null,
         private ?SeoKeywords             $keywords = null,
+        private ?WikiFontStyle           $fontStyle = null,
     ) {
     }
 
@@ -92,6 +94,11 @@ readonly class WikiSnapshot
     public function themeColor(): ?Color
     {
         return $this->themeColor;
+    }
+
+    public function fontStyle(): ?WikiFontStyle
+    {
+        return $this->fontStyle;
     }
 
     public function title(): ?SeoTitle

--- a/src/Wiki/Wiki/Domain/ValueObject/WikiFontStyle.php
+++ b/src/Wiki/Wiki/Domain/ValueObject/WikiFontStyle.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Wiki\Domain\ValueObject;
+
+enum WikiFontStyle: string
+{
+    case JA_POP = 'ja_pop';
+    case JA_GOTHIC = 'ja_gothic';
+    case JA_MINCHO = 'ja_mincho';
+    case JA_ARTISTIC = 'ja_artistic';
+    case JA_HANDWRITTEN = 'ja_handwritten';
+    case KO_ROUNDED = 'ko_rounded';
+    case KO_GOTHIC = 'ko_gothic';
+    case KO_MYUNGJO = 'ko_myungjo';
+    case KO_MODERN = 'ko_modern';
+    case KO_HANDWRITTEN = 'ko_handwritten';
+    case EN_SANS = 'en_sans';
+    case EN_SERIF = 'en_serif';
+    case EN_DISPLAY = 'en_display';
+    case EN_MODERN = 'en_modern';
+    case EN_HANDWRITTEN = 'en_handwritten';
+
+    /** @return list<string> */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    /**
+     * @return list<array{id: string, language: string, category: string, label: string}>
+     */
+    public static function options(): array
+    {
+        return array_map(
+            static fn (self $fontStyle): array => $fontStyle->option(),
+            self::cases(),
+        );
+    }
+
+    /**
+     * @return array{id: string, language: string, category: string, label: string}
+     */
+    public function option(): array
+    {
+        return match ($this) {
+            self::JA_POP => $this->toOption('ja', 'pop', 'ポップ'),
+            self::JA_GOTHIC => $this->toOption('ja', 'gothic', 'ゴシック'),
+            self::JA_MINCHO => $this->toOption('ja', 'mincho', '明朝'),
+            self::JA_ARTISTIC => $this->toOption('ja', 'artistic', 'アーティスティック'),
+            self::JA_HANDWRITTEN => $this->toOption('ja', 'handwritten', '手書き'),
+            self::KO_ROUNDED => $this->toOption('ko', 'rounded', '라운드'),
+            self::KO_GOTHIC => $this->toOption('ko', 'gothic', '고딕'),
+            self::KO_MYUNGJO => $this->toOption('ko', 'myungjo', '명조'),
+            self::KO_MODERN => $this->toOption('ko', 'modern', '모던'),
+            self::KO_HANDWRITTEN => $this->toOption('ko', 'handwritten', '손글씨'),
+            self::EN_SANS => $this->toOption('en', 'sans', 'Sans'),
+            self::EN_SERIF => $this->toOption('en', 'serif', 'Serif'),
+            self::EN_DISPLAY => $this->toOption('en', 'display', 'Display'),
+            self::EN_MODERN => $this->toOption('en', 'modern', 'Modern'),
+            self::EN_HANDWRITTEN => $this->toOption('en', 'handwritten', 'Handwritten'),
+        };
+    }
+
+    /**
+     * @return array{id: string, language: string, category: string, label: string}
+     */
+    private function toOption(string $language, string $category, string $label): array
+    {
+        return [
+            'id' => $this->value,
+            'language' => $language,
+            'category' => $category,
+            'label' => $label,
+        ];
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Factory/WikiSnapshotFactory.php
+++ b/src/Wiki/Wiki/Infrastructure/Factory/WikiSnapshotFactory.php
@@ -43,6 +43,7 @@ readonly class WikiSnapshotFactory implements WikiSnapshotFactoryInterface
             $wiki->title(),
             $wiki->metaDescription(),
             $wiki->keywords(),
+            fontStyle: $wiki->fontStyle(),
         );
     }
 }

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
@@ -57,6 +57,7 @@ readonly class GetAgencyDraftWiki implements GetAgencyDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::AGENCY->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
@@ -45,6 +45,7 @@ readonly class GetAgencyWiki implements GetAgencyWikiInterface
             resourceType: ResourceType::AGENCY->value,
             version: $model->version,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
@@ -59,6 +59,7 @@ readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::GROUP->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
@@ -45,6 +45,7 @@ readonly class GetGroupWiki implements GetGroupWikiInterface
             resourceType: ResourceType::GROUP->value,
             version: $model->version,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMyAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMyAgencyDraftWiki.php
@@ -54,6 +54,7 @@ readonly class GetMyAgencyDraftWiki implements GetMyAgencyDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::AGENCY->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMyGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMyGroupDraftWiki.php
@@ -54,6 +54,7 @@ readonly class GetMyGroupDraftWiki implements GetMyGroupDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::GROUP->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMySongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMySongDraftWiki.php
@@ -57,6 +57,7 @@ readonly class GetMySongDraftWiki implements GetMySongDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::SONG->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMyTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMyTalentDraftWiki.php
@@ -58,6 +58,7 @@ readonly class GetMyTalentDraftWiki implements GetMyTalentDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::TALENT->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
@@ -60,6 +60,7 @@ readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::SONG->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
@@ -47,6 +47,7 @@ readonly class GetSongWiki implements GetSongWikiInterface
             resourceType: ResourceType::SONG->value,
             version: $model->version,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
@@ -61,6 +61,7 @@ readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
             language: $model->language,
             resourceType: ResourceType::TALENT->value,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
@@ -48,6 +48,7 @@ readonly class GetTalentWiki implements GetTalentWikiInterface
             resourceType: ResourceType::TALENT->value,
             version: $model->version,
             themeColor: $model->theme_color,
+            fontStyle: $model->font_style,
             title: $model->title,
             metaDescription: $model->meta_description,
             keywords: $model->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/ListDraftWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListDraftWikis.php
@@ -182,6 +182,7 @@ readonly class ListDraftWikis implements ListDraftWikisInterface
             language: $wiki->language,
             resourceType: $wiki->resource_type,
             themeColor: $wiki->theme_color,
+            fontStyle: $wiki->font_style,
             title: $wiki->title,
             metaDescription: $wiki->meta_description,
             keywords: $wiki->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/ListMyDraftWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListMyDraftWikis.php
@@ -86,6 +86,7 @@ readonly class ListMyDraftWikis implements ListMyDraftWikisInterface
             language: $wiki->language,
             resourceType: $wiki->resource_type,
             themeColor: $wiki->theme_color,
+            fontStyle: $wiki->font_style,
             title: $wiki->title,
             metaDescription: $wiki->meta_description,
             keywords: $wiki->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/ListVersionInconsistentWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListVersionInconsistentWikis.php
@@ -128,6 +128,7 @@ readonly class ListVersionInconsistentWikis implements ListVersionInconsistentWi
             resourceType: $wiki->resource_type,
             version: $wiki->version,
             themeColor: $wiki->theme_color,
+            fontStyle: $wiki->font_style,
             title: $wiki->title,
             metaDescription: $wiki->meta_description,
             keywords: $wiki->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/ListWikis.php
@@ -149,6 +149,7 @@ readonly class ListWikis implements ListWikisInterface
             resourceType: $wiki->resource_type,
             version: $wiki->version,
             themeColor: $wiki->theme_color,
+            fontStyle: $wiki->font_style,
             title: $wiki->title,
             metaDescription: $wiki->meta_description,
             keywords: $wiki->keywords,

--- a/src/Wiki/Wiki/Infrastructure/Repository/DraftWikiRepository.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/DraftWikiRepository.php
@@ -30,6 +30,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\DraftWikiRejectionReason;
 use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 readonly class DraftWikiRepository implements DraftWikiRepositoryInterface
@@ -157,6 +158,7 @@ readonly class DraftWikiRepository implements DraftWikiRepositoryInterface
                 'image_identifier' => $draftWiki->imageIdentifier() ? (string) $draftWiki->imageIdentifier() : null,
                 'sections' => SectionContentMapper::collectionToArray($draftWiki->sections()),
                 'theme_color' => $draftWiki->themeColor() ? (string) $draftWiki->themeColor() : null,
+                'font_style' => $draftWiki->fontStyle()?->value,
                 'title' => $draftWiki->title() ? (string) $draftWiki->title() : null,
                 'meta_description' => $draftWiki->metaDescription() ? (string) $draftWiki->metaDescription() : null,
                 'keywords' => $draftWiki->keywords()?->values(),
@@ -254,6 +256,7 @@ readonly class DraftWikiRepository implements DraftWikiRepositoryInterface
             $model->meta_description !== null ? new MetaDescription($model->meta_description) : null,
             $model->keywords !== null ? new SeoKeywords($model->keywords) : null,
             $model->rejection_reason !== null ? new DraftWikiRejectionReason($model->rejection_reason) : null,
+            fontStyle: $model->font_style ? WikiFontStyle::from($model->font_style) : null,
         );
     }
 

--- a/src/Wiki/Wiki/Infrastructure/Repository/WikiRepository.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/WikiRepository.php
@@ -29,6 +29,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\Color;
 use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 
 readonly class WikiRepository implements WikiRepositoryInterface
@@ -162,6 +163,7 @@ readonly class WikiRepository implements WikiRepositoryInterface
                 'image_identifier' => $wiki->imageIdentifier() ? (string) $wiki->imageIdentifier() : null,
                 'sections' => SectionContentMapper::collectionToArray($wiki->sections()),
                 'theme_color' => $wiki->themeColor() ? (string) $wiki->themeColor() : null,
+                'font_style' => $wiki->fontStyle()?->value,
                 'title' => $wiki->title() ? (string) $wiki->title() : null,
                 'meta_description' => $wiki->metaDescription() ? (string) $wiki->metaDescription() : null,
                 'keywords' => $wiki->keywords()?->values(),
@@ -250,6 +252,7 @@ readonly class WikiRepository implements WikiRepositoryInterface
             $model->meta_description !== null ? new MetaDescription($model->meta_description) : null,
             $model->keywords !== null ? new SeoKeywords($model->keywords) : null,
             $model->published_at?->toDateTimeImmutable(),
+            fontStyle: $model->font_style ? WikiFontStyle::from($model->font_style) : null,
         );
     }
 

--- a/src/Wiki/Wiki/Infrastructure/Repository/WikiSnapshotRepository.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/WikiSnapshotRepository.php
@@ -28,6 +28,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\Color;
 use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiSnapshotIdentifier;
 
@@ -50,6 +51,7 @@ readonly class WikiSnapshotRepository implements WikiSnapshotRepositoryInterface
                 'image_identifier' => $snapshot->imageIdentifier() ? (string) $snapshot->imageIdentifier() : null,
                 'sections' => SectionContentMapper::collectionToArray($snapshot->sections()),
                 'theme_color' => $snapshot->themeColor() ? (string) $snapshot->themeColor() : null,
+                'font_style' => $snapshot->fontStyle()?->value,
                 'title' => $snapshot->title() ? (string) $snapshot->title() : null,
                 'meta_description' => $snapshot->metaDescription() ? (string) $snapshot->metaDescription() : null,
                 'keywords' => $snapshot->keywords()?->values(),
@@ -176,6 +178,7 @@ readonly class WikiSnapshotRepository implements WikiSnapshotRepositoryInterface
             $model->title !== null ? new SeoTitle($model->title) : null,
             $model->meta_description !== null ? new MetaDescription($model->meta_description) : null,
             $model->keywords !== null ? new SeoKeywords($model->keywords) : null,
+            fontStyle: $model->font_style ? WikiFontStyle::from($model->font_style) : null,
         );
     }
 

--- a/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiInputTest.php
@@ -19,6 +19,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
@@ -51,6 +52,7 @@ class CreateWikiInputTest extends TestCase
         );
         $sections = new SectionContentCollection();
         $themeColor = new Color('#FF5733');
+        $fontStyle = WikiFontStyle::JA_POP;
         $slug = new Slug('gr-twice');
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $agencyIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
@@ -75,6 +77,7 @@ class CreateWikiInputTest extends TestCase
             title: $title,
             metaDescription: $metaDescription,
             keywords: $keywords,
+            fontStyle: $fontStyle,
         );
 
         $this->assertSame((string) $publishedWikiIdentifier, (string) $input->publishedWikiIdentifier());
@@ -83,6 +86,7 @@ class CreateWikiInputTest extends TestCase
         $this->assertSame($basic, $input->basic());
         $this->assertSame($sections, $input->sections());
         $this->assertSame((string) $themeColor, (string) $input->themeColor());
+        $this->assertSame($fontStyle, $input->fontStyle());
         $this->assertSame((string) $slug, (string) $input->slug());
         $this->assertSame($principalIdentifier, $input->principalIdentifier());
         $this->assertSame((string) $agencyIdentifier, (string) $input->agencyIdentifier());

--- a/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiInputTest.php
@@ -18,6 +18,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
@@ -49,6 +50,7 @@ class EditWikiInputTest extends TestCase
         );
         $sections = new SectionContentCollection();
         $themeColor = new Color('#FF5733');
+        $fontStyle = WikiFontStyle::JA_POP;
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $agencyIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
         $groupIdentifiers = [new WikiIdentifier(StrTestHelper::generateUuid())];
@@ -70,12 +72,14 @@ class EditWikiInputTest extends TestCase
             title: $title,
             metaDescription: $metaDescription,
             keywords: $keywords,
+            fontStyle: $fontStyle,
         );
 
         $this->assertSame((string) $wikiIdentifier, (string) $input->wikiIdentifier());
         $this->assertSame($basic, $input->basic());
         $this->assertSame($sections, $input->sections());
         $this->assertSame((string) $themeColor, (string) $input->themeColor());
+        $this->assertSame($fontStyle, $input->fontStyle());
         $this->assertSame($principalIdentifier, $input->principalIdentifier());
         $this->assertSame($resourceType->value, $input->resourceType()->value);
         $this->assertSame((string) $agencyIdentifier, (string) $input->agencyIdentifier());

--- a/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInputTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiInputTest.php
@@ -19,6 +19,7 @@ use Source\Wiki\Wiki\Domain\ValueObject\MetaDescription;
 use Source\Wiki\Wiki\Domain\ValueObject\Section\SectionContentCollection;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoKeywords;
 use Source\Wiki\Wiki\Domain\ValueObject\SeoTitle;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
 use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
@@ -50,6 +51,7 @@ class MergeWikiInputTest extends TestCase
         );
         $sections = new SectionContentCollection();
         $themeColor = new Color('#FF5733');
+        $fontStyle = WikiFontStyle::JA_POP;
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $mergedAt = new DateTimeImmutable('2026-01-02 12:00:00');
         $agencyIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
@@ -73,12 +75,14 @@ class MergeWikiInputTest extends TestCase
             title: $title,
             metaDescription: $metaDescription,
             keywords: $keywords,
+            fontStyle: $fontStyle,
         );
 
         $this->assertSame((string) $wikiIdentifier, (string) $input->wikiIdentifier());
         $this->assertSame($basic, $input->basic());
         $this->assertSame($sections, $input->sections());
         $this->assertSame((string) $themeColor, (string) $input->themeColor());
+        $this->assertSame($fontStyle, $input->fontStyle());
         $this->assertSame($principalIdentifier, $input->principalIdentifier());
         $this->assertSame($resourceType->value, $input->resourceType()->value);
         $this->assertSame($mergedAt, $input->mergedAt());

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiListItemReadModelTest.php
@@ -34,6 +34,7 @@ class DraftWikiListItemReadModelTest extends TestCase
             title: 'Chaeyoung Draft Wiki',
             metaDescription: 'Draft profile for Chaeyoung.',
             keywords: ['Chaeyoung', 'draft'],
+            fontStyle: 'ja_pop',
         );
 
         $this->assertSame([
@@ -44,6 +45,7 @@ class DraftWikiListItemReadModelTest extends TestCase
             'language' => 'ko',
             'resourceType' => 'talent',
             'themeColor' => '#FE5F8F',
+            'fontStyle' => 'ja_pop',
             'title' => 'Chaeyoung Draft Wiki',
             'metaDescription' => 'Draft profile for Chaeyoung.',
             'keywords' => ['Chaeyoung', 'draft'],

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
@@ -19,6 +19,7 @@ class DraftWikiReadModelTest extends TestCase
             language: 'ko',
             resourceType: 'group',
             themeColor: '#FE5F8F',
+            fontStyle: 'ja_pop',
             heroImage: [
                 'imageIdentifier' => null,
                 'src' => null,
@@ -62,6 +63,7 @@ class DraftWikiReadModelTest extends TestCase
         $this->assertSame('under_review', $readModel->status());
         $this->assertSame('内容が不十分です', $readModel->rejectionReason());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame('ja_pop', $readModel->fontStyle());
         $this->assertSame('TWICE Draft Wiki', $readModel->title());
         $this->assertSame('Draft profile and history for TWICE.', $readModel->metaDescription());
         $this->assertSame(['TWICE', 'draft'], $readModel->keywords());
@@ -78,6 +80,7 @@ class DraftWikiReadModelTest extends TestCase
             'status' => 'under_review',
             'rejectionReason' => '内容が不十分です',
             'themeColor' => '#FE5F8F',
+            'fontStyle' => 'ja_pop',
             'title' => 'TWICE Draft Wiki',
             'metaDescription' => 'Draft profile and history for TWICE.',
             'keywords' => ['TWICE', 'draft'],

--- a/tests/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/WikiListItemReadModelTest.php
@@ -29,6 +29,7 @@ class WikiListItemReadModelTest extends TestCase
             title: 'Chaeyoung Wiki',
             metaDescription: 'Profile for Chaeyoung.',
             keywords: ['Chaeyoung', 'TWICE'],
+            fontStyle: 'ja_pop',
         );
 
         $this->assertSame([
@@ -39,6 +40,7 @@ class WikiListItemReadModelTest extends TestCase
             'resourceType' => 'talent',
             'version' => 2,
             'themeColor' => '#FE5F8F',
+            'fontStyle' => 'ja_pop',
             'title' => 'Chaeyoung Wiki',
             'metaDescription' => 'Profile for Chaeyoung.',
             'keywords' => ['Chaeyoung', 'TWICE'],

--- a/tests/Wiki/Wiki/Application/UseCase/Query/WikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/WikiReadModelTest.php
@@ -20,6 +20,7 @@ class WikiReadModelTest extends TestCase
             resourceType: 'group',
             version: 2,
             themeColor: '#FE5F8F',
+            fontStyle: 'ja_pop',
             heroImage: [
                 'imageIdentifier' => null,
                 'src' => null,
@@ -60,6 +61,7 @@ class WikiReadModelTest extends TestCase
         $this->assertSame('group', $readModel->resourceType());
         $this->assertSame(2, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
+        $this->assertSame('ja_pop', $readModel->fontStyle());
         $this->assertSame('TWICE Wiki', $readModel->title());
         $this->assertSame('Profile and history for TWICE.', $readModel->metaDescription());
         $this->assertSame(['TWICE', 'K-pop'], $readModel->keywords());
@@ -75,6 +77,7 @@ class WikiReadModelTest extends TestCase
             'resourceType' => 'group',
             'version' => 2,
             'themeColor' => '#FE5F8F',
+            'fontStyle' => 'ja_pop',
             'title' => 'TWICE Wiki',
             'metaDescription' => 'Profile and history for TWICE.',
             'keywords' => ['TWICE', 'K-pop'],

--- a/tests/Wiki/Wiki/Domain/ValueObject/WikiFontStyleTest.php
+++ b/tests/Wiki/Wiki/Domain/ValueObject/WikiFontStyleTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Wiki\Domain\ValueObject;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiFontStyle;
+use ValueError;
+
+class WikiFontStyleTest extends TestCase
+{
+    #[DataProvider('validFontStyleProvider')]
+    public function testFromWithValidFontStyle(string $fontStyle): void
+    {
+        $valueObject = WikiFontStyle::from($fontStyle);
+
+        $this->assertSame($fontStyle, $valueObject->value);
+    }
+
+    public function testOptionsExposeStableMetadataForFrontend(): void
+    {
+        $options = WikiFontStyle::options();
+
+        $this->assertCount(15, $options);
+        $this->assertSame([
+            'id' => 'ja_pop',
+            'language' => 'ja',
+            'category' => 'pop',
+            'label' => 'ポップ',
+        ], $options[0]);
+        $this->assertSame(WikiFontStyle::values(), array_column($options, 'id'));
+    }
+
+    public function testThrowsValueErrorWithEmptyFontStyle(): void
+    {
+        $this->expectException(ValueError::class);
+
+        WikiFontStyle::from('');
+    }
+
+    #[DataProvider('invalidFontStyleProvider')]
+    public function testThrowsValueErrorWithInvalidFontStyle(string $fontStyle): void
+    {
+        $this->expectException(ValueError::class);
+
+        WikiFontStyle::from($fontStyle);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validFontStyleProvider(): array
+    {
+        return array_reduce(
+            WikiFontStyle::values(),
+            static function (array $cases, string $fontStyle): array {
+                $cases[$fontStyle] = [$fontStyle];
+
+                return $cases;
+            },
+            [],
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidFontStyleProvider(): array
+    {
+        return [
+            'unknown slug' => ['ja_unknown'],
+            'actual font family' => ['Noto Sans JP'],
+            'uppercase slug' => ['JA_POP'],
+            'wrong language' => ['fr_serif'],
+        ];
+    }
+}

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
@@ -338,6 +338,7 @@ class ListDraftWikisTest extends TestCase
             'language' => 'ko',
             'resourceType' => 'group',
             'themeColor' => '#ff3366',
+            'fontStyle' => null,
             'title' => 'TWICE Draft Wiki',
             'metaDescription' => 'Draft profile for TWICE.',
             'keywords' => ['TWICE', 'draft'],

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -112,6 +112,26 @@ model GroupDraftWikiBasic {
   representativeSymbol: string;
 }
 
+
+@doc("Stable Wiki font style identifiers supported by the backend contract.")
+union WikiFontStyle {
+  "ja_pop",
+  "ja_gothic",
+  "ja_mincho",
+  "ja_artistic",
+  "ja_handwritten",
+  "ko_rounded",
+  "ko_gothic",
+  "ko_myungjo",
+  "ko_modern",
+  "ko_handwritten",
+  "en_sans",
+  "en_serif",
+  "en_display",
+  "en_modern",
+  "en_handwritten",
+}
+
 @doc("Detailed draft wiki payload used by the editor.")
 model DraftWikiDetail {
   @doc("Draft wiki identifier.")
@@ -130,6 +150,8 @@ model DraftWikiDetail {
   rejectionReason: DraftWikiRejectionReasonText | null;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -161,6 +183,8 @@ model WikiDetail {
   version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -266,6 +290,8 @@ model TalentDraftWikiDetail {
   rejectionReason: DraftWikiRejectionReasonText | null;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -297,6 +323,8 @@ model TalentWikiDetail {
   version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -440,6 +468,8 @@ model SongDraftWikiDetail {
   rejectionReason: DraftWikiRejectionReasonText | null;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -471,6 +501,8 @@ model SongWikiDetail {
   version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -526,6 +558,8 @@ model AgencyDraftWikiDetail {
   rejectionReason: DraftWikiRejectionReasonText | null;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -557,6 +591,8 @@ model AgencyWikiDetail {
   version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -18,7 +18,9 @@ model CreateWikiRequestBody extends WikiAssociationTargets {
   @doc("Section content payloads.")
   sections?: unknown[];
   @doc("Theme color applied to the wiki.")
-  themeColor?: string;
+  themeColor?: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle?: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title?: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -59,7 +61,9 @@ model UpdateWikiDraftRequestBody extends WikiAssociationTargets {
   @doc("Section content payloads.")
   sections?: unknown[];
   @doc("Theme color applied to the wiki.")
-  themeColor?: string;
+  themeColor?: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle?: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title?: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -197,6 +201,8 @@ model WikiListItem {
   version: int32;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the wiki.")
@@ -266,6 +272,8 @@ model DraftWikiListItem {
   resourceType: string;
   @doc("Theme color applied to the wiki.")
   themeColor: string | null;
+  @doc("Stable font style identifier applied to the wiki.")
+  fontStyle: WikiFontStyle | null;
   @doc("SEO title for the draft wiki.")
   title: SeoTitleText | null;
   @doc("SEO meta description for the draft wiki.")


### PR DESCRIPTION
## 📝 変更内容

- Wiki のテーマ設定に `fontStyle` を追加し、作成・編集・マージ API で指定できるようにしました。
- `wikis` / `draft_wikis` / `wiki_snapshots` に `font_style` カラムを追加し、公開・翻訳・ロールバック・スナップショットで文字スタイルが引き継がれるようにしました。
- 日本語・韓国語・英語それぞれ 5 種類の安定した文字スタイル識別子を `WikiFontStyle` と TypeSpec/OpenAPI の契約として定義しました。
- 公開 Wiki / ドラフト Wiki の詳細・一覧レスポンスに `fontStyle` を追加しました。
- TypeSpec と OpenAPI を更新しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki ごとの個性をテーマカラーだけでなく文字表現でも出せるようにするため、バックエンド側の保存・取得・API 契約に文字スタイル設定を追加しました。既存 Wiki との互換性を保つため `fontStyle` は nullable としています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
  - PHP CS Fixer: Fixed 0 files
  - PHPStan: No errors
  - PHPUnit: OK (2767 tests, 8911 assertions)
- [x] 新しく追加した機能に対するテストを作成
  - `WikiFontStyleTest` を追加
  - input / read model / list query の fontStyle 検証を追加
- [x] 既存のテストが壊れていないことを確認
- [x] `task openapi` で TypeSpec/OpenAPI 生成が成功することを確認

### 動作確認

- Wiki 作成・編集・マージ入力で `fontStyle` を受け取り、許可された識別子のみ通すことを確認しました。
- 一覧・詳細レスポンス、公開・翻訳・ロールバック、スナップショット保存/復元で `fontStyle` が失われない実装になっていることを確認しました。

## 🔍 レビューのポイント

- `fontStyle` が既存の `themeColor` と同じ流れで、入力・Domain Entity・Repository・ReadModel・TypeSpec/OpenAPI に反映されているか
- 既存 Wiki 互換のため nullable とし、未設定時に `null` を返す設計になっているか
- `WikiFontStyle` の識別子が実フォント名ではなく安定 ID になっているか
- 新規マイグレーションが既存テーブルに対して安全に nullable カラムを追加しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #440

## ⚠️ 注意事項

- DB マイグレーションで `wikis` / `draft_wikis` / `wiki_snapshots` に nullable な `font_style` カラムを追加します。
- 実際のフォント読み込み、設定 UI、Wiki 表示画面への CSS 反映はこの PR の対象外です。
- 指定可能な文字スタイル識別子は `WikiFontStyle` / TypeSpec の `WikiFontStyle` union に定義しています。
- 指定された `qa-review`, `test-review`, `security-review`, `architecture-review` スキルは Hermes 上およびプロジェクト内で見つからなかったため、代替として同観点のセルフレビューと `task check` による検証を実施しました。未対応の有効なレビュー指摘はありません。

## 📸 スクリーンショット・デモ

バックエンド/API 契約変更のため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
