### PR TITLE
Wiki作成リクエストのagencyIdentifierをnullableにする

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2783,8 +2783,10 @@ components:
           type: string
           description: Display name of the wiki.
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         groupIdentifiers:
           type: array
@@ -5019,8 +5021,10 @@ components:
       type: object
       properties:
         agencyIdentifier:
+          type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
           description: Associated agency identifier.
         groupIdentifiers:
           type: array

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -23,7 +23,7 @@ scalar DraftWikiRejectionReasonText extends string;
 @doc("Association targets that link a wiki to related agencies, groups, or talents.")
 model WikiAssociationTargets {
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier?: Uuid | null;
   @doc("Associated group identifiers.")
   groupIdentifiers?: Uuid[];
   @doc("Associated talent identifiers.")

--- a/typespec/services/wiki-private-api/wiki.tsp
+++ b/typespec/services/wiki-private-api/wiki.tsp
@@ -43,7 +43,7 @@ model AutoCreateWikiRequestBody {
   @doc("Display name of the wiki.")
   name: string;
   @doc("Associated agency identifier.")
-  agencyIdentifier?: Uuid;
+  agencyIdentifier?: Uuid | null;
   @doc("Associated group identifiers.")
   groupIdentifiers?: Uuid[];
   @doc("Associated talent identifiers.")


### PR DESCRIPTION
## 変更内容

- Wiki Private API の `agencyIdentifier` 入力を `Uuid | null` に変更
- `CreateWikiRequestBody` が継承する `WikiAssociationTargets` と `AutoCreateWikiRequestBody` の定義を揃えた
- OpenAPI を再生成し、`agencyIdentifier` に `nullable: true` を反映

## 変更の種類

- [x] バグ修正 (Bug fix)

## 変更理由・背景

公開済み Wiki から Draft を再作成する際、関連 agency が存在しない Wiki では `agencyIdentifier: null` が送られることがあります。
一方で OpenAPI/generated schema では `agencyIdentifier` が optional string として扱われ、null を許容していなかったため、フロント側で schema validation error になっていました。

バックエンドの UseCase 入力やレスポンスでは nullable として扱われているため、API 契約も nullable に揃えます。

## テスト

### テストの実行確認

- [x] `task openapi-generate` を実行し、OpenAPI 生成が成功することを確認

## レビューのポイント

- `WikiAssociationTargets.agencyIdentifier` が `Uuid | null` になっていること
- `AutoCreateWikiRequestBody.agencyIdentifier` も同様に nullable へ揃っていること
- 生成 OpenAPI に `nullable: true` が反映されていること

## 関連情報

### 関連Issue・タスク

なし

## 注意事項

フロント側で OpenAPI/generated schema の再生成が必要です。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した