### PR TITLE
公開Wiki詳細でヒーロー画像の非表示状態を返す

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -2731,7 +2731,7 @@ components:
           description: SEO keywords for the wiki.
         heroImage:
           allOf:
-            - $ref: '#/components/schemas/DraftWikiHeroImage'
+            - $ref: '#/components/schemas/WikiHeroImage'
           description: Hero image payload.
         basic:
           allOf:
@@ -4469,7 +4469,7 @@ components:
           description: SEO keywords for the wiki.
         heroImage:
           allOf:
-            - $ref: '#/components/schemas/DraftWikiHeroImage'
+            - $ref: '#/components/schemas/WikiHeroImage'
           description: Hero image payload.
         basic:
           allOf:
@@ -4804,7 +4804,7 @@ components:
           description: SEO keywords for the wiki.
         heroImage:
           allOf:
-            - $ref: '#/components/schemas/DraftWikiHeroImage'
+            - $ref: '#/components/schemas/WikiHeroImage'
           description: Hero image payload.
         basic:
           allOf:
@@ -5116,7 +5116,7 @@ components:
           description: SEO keywords for the wiki.
         heroImage:
           allOf:
-            - $ref: '#/components/schemas/DraftWikiHeroImage'
+            - $ref: '#/components/schemas/WikiHeroImage'
           description: Hero image payload.
         basic:
           allOf:
@@ -5146,6 +5146,33 @@ components:
         - en_modern
         - en_handwritten
       description: Stable Wiki font style identifiers supported by the backend contract.
+    WikiHeroImage:
+      type: object
+      required:
+        - imageIdentifier
+        - src
+        - alt
+        - isHidden
+      properties:
+        imageIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
+          description: Image identifier shown as the hero image.
+        src:
+          type: string
+          nullable: true
+          description: Resolved hero image URL.
+        alt:
+          type: string
+          nullable: true
+          description: Hero image alternative text.
+        isHidden:
+          type: boolean
+          nullable: true
+          description: Whether the hero image is hidden.
+      description: Hero image payload for a published wiki.
     WikiListItem:
       type: object
       required:

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyWiki.php
@@ -23,7 +23,12 @@ readonly class GetAgencyWiki implements GetAgencyWikiInterface
     public function process(GetAgencyWikiInputPort $input): WikiReadModel
     {
         $model = WikiModel::query()
-            ->select('wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'wikis.image_identifier')
             ->with(['agencyBasic'])
             ->where('wikis.resource_type', ResourceType::AGENCY->value)
@@ -53,6 +58,9 @@ readonly class GetAgencyWiki implements GetAgencyWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new AgencyWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupWiki.php
@@ -24,7 +24,12 @@ readonly class GetGroupWiki implements GetGroupWikiInterface
     public function process(GetGroupWikiInputPort $input): WikiReadModel
     {
         $model = WikiModel::query()
-            ->select('wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'wikis.image_identifier')
             ->with(['groupBasic'])
             ->where('wikis.resource_type', ResourceType::GROUP->value)
@@ -54,6 +59,9 @@ readonly class GetGroupWiki implements GetGroupWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new GroupWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongWiki.php
@@ -26,7 +26,12 @@ readonly class GetSongWiki implements GetSongWikiInterface
     public function process(GetSongWikiInputPort $input): WikiReadModel
     {
         $model = WikiModel::query()
-            ->select('wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'wikis.image_identifier')
             ->with(['songBasic.groups.groupBasic', 'songBasic.talents.talentBasic'])
             ->where('wikis.resource_type', ResourceType::SONG->value)
@@ -56,6 +61,9 @@ readonly class GetSongWiki implements GetSongWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new SongWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentWiki.php
@@ -24,7 +24,12 @@ readonly class GetTalentWiki implements GetTalentWikiInterface
     public function process(GetTalentWikiInputPort $input): WikiReadModel
     {
         $model = WikiModel::query()
-            ->select('wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'wikis.image_identifier')
             ->with(['talentBasic.groups.groupBasic'])
             ->where('wikis.resource_type', ResourceType::TALENT->value)
@@ -57,6 +62,9 @@ readonly class GetTalentWiki implements GetTalentWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new TalentWikiBasicReadModel(
                 name: $basic->name,

--- a/tests/Helper/CreateImage.php
+++ b/tests/Helper/CreateImage.php
@@ -25,6 +25,7 @@ class CreateImage
      *     approved_at?: string|null,
      *     updater_id?: string|null,
      *     updated_at?: string|null,
+     *     is_hidden?: bool,
      * } $overrides
      */
     public static function create(string $imageId, array $overrides = []): void
@@ -45,6 +46,7 @@ class CreateImage
             'approved_at' => $overrides['approved_at'] ?? now(),
             'updater_id' => $overrides['updater_id'] ?? null,
             'updated_at' => $overrides['updated_at'] ?? null,
+            'is_hidden' => $overrides['is_hidden'] ?? false,
         ]);
     }
 }

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyWikiTest.php
@@ -24,6 +24,7 @@ class GetAgencyWikiTest extends TestCase
         CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f404', [
             'image_path' => '/images/wiki/agency-hero.jpg',
             'alt_text' => 'JYP Entertainment hero image',
+            'is_hidden' => true,
         ]);
 
         CreateWiki::create(
@@ -96,6 +97,7 @@ class GetAgencyWikiTest extends TestCase
             'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f404',
             'src' => 'http://127.0.0.1:8080/images/wiki/agency-hero.jpg',
             'alt' => 'JYP Entertainment hero image',
+            'isHidden' => true,
         ], $readModel->heroImage());
         $this->assertInstanceOf(AgencyWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('JYP Entertainment', $readModel->basic()['name']);

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupWikiTest.php
@@ -63,7 +63,7 @@ class GetGroupWikiTest extends TestCase
         $this->assertSame('group', $readModel->resourceType());
         $this->assertSame(2, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
-        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
+        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null, 'isHidden' => null], $readModel->heroImage());
         $this->assertInstanceOf(GroupWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('TWICE', $readModel->basic()['name']);
         $this->assertSame('girl_group', $readModel->basic()['groupType']);

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetSongWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetSongWikiTest.php
@@ -108,7 +108,7 @@ class GetSongWikiTest extends TestCase
         $this->assertSame('song', $readModel->resourceType());
         $this->assertSame(5, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
-        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
+        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null, 'isHidden' => null], $readModel->heroImage());
         $this->assertInstanceOf(SongWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('TT', $readModel->basic()['name']);
         $this->assertSame('title_track', $readModel->basic()['songType']);

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetTalentWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetTalentWikiTest.php
@@ -98,7 +98,7 @@ class GetTalentWikiTest extends TestCase
         $this->assertSame('talent', $readModel->resourceType());
         $this->assertSame(4, $readModel->version());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
-        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
+        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null, 'isHidden' => null], $readModel->heroImage());
         $this->assertInstanceOf(TalentWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('채영', $readModel->basic()['name']);
         $this->assertSame('손채영', $readModel->basic()['realName']);

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -68,6 +68,18 @@ model DraftWikiHeroImage {
   alt: string | null;
 }
 
+@doc("Hero image payload for a published wiki.")
+model WikiHeroImage {
+  @doc("Image identifier shown as the hero image.")
+  imageIdentifier: Uuid | null;
+  @doc("Resolved hero image URL.")
+  src: string | null;
+  @doc("Hero image alternative text.")
+  alt: string | null;
+  @doc("Whether the hero image is hidden.")
+  isHidden: boolean | null;
+}
+
 @doc("Summary of a published agency linked from a wiki basic payload.")
 model WikiAgencySummary {
   @doc("Published agency wiki identifier.")
@@ -203,7 +215,7 @@ model WikiDetail {
   @maxItems(5)
   keywords: SeoKeywordText[] | null;
   @doc("Hero image payload.")
-  heroImage: DraftWikiHeroImage;
+  heroImage: WikiHeroImage;
   @doc("Basic wiki content payload.")
   basic: GroupDraftWikiBasic;
   @doc("Section content payloads.")
@@ -343,7 +355,7 @@ model TalentWikiDetail {
   @maxItems(5)
   keywords: SeoKeywordText[] | null;
   @doc("Hero image payload.")
-  heroImage: DraftWikiHeroImage;
+  heroImage: WikiHeroImage;
   @doc("Basic talent wiki content payload.")
   basic: TalentDraftWikiBasic;
   @doc("Section content payloads.")
@@ -521,7 +533,7 @@ model SongWikiDetail {
   @maxItems(5)
   keywords: SeoKeywordText[] | null;
   @doc("Hero image payload.")
-  heroImage: DraftWikiHeroImage;
+  heroImage: WikiHeroImage;
   @doc("Basic song wiki content payload.")
   basic: SongDraftWikiBasic;
   @doc("Section content payloads.")
@@ -611,7 +623,7 @@ model AgencyWikiDetail {
   @maxItems(5)
   keywords: SeoKeywordText[] | null;
   @doc("Hero image payload.")
-  heroImage: DraftWikiHeroImage;
+  heroImage: WikiHeroImage;
   @doc("Basic agency wiki content payload.")
   basic: AgencyDraftWikiBasic;
   @doc("Section content payloads.")


### PR DESCRIPTION
## 📝 変更内容

公開Wiki詳細レスポンスの `heroImage` に、ヒーロー画像の非表示状態を表す `isHidden` を追加しました。

- 公開Wiki詳細の Group / Talent / Song / Agency 各Queryで `wiki_images.is_hidden` を取得
- `heroImage.isHidden` を `bool|null` として返却
- 公開Wiki詳細用の `WikiHeroImage` TypeSpecモデルを追加
- OpenAPI生成結果を更新
- Queryテストと画像作成ヘルパーを更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

公開Wiki詳細を利用する側で、ヒーロー画像が設定されていても表示対象かどうかを判断できるようにするため、画像の非表示状態をAPIレスポンスに含めます。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`
  - CS Fixer: 変更なし
  - PHPStan: No errors
  - PHPUnit: OK (2824 tests, 8982 assertions)

## 🔍 レビューのポイント

- 公開Wiki詳細の `heroImage` に `isHidden` が追加されていること
- 画像未設定時は `isHidden: null`、画像設定時は boolean として返ること
- TypeSpecとOpenAPIの公開Wiki詳細スキーマが実装と一致していること

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
