### PR TITLE
fix: 認証必須ルートにauth.apiを適用

### DIFF
--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -3,19 +3,22 @@
 declare(strict_types=1);
 
 use Application\Http\Action\Wiki\Image\Command\ApproveImage\ApproveImageAction;
+use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
 use Application\Http\Action\Wiki\Image\Command\DeleteImage\DeleteImageAction;
 use Application\Http\Action\Wiki\Image\Command\RejectImage\RejectImageAction;
+use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
+use Application\Http\Action\Wiki\Image\Command\RequestImageHide\RequestImageHideAction;
 use Application\Http\Action\Wiki\Image\Command\UnhideImage\UnhideImageAction;
 use Application\Http\Action\Wiki\Image\Command\UploadImage\UploadImageAction;
 use Application\Http\Action\Wiki\Image\Query\ListDraftImages\ListDraftImagesAction;
 use Application\Http\Action\Wiki\Image\Query\ListUploadedImages\ListUploadedImagesAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification\ApproveCertificationAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\RejectCertification\RejectCertificationAction;
+use Application\Http\Action\Wiki\OfficialCertification\Command\RequestCertification\RequestCertificationAction;
 use Application\Http\Action\Wiki\Principal\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachPolicyToRole\AttachPolicyToRoleAction;
 use Application\Http\Action\Wiki\Principal\Command\AttachRoleToPrincipalGroup\AttachRoleToPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\CreatePolicy\CreatePolicyAction;
-use Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification\ApproveCertificationAction;
-use Application\Http\Action\Wiki\OfficialCertification\Command\RejectCertification\RejectCertificationAction;
-use Application\Http\Action\Wiki\OfficialCertification\Command\RequestCertification\RequestCertificationAction;
 use Application\Http\Action\Wiki\Principal\Command\CreatePrincipal\CreatePrincipalAction;
 use Application\Http\Action\Wiki\Principal\Command\CreatePrincipalGroup\CreatePrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\CreateRole\CreateRoleAction;
@@ -26,6 +29,7 @@ use Application\Http\Action\Wiki\Principal\Command\DetachPolicyFromRole\DetachPo
 use Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup\DetachRoleFromPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Query\GetCurrentPrincipal\GetCurrentPrincipalAction;
+use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinksAction;
 use Application\Http\Action\Wiki\Wiki\Command\ApproveWiki\ApproveWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\AutoCreateWiki\AutoCreateWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\CreateWiki\CreateWikiAction;
@@ -36,6 +40,8 @@ use Application\Http\Action\Wiki\Wiki\Command\PublishWiki\PublishWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RejectWiki\RejectWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\RollbackWiki\RollbackWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\SubmitWiki\SubmitWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\TranslateWiki\TranslateWikiAction;
+use Application\Http\Action\Wiki\Wiki\Command\WithdrawWiki\WithdrawWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetAgencyDraftWiki\GetAgencyDraftWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetAgencyWiki\GetAgencyWikiAction;
 use Application\Http\Action\Wiki\Wiki\Query\GetGroupDraftWiki\GetGroupDraftWikiAction;
@@ -54,12 +60,6 @@ use Application\Http\Action\Wiki\Wiki\Query\ListRelatedProfiles\ListRelatedProfi
 use Application\Http\Action\Wiki\Wiki\Query\ListVersionInconsistentWikis\ListVersionInconsistentWikisAction;
 use Application\Http\Action\Wiki\Wiki\Query\ListWikis\ListWikisAction;
 use Application\Http\Action\Wiki\Wiki\Query\SearchMasterWikis\SearchMasterWikisAction;
-use Application\Http\Action\Wiki\Image\Command\ApproveImageHideRequest\ApproveImageHideRequestAction;
-use Application\Http\Action\Wiki\Image\Command\RejectImageHideRequest\RejectImageHideRequestAction;
-use Application\Http\Action\Wiki\Image\Command\RequestImageHide\RequestImageHideAction;
-use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinksAction;
-use Application\Http\Action\Wiki\Wiki\Command\TranslateWiki\TranslateWikiAction;
-use Application\Http\Action\Wiki\Wiki\Command\WithdrawWiki\WithdrawWikiAction;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function () {
@@ -77,22 +77,22 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
     Route::post('/wiki/{wikiId}/withdraw', WithdrawWikiAction::class);
 });
 Route::get('/wikis/version-inconsistencies', ListVersionInconsistentWikisAction::class)->middleware(['auth.api', 'resolve.actor']);
-Route::get('/wikis/{language}/masters', SearchMasterWikisAction::class);
+Route::get('/wikis/{language}/masters', SearchMasterWikisAction::class)->middleware('auth.api');
 Route::get('/wikis/{language}', ListWikisAction::class);
 Route::get('/my/draft-wikis', ListMyDraftWikisAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);
 Route::get('/draft-wikis', ListDraftWikisAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);
 Route::get('/wiki/{language}/{slug}/related-profiles', ListRelatedProfilesAction::class);
 Route::get('/wiki/{language}/agency/{slug}', GetAgencyWikiAction::class);
-Route::get('/wiki/agency/{wikiIdentifier}/draft', GetAgencyDraftWikiAction::class);
+Route::get('/wiki/agency/{wikiIdentifier}/draft', GetAgencyDraftWikiAction::class)->middleware('auth.api');
 Route::get('/wiki/{language}/agency/{slug}/my/draft', GetMyAgencyDraftWikiAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);
 Route::get('/wiki/{language}/group/{slug}', GetGroupWikiAction::class);
-Route::get('/wiki/group/{wikiIdentifier}/draft', GetGroupDraftWikiAction::class);
+Route::get('/wiki/group/{wikiIdentifier}/draft', GetGroupDraftWikiAction::class)->middleware('auth.api');
 Route::get('/wiki/{language}/group/{slug}/my/draft', GetMyGroupDraftWikiAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);
 Route::get('/wiki/{language}/song/{slug}', GetSongWikiAction::class);
-Route::get('/wiki/song/{wikiIdentifier}/draft', GetSongDraftWikiAction::class);
+Route::get('/wiki/song/{wikiIdentifier}/draft', GetSongDraftWikiAction::class)->middleware('auth.api');
 Route::get('/wiki/{language}/song/{slug}/my/draft', GetMySongDraftWikiAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);
 Route::get('/wiki/{language}/talent/{slug}', GetTalentWikiAction::class);
-Route::get('/wiki/talent/{wikiIdentifier}/draft', GetTalentDraftWikiAction::class);
+Route::get('/wiki/talent/{wikiIdentifier}/draft', GetTalentDraftWikiAction::class)->middleware('auth.api');
 Route::get('/wiki/{language}/talent/{slug}/my/draft', GetMyTalentDraftWikiAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);
 
 // Image
@@ -109,18 +109,20 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
 // Principal
 Route::get('/principal/me', GetCurrentPrincipalAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::post('/principal/create', CreatePrincipalAction::class)->middleware(['auth.api', 'resolve.actor']);
-Route::post('/principal-group/create', CreatePrincipalGroupAction::class);
-Route::post('/principal-group/{principalGroupId}/add-member', AddPrincipalToPrincipalGroupAction::class);
-Route::post('/principal-group/{principalGroupId}/remove-member', RemovePrincipalFromPrincipalGroupAction::class);
-Route::delete('/principal-group/{principalGroupId}', DeletePrincipalGroupAction::class);
-Route::post('/principal-group/{principalGroupId}/attach-role', AttachRoleToPrincipalGroupAction::class);
-Route::post('/principal-group/{principalGroupId}/detach-role', DetachRoleFromPrincipalGroupAction::class);
-Route::post('/role/create', CreateRoleAction::class);
-Route::delete('/role/{roleId}', DeleteRoleAction::class);
-Route::post('/role/{roleId}/attach-policy', AttachPolicyToRoleAction::class);
-Route::post('/role/{roleId}/detach-policy', DetachPolicyFromRoleAction::class);
-Route::post('/policy/create', CreatePolicyAction::class);
-Route::delete('/policy/{policyId}', DeletePolicyAction::class);
+Route::middleware('auth.api')->group(function () {
+    Route::post('/principal-group/create', CreatePrincipalGroupAction::class);
+    Route::post('/principal-group/{principalGroupId}/add-member', AddPrincipalToPrincipalGroupAction::class);
+    Route::post('/principal-group/{principalGroupId}/remove-member', RemovePrincipalFromPrincipalGroupAction::class);
+    Route::delete('/principal-group/{principalGroupId}', DeletePrincipalGroupAction::class);
+    Route::post('/principal-group/{principalGroupId}/attach-role', AttachRoleToPrincipalGroupAction::class);
+    Route::post('/principal-group/{principalGroupId}/detach-role', DetachRoleFromPrincipalGroupAction::class);
+    Route::post('/role/create', CreateRoleAction::class);
+    Route::delete('/role/{roleId}', DeleteRoleAction::class);
+    Route::post('/role/{roleId}/attach-policy', AttachPolicyToRoleAction::class);
+    Route::post('/role/{roleId}/detach-policy', DetachPolicyFromRoleAction::class);
+    Route::post('/policy/create', CreatePolicyAction::class);
+    Route::delete('/policy/{policyId}', DeletePolicyAction::class);
+});
 
 // ImageHideRequest
 Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function () {
@@ -130,9 +132,11 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
 });
 
 // OfficialCertification
-Route::post('/official-certification/request', RequestCertificationAction::class);
-Route::post('/official-certification/{certificationId}/approve', ApproveCertificationAction::class);
-Route::post('/official-certification/{certificationId}/reject', RejectCertificationAction::class);
+Route::middleware('auth.api')->group(function () {
+    Route::post('/official-certification/request', RequestCertificationAction::class);
+    Route::post('/official-certification/{certificationId}/approve', ApproveCertificationAction::class);
+    Route::post('/official-certification/{certificationId}/reject', RejectCertificationAction::class);
+});
 
 // VideoLink
 Route::post('/video-link/save', SaveVideoLinksAction::class)->middleware(['auth.api', 'resolve.actor', 'resolve.wiki']);

--- a/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
+++ b/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
@@ -82,6 +82,29 @@ class AuthenticatedRouteProtectionTest extends TestCase
         $middleware->handle($request, fn () => response('ok'));
     }
 
+    public function testWikiRoutesWithoutAuthApiMiddlewareMatchPublicRouteWhitelist(): void
+    {
+        $actualPublicWikiRouteUris = [];
+
+        foreach (RouteFacade::getRoutes()->getRoutes() as $route) {
+            if (! str_starts_with($route->uri(), 'api/wiki/')) {
+                continue;
+            }
+
+            if (! in_array('auth.api', $route->gatherMiddleware(), true)) {
+                $actualPublicWikiRouteUris[] = $route->uri();
+            }
+        }
+
+        $actualPublicWikiRouteUris = array_values(array_unique($actualPublicWikiRouteUris));
+        sort($actualPublicWikiRouteUris);
+
+        $expectedPublicWikiRouteUris = self::publicWikiRouteUris();
+        sort($expectedPublicWikiRouteUris);
+
+        $this->assertSame($expectedPublicWikiRouteUris, $actualPublicWikiRouteUris);
+    }
+
     /**
      * @return array<string, array{string, string}>
      */
@@ -175,6 +198,21 @@ class AuthenticatedRouteProtectionTest extends TestCase
             'wiki: group detail' => ['GET', '/api/wiki/wiki/ja/group/group-slug'],
             'wiki: song detail' => ['GET', '/api/wiki/wiki/ja/song/song-slug'],
             'wiki: talent detail' => ['GET', '/api/wiki/wiki/ja/talent/talent-slug'],
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function publicWikiRouteUris(): array
+    {
+        return [
+            'api/wiki/wiki/{language}/{slug}/related-profiles',
+            'api/wiki/wiki/{language}/agency/{slug}',
+            'api/wiki/wiki/{language}/group/{slug}',
+            'api/wiki/wiki/{language}/song/{slug}',
+            'api/wiki/wiki/{language}/talent/{slug}',
+            'api/wiki/wikis/{language}',
         ];
     }
 

--- a/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
+++ b/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
@@ -7,18 +7,73 @@ namespace Tests\Http\Middleware;
 use Application\Http\Exceptions\UnauthorizedHttpException;
 use Application\Http\Middleware\EnsureAuthenticated;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route as RouteFacade;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class AuthenticatedRouteProtectionTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $router = $this->app['router'];
+        $router->aliasMiddleware('auth.api', \Application\Http\Middleware\EnsureAuthenticated::class);
+        $router->aliasMiddleware('resolve.actor', \Application\Http\Middleware\ResolveActorContext::class);
+        $router->aliasMiddleware('resolve.wiki', \Application\Http\Middleware\ResolveWikiContext::class);
+        $router->aliasMiddleware('session', \Illuminate\Session\Middleware\StartSession::class);
+
+        $routePath = static fn (string $file): string => __DIR__ . '/../../../routes/' . $file;
+
+        RouteFacade::middleware(['api', 'session'])
+            ->prefix('api/identity')
+            ->group($routePath('identity_api.php'));
+        RouteFacade::middleware(['api', 'session', 'auth.api', 'resolve.actor'])
+            ->prefix('api/monetization')
+            ->group($routePath('monetization_api.php'));
+        RouteFacade::middleware(['api', 'session'])
+            ->prefix('api/account')
+            ->group($routePath('account_api.php'));
+        RouteFacade::middleware(['api', 'session'])
+            ->prefix('api/wiki')
+            ->group($routePath('wiki_private_api.php'));
+    }
+
     #[DataProvider('authenticatedRouteProvider')]
-    public function testUnauthenticatedRequestThrowsUnauthorizedException(string $method, string $uri): void
+    public function testAuthenticatedRoutesIncludeAuthApiMiddleware(string $method, string $uri): void
+    {
+        $this->assertContains('auth.api', $this->routeFor($method, $uri)->gatherMiddleware());
+    }
+
+    /**
+     * @param array<int, string> $expectedContextMiddleware
+     */
+    #[DataProvider('contextAwareAuthenticatedRouteProvider')]
+    public function testContextAwareAuthenticatedRoutesIncludeRequiredContextMiddleware(
+        string $method,
+        string $uri,
+        array $expectedContextMiddleware,
+    ): void {
+        $middleware = $this->routeFor($method, $uri)->gatherMiddleware();
+
+        foreach ($expectedContextMiddleware as $expectedMiddleware) {
+            $this->assertContains($expectedMiddleware, $middleware);
+        }
+    }
+
+    #[DataProvider('publicRouteProvider')]
+    public function testPublicExceptionRoutesDoNotIncludeAuthApiMiddleware(string $method, string $uri): void
+    {
+        $this->assertNotContains('auth.api', $this->routeFor($method, $uri)->gatherMiddleware());
+    }
+
+    public function testEnsureAuthenticatedMiddlewareRejectsUnauthenticatedRequests(): void
     {
         Auth::shouldReceive('check')->andReturn(false);
 
-        $request = Request::create($uri, $method);
+        $request = Request::create('/api/wiki/principal/me', 'GET');
         $request->headers->set('Accept-Language', 'en');
         $middleware = new EnsureAuthenticated();
 
@@ -33,20 +88,100 @@ class AuthenticatedRouteProtectionTest extends TestCase
     public static function authenticatedRouteProvider(): array
     {
         return [
-            // Identity (authenticated routes)
+            // Identity: 認証開始系以外の操作は認証必須
+            'identity: me' => ['GET', '/api/identity/auth/me'],
             'identity: logout' => ['POST', '/api/identity/auth/logout'],
             'identity: switch-identity' => ['POST', '/api/identity/auth/switch-identity'],
+            'identity: update me' => ['PATCH', '/api/identity/identities/me'],
 
-            // Account (all routes require auth)
-            'account: create account' => ['POST', '/api/account/accounts'],
+            // Account: signup 用の POST /accounts 以外は認証必須
+            'account: delete account' => ['DELETE', '/api/account/accounts/00000000-0000-0000-0000-000000000001'],
+            'account: request delegation' => ['POST', '/api/account/delegations'],
+            'account: create invitation' => ['POST', '/api/account/invitations'],
 
-            // Monetization (all routes require auth)
+            // Monetization: bootstrap/app.php のグループ設定で全 route が認証必須
             'monetization: provision account' => ['POST', '/api/monetization/accounts'],
+            'monetization: authorize payment' => ['POST', '/api/monetization/payments/authorize'],
+            'monetization: execute transfer' => ['POST', '/api/monetization/transfers/00000000-0000-0000-0000-000000000002/execute'],
 
-            // Wiki (all routes require auth)
+            // Wiki command / review / draft / admin / auxiliary edit APIs
             'wiki: create wiki' => ['POST', '/api/wiki/wiki/create'],
+            'wiki: master search' => ['GET', '/api/wiki/wikis/ja/masters'],
+            'wiki: version inconsistencies' => ['GET', '/api/wiki/wikis/version-inconsistencies'],
+            'wiki: agency draft' => ['GET', '/api/wiki/wiki/agency/00000000-0000-0000-0000-000000000003/draft'],
+            'wiki: group draft' => ['GET', '/api/wiki/wiki/group/00000000-0000-0000-0000-000000000004/draft'],
+            'wiki: song draft' => ['GET', '/api/wiki/wiki/song/00000000-0000-0000-0000-000000000005/draft'],
+            'wiki: talent draft' => ['GET', '/api/wiki/wiki/talent/00000000-0000-0000-0000-000000000006/draft'],
+            'wiki: my draft' => ['GET', '/api/wiki/wiki/ja/group/group-slug/my/draft'],
+            'wiki: draft wikis' => ['GET', '/api/wiki/draft-wikis'],
+            'wiki: draft images' => ['GET', '/api/wiki/draft-images'],
+            'wiki: uploaded images' => ['GET', '/api/wiki/images'],
+            'wiki: image upload' => ['POST', '/api/wiki/image/upload'],
             'wiki: current principal' => ['GET', '/api/wiki/principal/me'],
             'wiki: create principal' => ['POST', '/api/wiki/principal/create'],
+            'wiki: create principal group' => ['POST', '/api/wiki/principal-group/create'],
+            'wiki: add principal group member' => ['POST', '/api/wiki/principal-group/00000000-0000-0000-0000-000000000007/add-member'],
+            'wiki: delete principal group' => ['DELETE', '/api/wiki/principal-group/00000000-0000-0000-0000-000000000008'],
+            'wiki: create role' => ['POST', '/api/wiki/role/create'],
+            'wiki: delete role' => ['DELETE', '/api/wiki/role/00000000-0000-0000-0000-000000000009'],
+            'wiki: attach policy' => ['POST', '/api/wiki/role/00000000-0000-0000-0000-000000000010/attach-policy'],
+            'wiki: create policy' => ['POST', '/api/wiki/policy/create'],
+            'wiki: delete policy' => ['DELETE', '/api/wiki/policy/00000000-0000-0000-0000-000000000011'],
+            'wiki: official certification request' => ['POST', '/api/wiki/official-certification/request'],
+            'wiki: official certification approve' => ['POST', '/api/wiki/official-certification/00000000-0000-0000-0000-000000000012/approve'],
+            'wiki: official certification reject' => ['POST', '/api/wiki/official-certification/00000000-0000-0000-0000-000000000013/reject'],
+            'wiki: video link save' => ['POST', '/api/wiki/video-link/save'],
         ];
+    }
+
+    /**
+     * @return array<string, array{string, string, array<int, string>}>
+     */
+    public static function contextAwareAuthenticatedRouteProvider(): array
+    {
+        return [
+            'identity authenticated routes resolve actor' => ['GET', '/api/identity/auth/me', ['resolve.actor']],
+            'account authenticated routes resolve actor' => ['POST', '/api/account/delegations', ['resolve.actor']],
+            'monetization routes resolve actor from bootstrap group' => ['POST', '/api/monetization/accounts', ['resolve.actor']],
+            'wiki commands resolve actor and wiki' => ['POST', '/api/wiki/wiki/create', ['resolve.actor', 'resolve.wiki']],
+            'wiki my draft resolves actor and wiki' => ['GET', '/api/wiki/wiki/ja/group/group-slug/my/draft', ['resolve.actor', 'resolve.wiki']],
+            'wiki current principal resolves actor' => ['GET', '/api/wiki/principal/me', ['resolve.actor']],
+            'wiki image upload resolves actor and wiki' => ['POST', '/api/wiki/image/upload', ['resolve.actor', 'resolve.wiki']],
+            'wiki video link resolves actor and wiki' => ['POST', '/api/wiki/video-link/save', ['resolve.actor', 'resolve.wiki']],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function publicRouteProvider(): array
+    {
+        return [
+            // Identity: 認証開始に必要な公開API
+            'identity: send auth code' => ['POST', '/api/identity/auth/send-auth-code'],
+            'identity: verify email' => ['POST', '/api/identity/auth/verify-email'],
+            'identity: register' => ['POST', '/api/identity/auth/register'],
+            'identity: login' => ['POST', '/api/identity/auth/login'],
+            'identity: social redirect' => ['GET', '/api/identity/auth/social/google/redirect'],
+            'identity: social callback' => ['GET', '/api/identity/auth/social/google/callback'],
+
+            // Account: signup フローで利用する公開例外
+            'account: create account' => ['POST', '/api/account/accounts'],
+
+            // Wiki: トップページ・Wiki一覧・Wiki詳細で必要な公開取得API
+            'wiki: list wikis' => ['GET', '/api/wiki/wikis/ja'],
+            'wiki: related profiles' => ['GET', '/api/wiki/wiki/ja/group-slug/related-profiles'],
+            'wiki: agency detail' => ['GET', '/api/wiki/wiki/ja/agency/agency-slug'],
+            'wiki: group detail' => ['GET', '/api/wiki/wiki/ja/group/group-slug'],
+            'wiki: song detail' => ['GET', '/api/wiki/wiki/ja/song/song-slug'],
+            'wiki: talent detail' => ['GET', '/api/wiki/wiki/ja/talent/talent-slug'],
+        ];
+    }
+
+    private function routeFor(string $method, string $uri): Route
+    {
+        $request = Request::create($uri, $method);
+
+        return RouteFacade::getRoutes()->match($request);
     }
 }


### PR DESCRIPTION
## 📝 変更内容

- Wiki の draft / master search / principal group / role / policy / official certification など、認証必須扱いの API ルートに既存の `auth.api` ミドルウェアを適用しました。
- 公開 Wiki 一覧・詳細・関連プロフィール取得、Identity の signup/login/auth code/social login、Account の `POST /accounts` は公開例外として維持しました。
- `AuthenticatedRouteProtectionTest` を拡充し、実ルート定義に `auth.api` / `resolve.actor` / `resolve.wiki` が含まれること、および公開例外に `auth.api` が含まれないことを検証するようにしました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

認証必須であるべき Wiki 管理系・審査系・draft 系 API の一部が未保護のまま残っていたため、既存の `auth.api` ミドルウェアで未認証アクセスを拒否できる状態にします。
公開ページや signup/login に必要な API は未ログインでも利用できる必要があるため、公開例外としてテストで固定しています。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行結果:

- [x] `task test-no-db filter=AuthenticatedRouteProtectionTest` → OK（58 tests, 62 assertions）
- [x] `task test-no-db` → OK（2248 tests, 7125 assertions）
- [x] `task phpstan` → OK（No errors）
- [x] `docker-compose run --rm --no-deps php bash -c 'composer cs-check'` → OK（0 files need fixing）
- [x] `git diff --check` → OK
- [x] `docker-compose run --rm --no-deps php bash -c 'php artisan route:list --path=api/wiki -vv'` → 対象ルートの middleware 表示を確認

補足:

- ホストの `vendor/bin/phpunit ...` は、ホスト PHP が 8.4.2 で project requirement が PHP >= 8.5 のため実行不可でした。Docker 上の PHP 8.5.8 で上記テストを実行済みです。
- `task test filter=AuthenticatedRouteProtectionTest` は、別作業ツリー由来の `issue-444-official-colors-vo-testing_db-1` が `5433` を使用中のため DB コンテナ起動で失敗しました。今回の変更対象テストは non-DB テストとして `task test-no-db filter=AuthenticatedRouteProtectionTest` で通過済みです。

### 動作確認

- `php artisan route:list --path=api/wiki -vv` で、認証必須対象ルートに `auth.api` が付与され、公開 Wiki 一覧・詳細・関連プロフィール取得ルートに `auth.api` が付与されていないことを確認しました。
- フロント側の `/mypage` および Wiki edit ページは、既存実装で未認証時に login / mypage へ redirect することを確認しました。

## 🔍 レビューのポイント

- 公開 Wiki 一覧・詳細・関連プロフィール取得 API が未ログインで利用可能なままか
- draft / 審査 / 管理 / principal group / role / policy / official certification 系 API に `auth.api` が適用されているか
- actor/wiki context が必要な既存ルートで `resolve.actor` / `resolve.wiki` の適用が維持されているか
- テストが実ルート定義の middleware 設定を検証できているか

Review skills used:

- QA review: no actionable findings
- Security review: no actionable findings
- Architecture review: no actionable findings
- Test review: pending at PR creation time / additional test checks were performed manually as listed above

## 📖 関連情報

### 関連Issue・タスク

Closes #446

## ⚠️ 注意事項

- 新規ミドルウェアは追加していません。既存の `auth.api` を利用しています。
- DB テスト全体はローカル Docker の `5433` ポート競合により未実行です。
- マイグレーションや OpenAPI 生成物の変更はありません。

## 📸 スクリーンショット・デモ

UI 変更なし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
