### PR TITLE
add: 削除申請中画像一覧APIを追加

### DIFF
--- a/application/Http/Action/Wiki/Image/Query/ListImageDeletionRequests/ListImageDeletionRequestsAction.php
+++ b/application/Http/Action/Wiki/Image/Query/ListImageDeletionRequests/ListImageDeletionRequestsAction.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Query\ListImageDeletionRequests;
+
+use Application\Http\Context\WikiContext;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInput;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsOutput;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ListImageDeletionRequestsAction
+{
+    public function __construct(
+        private ListImageDeletionRequestsInterface $listImageDeletionRequests,
+        private WikiContext $wikiContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(ListImageDeletionRequestsRequest $request): JsonResponse
+    {
+        try {
+            try {
+                $input = new ListImageDeletionRequestsInput(
+                    principalIdentifier: $this->wikiContext->principalIdentifier,
+                    perPage: $request->perPage(),
+                );
+                $output = new ListImageDeletionRequestsOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $this->listImageDeletionRequests->process($input, $output);
+            } catch (DisallowedException $e) {
+                $this->logger->error((string) $e);
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $request->language()), previous: $e);
+            } catch (PrincipalNotFoundException $e) {
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+            }
+        } catch (ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Image/Query/ListImageDeletionRequests/ListImageDeletionRequestsRequest.php
+++ b/application/Http/Action/Wiki/Image/Query/ListImageDeletionRequests/ListImageDeletionRequestsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Image\Query\ListImageDeletionRequests;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListImageDeletionRequestsRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+
+    public function perPage(): ?int
+    {
+        $perPage = $this->query('perPage');
+
+        return $perPage === null ? null : (int) $perPage;
+    }
+}

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -22,8 +22,10 @@ use Source\Wiki\Image\Application\UseCase\Command\UnhideImage\UnhideImageInterfa
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImage;
 use Source\Wiki\Image\Application\UseCase\Command\UploadImage\UploadImageInterface;
 use Source\Wiki\Image\Application\UseCase\Query\ListDraftImages\ListDraftImagesInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInterface;
 use Source\Wiki\Image\Application\UseCase\Query\ListUploadedImages\ListUploadedImagesInterface;
 use Source\Wiki\Image\Infrastructure\Query\ListDraftImages;
+use Source\Wiki\Image\Infrastructure\Query\ListImageDeletionRequests;
 use Source\Wiki\Image\Infrastructure\Query\ListUploadedImages;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertification;
 use Source\Wiki\OfficialCertification\Application\UseCase\Command\ApproveCertification\ApproveCertificationInterface;
@@ -149,6 +151,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RequestImageDeletionInterface::class, RequestImageDeletion::class);
         $this->app->singleton(ApproveImageDeletionInterface::class, ApproveImageDeletion::class);
         $this->app->singleton(RejectImageDeletionInterface::class, RejectImageDeletion::class);
+        $this->app->singleton(ListImageDeletionRequestsInterface::class, ListImageDeletionRequests::class);
         $this->app->singleton(ListDraftImagesInterface::class, ListDraftImages::class);
         $this->app->singleton(ListUploadedImagesInterface::class, ListUploadedImages::class);
         $this->app->singleton(CreateWikiInterface::class, CreateWiki::class);

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -125,6 +125,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /image-deletion-requests:
+    get:
+      operationId: ImageDeletionRequestListOperations_listImageDeletionRequests
+      description: List uploaded images with pending image deletion requests.
+      parameters:
+        - name: perPage
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            nullable: true
+          explode: false
+      responses:
+        '200':
+          description: Response returned when pending image deletion request list retrieval succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListImageDeletionRequestsResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /image/upload:
     post:
       operationId: ImageOperations_uploadImage
@@ -3414,6 +3458,67 @@ components:
           type: string
           description: Representative symbol of the group.
       description: Basic payload for a group draft wiki.
+    ImageDeletionRequestListItem:
+      type: object
+      required:
+        - imageIdentifier
+        - url
+        - resourceType
+        - translationSetIdentifier
+        - displayOrder
+        - sourceUrl
+        - sourceName
+        - altText
+        - isHidden
+        - uploadedAt
+        - name
+        - email
+        - reason
+      properties:
+        imageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Image identifier.
+        url:
+          type: string
+          description: Absolute image URL.
+        resourceType:
+          type: string
+          description: Resource type that the image belongs to.
+        translationSetIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Translation set identifier that the image belongs to.
+        displayOrder:
+          type: integer
+          format: int32
+          description: Display order of the image.
+        sourceUrl:
+          type: string
+          description: Original source URL of the image.
+        sourceName:
+          type: string
+          description: Original source name of the image.
+        altText:
+          type: string
+          description: Alternative text for the image.
+        isHidden:
+          type: boolean
+          description: Whether the image is hidden.
+        uploadedAt:
+          type: string
+          nullable: true
+          description: Timestamp when the image was uploaded.
+        name:
+          type: string
+          description: Name of the image deletion requester.
+        email:
+          type: string
+          description: Email address of the image deletion requester.
+        reason:
+          type: string
+          description: Reason for the image deletion request.
+      description: Uploaded image item with pending image deletion request details.
     ImageDeletionRequestSummary:
       type: object
       required:
@@ -3580,6 +3685,37 @@ components:
           format: int32
           description: Number of wikis per page.
       description: Response body for the draft wiki list endpoint.
+    ListImageDeletionRequestsResponseBody:
+      type: object
+      required:
+        - images
+        - current_page
+        - last_page
+        - total
+        - per_page
+      properties:
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImageDeletionRequestListItem'
+          description: Uploaded images that have pending image deletion requests for the requested page.
+        current_page:
+          type: integer
+          format: int32
+          description: Current page number.
+        last_page:
+          type: integer
+          format: int32
+          description: Last page number.
+        total:
+          type: integer
+          format: int32
+          description: Total number of pending image deletion requests.
+        per_page:
+          type: integer
+          format: int32
+          description: Number of images per page.
+      description: Response body for the pending image deletion request list endpoint.
     ListRelatedProfilesResponseBody:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -10,6 +10,7 @@ use Application\Http\Action\Wiki\Image\Command\RejectImageDeletion\RejectImageDe
 use Application\Http\Action\Wiki\Image\Command\RequestImageDeletion\RequestImageDeletionAction;
 use Application\Http\Action\Wiki\Image\Command\UnhideImage\UnhideImageAction;
 use Application\Http\Action\Wiki\Image\Command\UploadImage\UploadImageAction;
+use Application\Http\Action\Wiki\Image\Query\ListImageDeletionRequests\ListImageDeletionRequestsAction;
 use Application\Http\Action\Wiki\Image\Query\ListDraftImages\ListDraftImagesAction;
 use Application\Http\Action\Wiki\Image\Query\ListUploadedImages\ListUploadedImagesAction;
 use Application\Http\Action\Wiki\OfficialCertification\Command\ApproveCertification\ApproveCertificationAction;
@@ -126,6 +127,7 @@ Route::middleware('auth.api')->group(function () {
 
 // ImageDeletionRequest
 Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function () {
+    Route::get('/image-deletion-requests', ListImageDeletionRequestsAction::class);
     Route::post('/image/{imageId}/request-deletion', RequestImageDeletionAction::class);
     Route::post('/image/{imageId}/approve-deletion', ApproveImageDeletionAction::class);
     Route::post('/image/{imageId}/reject-deletion', RejectImageDeletionAction::class);

--- a/src/Wiki/Image/Application/UseCase/Query/ImageDeletionRequestListItemReadModel.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ImageDeletionRequestListItemReadModel.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query;
+
+readonly class ImageDeletionRequestListItemReadModel
+{
+    public function __construct(
+        private string $imageIdentifier,
+        private string $url,
+        private string $resourceType,
+        private string $translationSetIdentifier,
+        private int $displayOrder,
+        private string $sourceUrl,
+        private string $sourceName,
+        private string $altText,
+        private bool $isHidden,
+        private ?string $uploadedAt,
+        private string $name,
+        private string $email,
+        private string $reason,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'imageIdentifier' => $this->imageIdentifier,
+            'url' => $this->url,
+            'resourceType' => $this->resourceType,
+            'translationSetIdentifier' => $this->translationSetIdentifier,
+            'displayOrder' => $this->displayOrder,
+            'sourceUrl' => $this->sourceUrl,
+            'sourceName' => $this->sourceName,
+            'altText' => $this->altText,
+            'isHidden' => $this->isHidden,
+            'uploadedAt' => $this->uploadedAt,
+            'name' => $this->name,
+            'email' => $this->email,
+            'reason' => $this->reason,
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInput.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInput.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests;
+
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+
+readonly class ListImageDeletionRequestsInput implements ListImageDeletionRequestsInputPort
+{
+    public function __construct(
+        private PrincipalIdentifier $principalIdentifier,
+        private ?int $perPage = null,
+    ) {
+    }
+
+    public function principalIdentifier(): PrincipalIdentifier
+    {
+        return $this->principalIdentifier;
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage ?? 10;
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInputPort.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests;
+
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+
+interface ListImageDeletionRequestsInputPort
+{
+    public function principalIdentifier(): PrincipalIdentifier;
+
+    public function perPage(): int;
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInterface.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests;
+
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+
+interface ListImageDeletionRequestsInterface
+{
+    /**
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function process(ListImageDeletionRequestsInputPort $input, ListImageDeletionRequestsOutputPort $output): void;
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsOutput.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests;
+
+use Source\Wiki\Image\Application\UseCase\Query\ImageDeletionRequestListItemReadModel;
+
+class ListImageDeletionRequestsOutput implements ListImageDeletionRequestsOutputPort
+{
+    /** @var list<ImageDeletionRequestListItemReadModel> */
+    private array $images = [];
+
+    private ?int $currentPage = null;
+
+    private ?int $lastPage = null;
+
+    private ?int $total = null;
+
+    private ?int $perPage = null;
+
+    /**
+     * @param list<ImageDeletionRequestListItemReadModel> $images
+     */
+    public function output(array $images, int $currentPage, int $lastPage, int $total, int $perPage): void
+    {
+        $this->images = $images;
+        $this->currentPage = $currentPage;
+        $this->lastPage = $lastPage;
+        $this->total = $total;
+        $this->perPage = $perPage;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'images' => array_map(static fn (ImageDeletionRequestListItemReadModel $image): array => $image->toArray(), $this->images),
+            'current_page' => $this->currentPage,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'per_page' => $this->perPage,
+        ];
+    }
+}

--- a/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsOutputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests;
+
+use Source\Wiki\Image\Application\UseCase\Query\ImageDeletionRequestListItemReadModel;
+
+interface ListImageDeletionRequestsOutputPort
+{
+    /**
+     * @param list<ImageDeletionRequestListItemReadModel> $images
+     */
+    public function output(array $images, int $currentPage, int $lastPage, int $total, int $perPage): void;
+}

--- a/src/Wiki/Image/Infrastructure/Query/ListImageDeletionRequests.php
+++ b/src/Wiki/Image/Infrastructure/Query/ListImageDeletionRequests.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Image\Infrastructure\Query;
+
+use Application\Models\Wiki\ImageDeletionRequest;
+use Application\Models\Wiki\WikiImage;
+use DateTimeInterface;
+use Source\Shared\Infrastructure\Support\ImageUrl;
+use Source\Wiki\Image\Application\UseCase\Query\ImageDeletionRequestListItemReadModel;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInputPort;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsOutputPort;
+use Source\Wiki\Image\Domain\Repository\ImageRepositoryInterface;
+use Source\Wiki\Image\Domain\Service\ImageAuthorizationResourceBuilderInterface;
+use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Wiki\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\Exception\PrincipalNotFoundException;
+use Source\Wiki\Shared\Domain\ValueObject\Action;
+use Source\Wiki\Shared\Domain\ValueObject\ImageIdentifier;
+
+readonly class ListImageDeletionRequests implements ListImageDeletionRequestsInterface
+{
+    public function __construct(
+        private ImageRepositoryInterface $imageRepository,
+        private PrincipalRepositoryInterface $principalRepository,
+        private PolicyEvaluatorInterface $policyEvaluator,
+        private ImageAuthorizationResourceBuilderInterface $imageAuthorizationResourceBuilder,
+    ) {
+    }
+
+    /**
+     * @throws DisallowedException
+     * @throws PrincipalNotFoundException
+     */
+    public function process(ListImageDeletionRequestsInputPort $input, ListImageDeletionRequestsOutputPort $output): void
+    {
+        $principal = $this->principalRepository->findById($input->principalIdentifier());
+        if ($principal === null) {
+            throw new PrincipalNotFoundException();
+        }
+
+        /** @var list<ImageDeletionRequest> $requests */
+        $requests = ImageDeletionRequest::query()
+            ->with('image')
+            ->whereNull('reviewed_at')
+            ->whereHas('image')
+            ->orderByDesc('requested_at')
+            ->get()
+            ->all();
+
+        $readModels = [];
+        foreach ($requests as $request) {
+            $image = $request->image;
+            if (! $image instanceof WikiImage) {
+                continue;
+            }
+
+            $domainImage = $this->imageRepository->findById(new ImageIdentifier($image->id));
+            if ($domainImage === null) {
+                continue;
+            }
+
+            $resource = $this->imageAuthorizationResourceBuilder->buildFromImage($domainImage);
+            if (
+                ! $this->policyEvaluator->evaluate($principal, Action::APPROVE, $resource)
+                && ! $this->policyEvaluator->evaluate($principal, Action::REJECT, $resource)
+            ) {
+                throw new DisallowedException();
+            }
+
+            $readModels[] = $this->toReadModel($image, $request);
+        }
+
+        $perPage = $input->perPage();
+        $currentPage = max(1, (int) request()->query('page', 1));
+        $total = count($readModels);
+        $lastPage = max(1, (int) ceil($total / $perPage));
+        $pageItems = array_slice($readModels, ($currentPage - 1) * $perPage, $perPage);
+
+        $output->output($pageItems, $currentPage, $lastPage, $total, $perPage);
+    }
+
+    private function toReadModel(WikiImage $image, ImageDeletionRequest $request): ImageDeletionRequestListItemReadModel
+    {
+        return new ImageDeletionRequestListItemReadModel(
+            imageIdentifier: $image->id,
+            url: ImageUrl::fromPath($image->image_path) ?? '',
+            resourceType: $image->resource_type,
+            translationSetIdentifier: $image->translation_set_identifier,
+            displayOrder: $image->display_order,
+            sourceUrl: $image->source_url,
+            sourceName: $image->source_name,
+            altText: $image->alt_text,
+            isHidden: $image->is_hidden,
+            uploadedAt: $this->formatDateTime($image->uploaded_at),
+            name: $request->requester_name,
+            email: $request->requester_email,
+            reason: $request->reason,
+        );
+    }
+
+    private function formatDateTime(mixed $dateTime): ?string
+    {
+        if ($dateTime === null) {
+            return null;
+        }
+
+        if ($dateTime instanceof DateTimeInterface) {
+            return $dateTime->format(DateTimeInterface::ATOM);
+        }
+
+        return (string) $dateTime;
+    }
+}

--- a/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
+++ b/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
@@ -138,6 +138,7 @@ class AuthenticatedRouteProtectionTest extends TestCase
             'wiki: my draft' => ['GET', '/api/wiki/wiki/ja/group/group-slug/my/draft'],
             'wiki: draft wikis' => ['GET', '/api/wiki/draft-wikis'],
             'wiki: draft images' => ['GET', '/api/wiki/draft-images'],
+            'wiki: image deletion requests' => ['GET', '/api/wiki/image-deletion-requests'],
             'wiki: uploaded images' => ['GET', '/api/wiki/images'],
             'wiki: image upload' => ['POST', '/api/wiki/image/upload'],
             'wiki: current principal' => ['GET', '/api/wiki/principal/me'],
@@ -170,6 +171,7 @@ class AuthenticatedRouteProtectionTest extends TestCase
             'wiki my draft resolves actor and wiki' => ['GET', '/api/wiki/wiki/ja/group/group-slug/my/draft', ['resolve.actor', 'resolve.wiki']],
             'wiki current principal resolves actor' => ['GET', '/api/wiki/principal/me', ['resolve.actor']],
             'wiki image upload resolves actor and wiki' => ['POST', '/api/wiki/image/upload', ['resolve.actor', 'resolve.wiki']],
+            'wiki image deletion requests resolves actor and wiki' => ['GET', '/api/wiki/image-deletion-requests', ['resolve.actor', 'resolve.wiki']],
             'wiki video link resolves actor and wiki' => ['POST', '/api/wiki/video-link/save', ['resolve.actor', 'resolve.wiki']],
         ];
     }

--- a/tests/Wiki/Image/Application/UseCase/Query/ImageDeletionRequestListItemReadModelTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ImageDeletionRequestListItemReadModelTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query;
+
+use Source\Wiki\Image\Application\UseCase\Query\ImageDeletionRequestListItemReadModel;
+use Tests\TestCase;
+
+class ImageDeletionRequestListItemReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $readModel = new ImageDeletionRequestListItemReadModel(
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            url: 'https://example.com/images/talents/profile.jpg',
+            resourceType: 'talent',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            displayOrder: 1,
+            sourceUrl: 'https://example.com/source',
+            sourceName: 'Example Source',
+            altText: 'Profile image',
+            isHidden: false,
+            uploadedAt: '2026-05-01T00:00:00+00:00',
+            name: '申請者',
+            email: 'requester@example.com',
+            reason: '権利者から削除依頼があったため',
+        );
+
+        $this->assertSame([
+            'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            'url' => 'https://example.com/images/talents/profile.jpg',
+            'resourceType' => 'talent',
+            'translationSetIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            'displayOrder' => 1,
+            'sourceUrl' => 'https://example.com/source',
+            'sourceName' => 'Example Source',
+            'altText' => 'Profile image',
+            'isHidden' => false,
+            'uploadedAt' => '2026-05-01T00:00:00+00:00',
+            'name' => '申請者',
+            'email' => 'requester@example.com',
+            'reason' => '権利者から削除依頼があったため',
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsInputTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests;
+
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInput;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\TestCase;
+
+class ListImageDeletionRequestsInputTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $input = new ListImageDeletionRequestsInput(
+            principalIdentifier: new PrincipalIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f101'),
+        );
+
+        $this->assertSame(10, $input->perPage());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f101', (string) $input->principalIdentifier());
+    }
+
+    public function testAccessors(): void
+    {
+        $input = new ListImageDeletionRequestsInput(
+            principalIdentifier: new PrincipalIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f102'),
+            perPage: 20,
+        );
+
+        $this->assertSame(20, $input->perPage());
+        $this->assertSame('01965bb2-bcc9-7c6f-8b90-89f7f217f102', (string) $input->principalIdentifier());
+    }
+}

--- a/tests/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Query/ListImageDeletionRequests/ListImageDeletionRequestsOutputTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests;
+
+use Source\Wiki\Image\Application\UseCase\Query\ImageDeletionRequestListItemReadModel;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsOutput;
+use Tests\TestCase;
+
+class ListImageDeletionRequestsOutputTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $image = new ImageDeletionRequestListItemReadModel(
+            imageIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f101',
+            url: 'https://example.com/images/talents/profile.jpg',
+            resourceType: 'talent',
+            translationSetIdentifier: '01965bb2-bcc9-7c6f-8b90-89f7f217f201',
+            displayOrder: 1,
+            sourceUrl: 'https://example.com/source',
+            sourceName: 'Example Source',
+            altText: 'Profile image',
+            isHidden: false,
+            uploadedAt: '2026-05-01T00:00:00+00:00',
+            name: '申請者',
+            email: 'requester@example.com',
+            reason: '権利者から削除依頼があったため',
+        );
+
+        $output = new ListImageDeletionRequestsOutput();
+        $output->output([$image], 1, 3, 5, 2);
+
+        $this->assertSame([
+            'images' => [$image->toArray()],
+            'current_page' => 1,
+            'last_page' => 3,
+            'total' => 5,
+            'per_page' => 2,
+        ], $output->toArray());
+    }
+}

--- a/tests/Wiki/Image/Infrastructure/Query/ListImageDeletionRequestsTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListImageDeletionRequestsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Image\Infrastructure\Query;
+
+use Mockery;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInput;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsInterface;
+use Source\Wiki\Image\Application\UseCase\Query\ListImageDeletionRequests\ListImageDeletionRequestsOutput;
+use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Wiki\Shared\Domain\Exception\DisallowedException;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\CreateImage;
+use Tests\Helper\CreateImageDeletionRequest;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ListImageDeletionRequestsTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testProcessReturnsPendingDeletionRequestsWithRequesterDetails(): void
+    {
+        $principalIdentifier = $this->bindPrincipalRepository();
+        $this->setPolicyEvaluatorResult(true);
+
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f448f101', [
+            'resource_type' => 'talent',
+            'translation_set_identifier' => '01965bb2-bcc9-7c6f-8b90-89f7f448f901',
+            'image_path' => 'images/talents/deletion-request.jpg',
+            'display_order' => 3,
+            'source_url' => 'https://example.com/source-image',
+            'source_name' => 'Source Name',
+            'alt_text' => 'Deletion request target',
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateImageDeletionRequest::create('01965bb2-bcc9-7c6f-8b90-89f7f448d101', [
+            'image_id' => '01965bb2-bcc9-7c6f-8b90-89f7f448f101',
+            'requester_name' => 'Request User',
+            'requester_email' => 'request-user@example.com',
+            'reason' => '肖像権の懸念があるため',
+            'requested_at' => '2026-05-02 00:00:00',
+        ]);
+
+        $payload = $this->process(new ListImageDeletionRequestsInput($principalIdentifier))->toArray();
+
+        $this->assertSame(1, $payload['current_page']);
+        $this->assertSame(1, $payload['last_page']);
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame(10, $payload['per_page']);
+        $this->assertSame([
+            'imageIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f448f101',
+            'url' => 'http://127.0.0.1:8080/storage/images/talents/deletion-request.jpg',
+            'resourceType' => 'talent',
+            'translationSetIdentifier' => '01965bb2-bcc9-7c6f-8b90-89f7f448f901',
+            'displayOrder' => 3,
+            'sourceUrl' => 'https://example.com/source-image',
+            'sourceName' => 'Source Name',
+            'altText' => 'Deletion request target',
+            'isHidden' => false,
+            'uploadedAt' => '2026-05-01T00:00:00+00:00',
+            'name' => 'Request User',
+            'email' => 'request-user@example.com',
+            'reason' => '肖像権の懸念があるため',
+        ], $payload['images'][0]);
+    }
+
+    #[Group('useDb')]
+    public function testProcessExcludesReviewedDeletionRequests(): void
+    {
+        $principalIdentifier = $this->bindPrincipalRepository();
+        $this->setPolicyEvaluatorResult(true);
+
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f448f201', [
+            'uploaded_at' => '2026-05-01 00:00:00',
+        ]);
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f448f202', [
+            'uploaded_at' => '2026-05-02 00:00:00',
+        ]);
+        CreateImageDeletionRequest::create('01965bb2-bcc9-7c6f-8b90-89f7f448d201', [
+            'image_id' => '01965bb2-bcc9-7c6f-8b90-89f7f448f201',
+            'reviewed_at' => null,
+        ]);
+        CreateImageDeletionRequest::create('01965bb2-bcc9-7c6f-8b90-89f7f448d202', [
+            'image_id' => '01965bb2-bcc9-7c6f-8b90-89f7f448f202',
+            'reviewer_id' => StrTestHelper::generateUuid(),
+            'reviewed_at' => '2026-05-03 00:00:00',
+            'reviewer_comment' => '対応済み',
+        ]);
+
+        $payload = $this->process(new ListImageDeletionRequestsInput($principalIdentifier))->toArray();
+
+        $this->assertSame(1, $payload['total']);
+        $this->assertSame(['01965bb2-bcc9-7c6f-8b90-89f7f448f201'], array_column($payload['images'], 'imageIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessAppliesPagination(): void
+    {
+        $principalIdentifier = $this->bindPrincipalRepository();
+        $this->setPolicyEvaluatorResult(true);
+
+        foreach ([1, 2, 3] as $index) {
+            $imageId = sprintf('01965bb2-bcc9-7c6f-8b90-89f7f448f30%d', $index);
+            CreateImage::create($imageId, [
+                'uploaded_at' => sprintf('2026-05-0%d 00:00:00', $index),
+            ]);
+            CreateImageDeletionRequest::create(sprintf('01965bb2-bcc9-7c6f-8b90-89f7f448d30%d', $index), [
+                'image_id' => $imageId,
+                'requested_at' => sprintf('2026-05-0%d 00:00:00', $index),
+            ]);
+        }
+
+        $payload = $this->process(new ListImageDeletionRequestsInput($principalIdentifier, 2))->toArray();
+
+        $this->assertCount(2, $payload['images']);
+        $this->assertSame(2, $payload['per_page']);
+        $this->assertSame(2, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+        $this->assertSame([
+            '01965bb2-bcc9-7c6f-8b90-89f7f448f303',
+            '01965bb2-bcc9-7c6f-8b90-89f7f448f302',
+        ], array_column($payload['images'], 'imageIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessDisallowedWhenPrincipalCannotApproveOrReject(): void
+    {
+        $principalIdentifier = $this->bindPrincipalRepository();
+        $this->setPolicyEvaluatorResult(false);
+
+        CreateImage::create('01965bb2-bcc9-7c6f-8b90-89f7f448f401');
+        CreateImageDeletionRequest::create('01965bb2-bcc9-7c6f-8b90-89f7f448d401', [
+            'image_id' => '01965bb2-bcc9-7c6f-8b90-89f7f448f401',
+        ]);
+
+        $this->expectException(DisallowedException::class);
+        $this->process(new ListImageDeletionRequestsInput($principalIdentifier));
+    }
+
+    private function listImageDeletionRequests(): ListImageDeletionRequestsInterface
+    {
+        return $this->app->make(ListImageDeletionRequestsInterface::class);
+    }
+
+    private function process(ListImageDeletionRequestsInput $input): ListImageDeletionRequestsOutput
+    {
+        $output = new ListImageDeletionRequestsOutput();
+        $this->listImageDeletionRequests()->process($input, $output);
+
+        return $output;
+    }
+
+    private function bindPrincipalRepository(): PrincipalIdentifier
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findById')
+            ->with($principalIdentifier)
+            ->andReturn($principal);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+
+        return $principalIdentifier;
+    }
+}

--- a/typespec/services/wiki-private-api/image.tsp
+++ b/typespec/services/wiki-private-api/image.tsp
@@ -67,6 +67,36 @@ model UploadedImageListItem {
   uploadedAt: string | null;
 }
 
+@doc("Uploaded image item with pending image deletion request details.")
+model ImageDeletionRequestListItem {
+  @doc("Image identifier.")
+  imageIdentifier: Uuid;
+  @doc("Absolute image URL.")
+  url: string;
+  @doc("Resource type that the image belongs to.")
+  resourceType: string;
+  @doc("Translation set identifier that the image belongs to.")
+  translationSetIdentifier: Uuid;
+  @doc("Display order of the image.")
+  displayOrder: int32;
+  @doc("Original source URL of the image.")
+  sourceUrl: string;
+  @doc("Original source name of the image.")
+  sourceName: string;
+  @doc("Alternative text for the image.")
+  altText: string;
+  @doc("Whether the image is hidden.")
+  isHidden: boolean;
+  @doc("Timestamp when the image was uploaded.")
+  uploadedAt: string | null;
+  @doc("Name of the image deletion requester.")
+  name: string;
+  @doc("Email address of the image deletion requester.")
+  email: string;
+  @doc("Reason for the image deletion request.")
+  reason: string;
+}
+
 @doc("Approval status assigned to a draft image.")
 union DraftImageStatus {
   "approved",
@@ -125,6 +155,20 @@ model ListUploadedImagesResponseBody {
   per_page: int32;
 }
 
+@doc("Response body for the pending image deletion request list endpoint.")
+model ListImageDeletionRequestsResponseBody {
+  @doc("Uploaded images that have pending image deletion requests for the requested page.")
+  images: ImageDeletionRequestListItem[];
+  @doc("Current page number.")
+  current_page: int32;
+  @doc("Last page number.")
+  last_page: int32;
+  @doc("Total number of pending image deletion requests.")
+  total: int32;
+  @doc("Number of images per page.")
+  per_page: int32;
+}
+
 @doc("Response body for the draft image list endpoint.")
 model ListDraftImagesResponseBody {
   @doc("Draft images for the requested page.")
@@ -143,6 +187,12 @@ model ListDraftImagesResponseBody {
 model ListUploadedImagesResponse {
   @statusCode statusCode: 200;
   @body body: ListUploadedImagesResponseBody;
+}
+
+@doc("Response returned when pending image deletion request list retrieval succeeds.")
+model ListImageDeletionRequestsResponse {
+  @statusCode statusCode: 200;
+  @body body: ListImageDeletionRequestsResponseBody;
 }
 
 @doc("Response returned when draft image list retrieval succeeds.")
@@ -256,4 +306,12 @@ interface DraftImageListOperations {
     @query status: DraftImageStatus,
     @query perPage?: int32,
   ): ListDraftImagesResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+}
+@route("/image-deletion-requests")
+interface ImageDeletionRequestListOperations {
+  @get
+  @doc("List uploaded images with pending image deletion requests.")
+  listImageDeletionRequests(
+    @query perPage?: int32 | null,
+  ): ListImageDeletionRequestsResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- `GET /api/wiki/image-deletion-requests` を追加し、削除申請中（`image_deletion_requests.reviewed_at is null`）のアップロード済み画像一覧を取得できるようにしました。
- 削除申請一覧専用の `ImageDeletionRequestListItemReadModel` / `ListImageDeletionRequests` Query UseCase / HTTP Action・Request を追加しました。
- 削除申請者情報（`name`, `email`, `reason`）は専用 ReadModel にのみ持たせ、既存の公開画像一覧 `UploadedImageReadModel` には混入しない構成にしています。
- `auth.api`, `resolve.actor`, `resolve.wiki` 配下の route とし、対象画像に対して approve または reject 権限がない場合は `403` を返すようにしました。
- TypeSpec と生成済み OpenAPI を新規 API 契約に合わせて更新しました。
- pending / reviewed 除外 / requester 情報 / ページネーション / 権限なし 403 / route 認証・context middleware のテストを追加しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

画像削除申請をレビューする利用者が、現在対応待ちの申請画像を一覧で確認できる API が必要なためです。
申請者情報は個人情報に近いため、公開済み画像一覧の ReadModel とは分離し、削除申請レビュー用途の専用レスポンスに限定しています。

## 🧪 テスト

### テストの実行確認

- [x] `task cs-fix` を実行し、CS Fixer がパスすることを確認
- [x] `task phpstan` を実行し、PHPStan がパスすることを確認
- [x] `task test` を実行し、全 PHPUnit テストがパスすることを確認（2832 tests, 9002 assertions）
- [x] `task openapi-generate` を実行し、TypeSpec から OpenAPI を生成できることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- Query テストで pending の削除申請のみが返ること、reviewed 済みの申請が除外されることを確認しました。
- Query テストで画像情報と `name`, `email`, `reason` が返ること、およびページネーションを確認しました。
- HTTP Action テストで権限がない場合に `403` になることを確認しました。
- route protection テストで新規 API が `auth.api`, `resolve.actor`, `resolve.wiki` を通ることを確認しました。

## 🔍 レビューのポイント

- `UploadedImageReadModel` に申請者情報を追加せず、削除申請一覧専用 ReadModel に分離できているか
- pending 判定が `reviewed_at is null` のみに限定されているか
- approve / reject 権限のない利用者に申請者情報が返らない認可になっているか
- TypeSpec / OpenAPI のレスポンスモデルと実装レスポンスが一致しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #448

## ⚠️ 注意事項

- DB マイグレーションはありません。
- 既存 `GET /api/wiki/images` のレスポンス構造は変更していません。
- プロジェクト指定の `qa-review`, `test-review`, `security-review`, `architecture-review` スキルは Hermes / project-local skill として見つからなかったため、代替として実装差分の手動レビューと上記チェックを実施しました。未対応のレビュー指摘はありません。

## 📸 スクリーンショット・デモ

API 追加のみのため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した