### PR TITLE
Draft Wiki詳細と画像一覧で非表示画像を扱う

### DIFF
--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -3134,6 +3134,7 @@ components:
         - imageIdentifier
         - src
         - alt
+        - isHidden
       properties:
         imageIdentifier:
           type: string
@@ -3149,6 +3150,10 @@ components:
           type: string
           nullable: true
           description: Hero image alternative text.
+        isHidden:
+          type: boolean
+          nullable: true
+          description: Whether the hero image is hidden.
       description: Hero image payload for a draft wiki.
     DraftWikiListItem:
       type: object

--- a/src/Wiki/Image/Infrastructure/Query/ListUploadedImages.php
+++ b/src/Wiki/Image/Infrastructure/Query/ListUploadedImages.php
@@ -20,6 +20,7 @@ readonly class ListUploadedImages implements ListUploadedImagesInterface
         /** @var LengthAwarePaginator<int, WikiImage> $paginator */
         $paginator = WikiImage::query()
             ->where('translation_set_identifier', (string) $input->translationSetIdentifier())
+            ->where('is_hidden', false)
             ->orderBy('uploaded_at', 'desc')
             ->paginate($input->perPage());
 

--- a/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWiki.php
@@ -32,7 +32,12 @@ readonly class GetAgencyDraftWiki implements GetAgencyDraftWikiInterface
     private function getByIdentifier(DraftWikiIdentifier $wikiIdentifier): DraftWikiReadModel
     {
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['agencyBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::AGENCY->value)
@@ -65,6 +70,9 @@ readonly class GetAgencyDraftWiki implements GetAgencyDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new AgencyWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWiki.php
@@ -35,7 +35,12 @@ readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
     private function getByIdentifier(DraftWikiIdentifier $wikiIdentifier): DraftWikiReadModel
     {
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['groupBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::GROUP->value)
@@ -68,6 +73,9 @@ readonly class GetGroupDraftWiki implements GetGroupDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new GroupWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMyAgencyDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMyAgencyDraftWiki.php
@@ -27,7 +27,12 @@ readonly class GetMyAgencyDraftWiki implements GetMyAgencyDraftWikiInterface
         $editorIdentifier = $input->editorIdentifier();
 
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['agencyBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::AGENCY->value)
@@ -62,6 +67,9 @@ readonly class GetMyAgencyDraftWiki implements GetMyAgencyDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new AgencyWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMyGroupDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMyGroupDraftWiki.php
@@ -28,7 +28,12 @@ readonly class GetMyGroupDraftWiki implements GetMyGroupDraftWikiInterface
         $editorIdentifier = $input->editorIdentifier();
 
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['groupBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::GROUP->value)
@@ -63,6 +68,9 @@ readonly class GetMyGroupDraftWiki implements GetMyGroupDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new GroupWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMySongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMySongDraftWiki.php
@@ -31,7 +31,12 @@ readonly class GetMySongDraftWiki implements GetMySongDraftWikiInterface
         $editorIdentifier = $input->editorIdentifier();
 
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['songBasic.groups.groupBasic', 'songBasic.talents.talentBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::SONG->value)
@@ -66,6 +71,9 @@ readonly class GetMySongDraftWiki implements GetMySongDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new SongWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetMyTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetMyTalentDraftWiki.php
@@ -29,7 +29,12 @@ readonly class GetMyTalentDraftWiki implements GetMyTalentDraftWikiInterface
         $editorIdentifier = $input->editorIdentifier();
 
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['talentBasic.groups.groupBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::TALENT->value)
@@ -67,6 +72,9 @@ readonly class GetMyTalentDraftWiki implements GetMyTalentDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new TalentWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetSongDraftWiki.php
@@ -36,7 +36,12 @@ readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
     private function getByIdentifier(DraftWikiIdentifier $wikiIdentifier): DraftWikiReadModel
     {
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['songBasic.groups.groupBasic', 'songBasic.talents.talentBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::SONG->value)
@@ -69,6 +74,9 @@ readonly class GetSongDraftWiki implements GetSongDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new SongWikiBasicReadModel(
                 name: $basic->name,

--- a/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
+++ b/src/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWiki.php
@@ -34,7 +34,12 @@ readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
     private function getByIdentifier(DraftWikiIdentifier $wikiIdentifier): DraftWikiReadModel
     {
         $model = DraftWikiModel::query()
-            ->select('draft_wikis.*', 'wiki_images.image_path as hero_image_path', 'wiki_images.alt_text as hero_image_alt_text')
+            ->select(
+                'draft_wikis.*',
+                'wiki_images.image_path as hero_image_path',
+                'wiki_images.alt_text as hero_image_alt_text',
+                'wiki_images.is_hidden as hero_image_is_hidden',
+            )
             ->leftJoin('wiki_images', 'wiki_images.id', '=', 'draft_wikis.image_identifier')
             ->with(['talentBasic.groups.groupBasic', 'publishedWiki'])
             ->where('draft_wikis.resource_type', ResourceType::TALENT->value)
@@ -70,6 +75,9 @@ readonly class GetTalentDraftWiki implements GetTalentDraftWikiInterface
                 'imageIdentifier' => $model->image_identifier,
                 'src' => ImageUrl::fromPath($model->getAttribute('hero_image_path')),
                 'alt' => $model->getAttribute('hero_image_alt_text'),
+                'isHidden' => $model->getAttribute('hero_image_is_hidden') === null
+                    ? null
+                    : (bool) $model->getAttribute('hero_image_is_hidden'),
             ],
             basic: new TalentWikiBasicReadModel(
                 name: $basic->name,

--- a/tests/Wiki/Image/Infrastructure/Query/ListUploadedImagesTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListUploadedImagesTest.php
@@ -108,6 +108,34 @@ class ListUploadedImagesTest extends TestCase
     }
 
     #[Group('useDb')]
+    public function testProcessExcludesHiddenImages(): void
+    {
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f701', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f801',
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f702', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f801',
+            'uploaded_at' => '2026-05-02 00:00:00',
+            'is_hidden' => true,
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f703', [
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f801',
+            'uploaded_at' => '2026-05-03 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListUploadedImagesInput(
+            translationSetIdentifier: new TranslationSetIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f801'),
+        ))->toArray();
+
+        $this->assertSame(2, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f703',
+            '01965bb2-bcc9-7c6f-8b90-89f7f217f701',
+        ], array_column($payload['images'], 'imageIdentifier'));
+    }
+
+    #[Group('useDb')]
     public function testProcessReturnsImageMetadata(): void
     {
         CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f501', [

--- a/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Query/DraftWikiReadModelTest.php
@@ -24,6 +24,7 @@ class DraftWikiReadModelTest extends TestCase
                 'imageIdentifier' => null,
                 'src' => null,
                 'alt' => null,
+                'isHidden' => null,
             ],
             basic: [
                 'name' => 'TWICE',
@@ -67,7 +68,7 @@ class DraftWikiReadModelTest extends TestCase
         $this->assertSame('TWICE Draft Wiki', $readModel->title());
         $this->assertSame('Draft profile and history for TWICE.', $readModel->metaDescription());
         $this->assertSame(['TWICE', 'draft'], $readModel->keywords());
-        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
+        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null, 'isHidden' => null], $readModel->heroImage());
         $this->assertInstanceOf(GroupWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('TWICE', $readModel->basic()['name']);
         $this->assertSame('overview', $readModel->sections()[0]['id']);
@@ -88,6 +89,7 @@ class DraftWikiReadModelTest extends TestCase
                 'imageIdentifier' => null,
                 'src' => null,
                 'alt' => null,
+                'isHidden' => null,
             ],
             'basic' => [
                 'name' => 'TWICE',

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetAgencyDraftWikiTest.php
@@ -33,6 +33,7 @@ class GetAgencyDraftWikiTest extends TestCase
         CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f217f404', [
             'image_path' => '/images/wiki/agency-hero.jpg',
             'alt_text' => 'JYP Entertainment hero image',
+            'is_hidden' => true,
         ]);
 
         CreateDraftWiki::create(
@@ -105,6 +106,7 @@ class GetAgencyDraftWikiTest extends TestCase
             'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f404',
             'src' => 'http://127.0.0.1:8080/images/wiki/agency-hero.jpg',
             'alt' => 'JYP Entertainment hero image',
+            'isHidden' => true,
         ], $readModel->heroImage());
         $this->assertInstanceOf(AgencyWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('JYP Entertainment', $readModel->basic()['name']);

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetGroupDraftWikiTest.php
@@ -32,7 +32,7 @@ class GetGroupDraftWikiTest extends TestCase
         $this->assertSame('group', $readModel->resourceType());
         $this->assertSame('pending', $readModel->status());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
-        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
+        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null, 'isHidden' => null], $readModel->heroImage());
         $this->assertInstanceOf(GroupWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('TWICE', $readModel->basic()['name']);
         $this->assertSame('girl_group', $readModel->basic()['groupType']);

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetSongDraftWikiTest.php
@@ -134,7 +134,7 @@ class GetSongDraftWikiTest extends TestCase
         $this->assertSame('song', $readModel->resourceType());
         $this->assertSame('楽曲説明を見直してください', $readModel->rejectionReason());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
-        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
+        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null, 'isHidden' => null], $readModel->heroImage());
         $this->assertInstanceOf(SongWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('TT', $readModel->basic()['name']);
         $this->assertSame('title_track', $readModel->basic()['songType']);

--- a/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/GetTalentDraftWikiTest.php
@@ -30,7 +30,7 @@ class GetTalentDraftWikiTest extends TestCase
         $this->assertSame('ko', $readModel->language());
         $this->assertSame('talent', $readModel->resourceType());
         $this->assertSame('#FE5F8F', $readModel->themeColor());
-        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null], $readModel->heroImage());
+        $this->assertSame(['imageIdentifier' => null, 'src' => null, 'alt' => null, 'isHidden' => null], $readModel->heroImage());
         $this->assertInstanceOf(TalentWikiBasicReadModel::class, $readModel->basic());
         $this->assertSame('Chaeyoung', $readModel->basic()['name']);
         $this->assertSame('Son Chaeyoung', $readModel->basic()['realName']);

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -66,6 +66,8 @@ model DraftWikiHeroImage {
   src: string | null;
   @doc("Hero image alternative text.")
   alt: string | null;
+  @doc("Whether the hero image is hidden.")
+  isHidden: boolean | null;
 }
 
 @doc("Hero image payload for a published wiki.")


### PR DESCRIPTION
## 📝 変更内容

Draft Wiki詳細レスポンスの `heroImage` に、ヒーロー画像の非表示状態を表す `isHidden` を追加しました。

あわせて、アップロード済み画像一覧では非表示画像を返さないようにしました。

- Draft Wiki詳細の Group / Talent / Song / Agency 各Queryで `wiki_images.is_hidden` を取得
- 所有者向け Draft Wiki詳細の `GetMy*DraftWiki` でも `heroImage.isHidden` を返却
- `DraftWikiHeroImage` の TypeSpec / OpenAPI を更新
- `ListUploadedImages` で `is_hidden = false` の画像のみ取得
- Draft詳細と画像一覧のテストを更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Draft Wiki詳細を利用する側で、ヒーロー画像が設定されていても表示対象かどうかを判断できるようにするため、画像の非表示状態をAPIレスポンスに含めます。

また、アップロード済み画像一覧では選択対象として非表示画像を出さないようにし、削除申請などで非表示になった画像が再利用されにくい状態にします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task openapi`
- `task test filter=ListUploadedImages`
  - OK (8 tests, 21 assertions)
- `task test filter=DraftWiki`
  - OK (130 tests, 485 assertions)
- `task check`
  - CS Fixer: 変更なし
  - PHPStan: No errors
  - PHPUnit: OK (2825 tests, 8984 assertions)

## 🔍 レビューのポイント

- Draft Wiki詳細の `heroImage` に `isHidden` が追加されていること
- 画像未設定時は `isHidden: null`、画像設定時は boolean として返ること
- `ListUploadedImages` のページング対象から hidden 画像が除外されること
- TypeSpecとOpenAPIの `DraftWikiHeroImage` が実装と一致していること

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
