### PR TITLE
画像削除拒否理由をrejectReasonに変更

### DIFF
--- a/application/Http/Action/Wiki/Image/Command/ApproveImageDeletion/ApproveImageDeletionAction.php
+++ b/application/Http/Action/Wiki/Image/Command/ApproveImageDeletion/ApproveImageDeletionAction.php
@@ -46,7 +46,6 @@ readonly class ApproveImageDeletionAction
                 $input = new ApproveImageDeletionInput(
                     new ImageIdentifier($request->imageId()),
                     $this->wikiContext->principalIdentifier,
-                    $request->reviewerComment(),
                 );
                 $output = new ApproveImageDeletionOutput();
             } catch (InvalidArgumentException $e) {

--- a/application/Http/Action/Wiki/Image/Command/ApproveImageDeletion/ApproveImageDeletionRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/ApproveImageDeletion/ApproveImageDeletionRequest.php
@@ -23,5 +23,4 @@ class ApproveImageDeletionRequest extends FormRequest
     {
         return (string) $this->route('imageId');
     }
-
 }

--- a/application/Http/Action/Wiki/Image/Command/ApproveImageDeletion/ApproveImageDeletionRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/ApproveImageDeletion/ApproveImageDeletionRequest.php
@@ -16,9 +16,7 @@ class ApproveImageDeletionRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'reviewerComment' => ['required', 'string'],
-        ];
+        return [];
     }
 
     public function imageId(): string
@@ -26,8 +24,4 @@ class ApproveImageDeletionRequest extends FormRequest
         return (string) $this->route('imageId');
     }
 
-    public function reviewerComment(): string
-    {
-        return (string) $this->input('reviewerComment');
-    }
 }

--- a/application/Http/Action/Wiki/Image/Command/RejectImageDeletion/RejectImageDeletionAction.php
+++ b/application/Http/Action/Wiki/Image/Command/RejectImageDeletion/RejectImageDeletionAction.php
@@ -46,7 +46,7 @@ readonly class RejectImageDeletionAction
                 $input = new RejectImageDeletionInput(
                     new ImageIdentifier($request->imageId()),
                     $this->wikiContext->principalIdentifier,
-                    $request->reviewerComment(),
+                    $request->rejectReason(),
                 );
                 $output = new RejectImageDeletionOutput();
             } catch (InvalidArgumentException $e) {

--- a/application/Http/Action/Wiki/Image/Command/RejectImageDeletion/RejectImageDeletionRequest.php
+++ b/application/Http/Action/Wiki/Image/Command/RejectImageDeletion/RejectImageDeletionRequest.php
@@ -17,7 +17,7 @@ class RejectImageDeletionRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'reviewerComment' => ['required', 'string'],
+            'rejectReason' => ['required', 'string'],
         ];
     }
 
@@ -26,8 +26,8 @@ class RejectImageDeletionRequest extends FormRequest
         return (string) $this->route('imageId');
     }
 
-    public function reviewerComment(): string
+    public function rejectReason(): string
     {
-        return (string) $this->input('reviewerComment');
+        return (string) $this->input('rejectReason');
     }
 }

--- a/application/Models/Wiki/ImageDeletionRequest.php
+++ b/application/Models/Wiki/ImageDeletionRequest.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon $requested_at
  * @property ?string $reviewer_id
  * @property ?Carbon $reviewed_at
- * @property ?string $reviewer_comment
+ * @property ?string $reject_reason
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
  * @property-read ?WikiImage $image
@@ -31,7 +31,7 @@ use Illuminate\Support\Carbon;
     'requested_at',
     'reviewer_id',
     'reviewed_at',
-    'reviewer_comment',
+    'reject_reason',
 ])]
 #[\Illuminate\Database\Eloquent\Attributes\Table(name: 'image_deletion_requests', keyType: 'string')]
 class ImageDeletionRequest extends Model

--- a/database/migrations/2024_01_01_000045_create_image_hide_requests_table.php
+++ b/database/migrations/2024_01_01_000045_create_image_hide_requests_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->timestamp('requested_at')->comment('申請日時');
             $table->uuid('reviewer_id')->nullable()->comment('審査者ID');
             $table->timestamp('reviewed_at')->nullable()->comment('審査日時');
-            $table->text('reviewer_comment')->nullable()->comment('審査コメント');
+            $table->text('reject_reason')->nullable()->comment('拒否理由');
             $table->timestamps();
 
             $table->index('image_id', 'idx_image_id');

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -301,11 +301,11 @@ paths:
             $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
-          description: Response returned when an image deletion request is reviewed.
+          description: Response returned when an image deletion request is approved.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ImageDeletionReviewSummary'
+                $ref: '#/components/schemas/ImageDeletionApprovalSummary'
         '403':
           description: Access is forbidden.
           content:
@@ -336,12 +336,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ReviewImageDeletionRequestBody'
   /image/{imageId}/reject:
     post:
       operationId: ImageOperations_rejectImage
@@ -401,11 +395,11 @@ paths:
             $ref: '#/components/schemas/KPool.Common.Uuid'
       responses:
         '200':
-          description: Response returned when an image deletion request is reviewed.
+          description: Response returned when an image deletion request is rejected.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ImageDeletionReviewSummary'
+                $ref: '#/components/schemas/ImageDeletionRejectionSummary'
         '403':
           description: Access is forbidden.
           content:
@@ -441,7 +435,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ReviewImageDeletionRequestBody'
+              $ref: '#/components/schemas/RejectImageDeletionRequestBody'
   /image/{imageId}/request-deletion:
     post:
       operationId: ImageOperations_requestImageDeletion
@@ -3463,6 +3457,38 @@ components:
           type: string
           description: Representative symbol of the group.
       description: Basic payload for a group draft wiki.
+    ImageDeletionApprovalSummary:
+      type: object
+      required:
+        - imageIdentifier
+        - isHidden
+      properties:
+        imageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Image identifier.
+        isHidden:
+          type: boolean
+          description: Whether the image is hidden after the approval.
+      description: Summary of an image deletion request approval result.
+    ImageDeletionRejectionSummary:
+      type: object
+      required:
+        - imageIdentifier
+        - rejectReason
+        - isHidden
+      properties:
+        imageIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Image identifier.
+        rejectReason:
+          type: string
+          description: Reason for rejecting the image deletion request.
+        isHidden:
+          type: boolean
+          description: Whether the image is hidden after the rejection.
+      description: Summary of an image deletion request rejection result.
     ImageDeletionRequestListItem:
       type: object
       required:
@@ -3550,24 +3576,6 @@ components:
           type: boolean
           description: Whether the image is hidden while the deletion request is pending.
       description: Summary of an image deletion request.
-    ImageDeletionReviewSummary:
-      type: object
-      required:
-        - imageIdentifier
-        - reviewerComment
-        - isHidden
-      properties:
-        imageIdentifier:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Image identifier.
-        reviewerComment:
-          type: string
-          description: Comment left by the reviewer.
-        isHidden:
-          type: boolean
-          description: Whether the image is hidden after the review.
-      description: Summary of an image deletion request review result.
     ImageDraftSummary:
       type: object
       required:
@@ -4010,6 +4018,15 @@ components:
           format: int32
           description: Published version number.
       description: Summary of a published wiki.
+    RejectImageDeletionRequestBody:
+      type: object
+      required:
+        - rejectReason
+      properties:
+        rejectReason:
+          type: string
+          description: Reason for rejecting the image deletion request.
+      description: Request body for rejecting an image deletion request.
     RejectWikiRequestBody:
       type: object
       required:
@@ -4109,15 +4126,6 @@ components:
           type: string
           description: Reason for requesting the image to be hidden.
       description: Request body for creating an image deletion request.
-    ReviewImageDeletionRequestBody:
-      type: object
-      required:
-        - reviewerComment
-      properties:
-        reviewerComment:
-          type: string
-          description: Comment from the reviewer.
-      description: Request body for reviewing an image deletion request.
     RoleSummary:
       type: object
       required:

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletion.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletion.php
@@ -56,7 +56,7 @@ readonly class ApproveImageDeletion implements ApproveImageDeletionInterface
             throw new DisallowedException();
         }
 
-        $image->approveDeletionRequest($input->principalIdentifier(), $input->reviewerComment());
+        $image->approveDeletionRequest($input->principalIdentifier());
         $this->imageRepository->save($image);
         foreach ($this->wikiRepository->findByImageIdentifier($input->imageIdentifier()) as $wiki) {
             $wiki->setImageIdentifier(null);

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInput.php
@@ -12,7 +12,6 @@ readonly class ApproveImageDeletionInput implements ApproveImageDeletionInputPor
     public function __construct(
         private ImageIdentifier $imageIdentifier,
         private PrincipalIdentifier $principalIdentifier,
-        private string $reviewerComment,
     ) {
     }
 
@@ -26,8 +25,4 @@ readonly class ApproveImageDeletionInput implements ApproveImageDeletionInputPor
         return $this->principalIdentifier;
     }
 
-    public function reviewerComment(): string
-    {
-        return $this->reviewerComment;
-    }
 }

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInput.php
@@ -24,5 +24,4 @@ readonly class ApproveImageDeletionInput implements ApproveImageDeletionInputPor
     {
         return $this->principalIdentifier;
     }
-
 }

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInputPort.php
@@ -12,6 +12,4 @@ interface ApproveImageDeletionInputPort
     public function imageIdentifier(): ImageIdentifier;
 
     public function principalIdentifier(): PrincipalIdentifier;
-
-    public function reviewerComment(): string;
 }

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionOutput.php
@@ -16,7 +16,7 @@ class ApproveImageDeletionOutput implements ApproveImageDeletionOutputPort
     }
 
     /**
-     * @return array{imageIdentifier: ?string, reviewerComment: ?string, isHidden: ?bool}
+     * @return array{imageIdentifier: ?string, isHidden: ?bool}
      */
     public function toArray(): array
     {
@@ -24,14 +24,12 @@ class ApproveImageDeletionOutput implements ApproveImageDeletionOutputPort
         if ($this->image === null || $deletionRequest === null) {
             return [
                 'imageIdentifier' => null,
-                'reviewerComment' => null,
                 'isHidden' => null,
             ];
         }
 
         return [
             'imageIdentifier' => (string) $this->image->imageIdentifier(),
-            'reviewerComment' => $deletionRequest->reviewerComment(),
             'isHidden' => $this->image->isHidden(),
         ];
     }

--- a/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionOutputPort.php
@@ -11,7 +11,7 @@ interface ApproveImageDeletionOutputPort
     public function setImage(Image $image): void;
 
     /**
-     * @return array{imageIdentifier: ?string, reviewerComment: ?string, isHidden: ?bool}
+     * @return array{imageIdentifier: ?string, isHidden: ?bool}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletion.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletion.php
@@ -48,7 +48,7 @@ readonly class RejectImageDeletion implements RejectImageDeletionInterface
             throw new DisallowedException();
         }
 
-        $image->rejectDeletionRequest($input->principalIdentifier(), $input->reviewerComment());
+        $image->rejectDeletionRequest($input->principalIdentifier(), $input->rejectReason());
         $this->imageRepository->save($image);
 
         $output->setImage($image);

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionInput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionInput.php
@@ -12,7 +12,7 @@ readonly class RejectImageDeletionInput implements RejectImageDeletionInputPort
     public function __construct(
         private ImageIdentifier $imageIdentifier,
         private PrincipalIdentifier $principalIdentifier,
-        private string $reviewerComment,
+        private string $rejectReason,
     ) {
     }
 
@@ -26,8 +26,8 @@ readonly class RejectImageDeletionInput implements RejectImageDeletionInputPort
         return $this->principalIdentifier;
     }
 
-    public function reviewerComment(): string
+    public function rejectReason(): string
     {
-        return $this->reviewerComment;
+        return $this->rejectReason;
     }
 }

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionInputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionInputPort.php
@@ -13,5 +13,5 @@ interface RejectImageDeletionInputPort
 
     public function principalIdentifier(): PrincipalIdentifier;
 
-    public function reviewerComment(): string;
+    public function rejectReason(): string;
 }

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionOutput.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionOutput.php
@@ -16,7 +16,7 @@ class RejectImageDeletionOutput implements RejectImageDeletionOutputPort
     }
 
     /**
-     * @return array{imageIdentifier: ?string, reviewerComment: ?string, isHidden: ?bool}
+     * @return array{imageIdentifier: ?string, rejectReason: ?string, isHidden: ?bool}
      */
     public function toArray(): array
     {
@@ -24,14 +24,14 @@ class RejectImageDeletionOutput implements RejectImageDeletionOutputPort
         if ($this->image === null || $deletionRequest === null) {
             return [
                 'imageIdentifier' => null,
-                'reviewerComment' => null,
+                'rejectReason' => null,
                 'isHidden' => null,
             ];
         }
 
         return [
             'imageIdentifier' => (string) $this->image->imageIdentifier(),
-            'reviewerComment' => $deletionRequest->reviewerComment(),
+            'rejectReason' => $deletionRequest->rejectReason(),
             'isHidden' => $this->image->isHidden(),
         ];
     }

--- a/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionOutputPort.php
+++ b/src/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionOutputPort.php
@@ -11,7 +11,7 @@ interface RejectImageDeletionOutputPort
     public function setImage(Image $image): void;
 
     /**
-     * @return array{imageIdentifier: ?string, reviewerComment: ?string, isHidden: ?bool}
+     * @return array{imageIdentifier: ?string, rejectReason: ?string, isHidden: ?bool}
      */
     public function toArray(): array;
 }

--- a/src/Wiki/Image/Domain/Entity/Image.php
+++ b/src/Wiki/Image/Domain/Entity/Image.php
@@ -237,7 +237,7 @@ class Image
         $this->hiddenAt = new DateTimeImmutable();
     }
 
-    public function approveDeletionRequest(PrincipalIdentifier $reviewerIdentifier, string $reviewerComment): void
+    public function approveDeletionRequest(PrincipalIdentifier $reviewerIdentifier): void
     {
         $pendingDeletionRequest = $this->pendingDeletionRequest();
         if ($pendingDeletionRequest === null) {
@@ -246,7 +246,7 @@ class Image
 
         foreach ($this->deletionRequests as $index => $deletionRequest) {
             if ($deletionRequest === $pendingDeletionRequest) {
-                $this->deletionRequests[$index] = $deletionRequest->approve($reviewerIdentifier, $reviewerComment);
+                $this->deletionRequests[$index] = $deletionRequest->approve($reviewerIdentifier);
 
                 break;
             }
@@ -254,7 +254,7 @@ class Image
 
     }
 
-    public function rejectDeletionRequest(PrincipalIdentifier $reviewerIdentifier, string $reviewerComment): void
+    public function rejectDeletionRequest(PrincipalIdentifier $reviewerIdentifier, string $rejectReason): void
     {
         $pendingDeletionRequest = $this->pendingDeletionRequest();
         if ($pendingDeletionRequest === null) {
@@ -263,7 +263,7 @@ class Image
 
         foreach ($this->deletionRequests as $index => $deletionRequest) {
             if ($deletionRequest === $pendingDeletionRequest) {
-                $this->deletionRequests[$index] = $deletionRequest->reject($reviewerIdentifier, $reviewerComment);
+                $this->deletionRequests[$index] = $deletionRequest->reject($reviewerIdentifier, $rejectReason);
 
                 break;
             }

--- a/src/Wiki/Image/Domain/ValueObject/DeletionRequest.php
+++ b/src/Wiki/Image/Domain/ValueObject/DeletionRequest.php
@@ -17,7 +17,7 @@ readonly class DeletionRequest
         private DateTimeImmutable $requestedAt,
         private ?PrincipalIdentifier $reviewerIdentifier,
         private ?DateTimeImmutable $reviewedAt,
-        private ?string $reviewerComment,
+        private ?string $rejectReason,
     ) {
     }
 
@@ -51,12 +51,12 @@ readonly class DeletionRequest
         return $this->reviewedAt;
     }
 
-    public function reviewerComment(): ?string
+    public function rejectReason(): ?string
     {
-        return $this->reviewerComment;
+        return $this->rejectReason;
     }
 
-    public function approve(PrincipalIdentifier $reviewerIdentifier, string $reviewerComment): self
+    public function approve(PrincipalIdentifier $reviewerIdentifier): self
     {
         if ($this->reviewedAt !== null) {
             throw new ImageDeletionRequestNotPendingException();
@@ -69,11 +69,11 @@ readonly class DeletionRequest
             $this->requestedAt,
             $reviewerIdentifier,
             new DateTimeImmutable(),
-            $reviewerComment,
+            null,
         );
     }
 
-    public function reject(PrincipalIdentifier $reviewerIdentifier, string $reviewerComment): self
+    public function reject(PrincipalIdentifier $reviewerIdentifier, string $rejectReason): self
     {
         if ($this->reviewedAt !== null) {
             throw new ImageDeletionRequestNotPendingException();
@@ -86,7 +86,7 @@ readonly class DeletionRequest
             $this->requestedAt,
             $reviewerIdentifier,
             new DateTimeImmutable(),
-            $reviewerComment,
+            $rejectReason,
         );
     }
 }

--- a/src/Wiki/Image/Infrastructure/Repository/ImageRepository.php
+++ b/src/Wiki/Image/Infrastructure/Repository/ImageRepository.php
@@ -86,7 +86,7 @@ final class ImageRepository implements ImageRepositoryInterface
                 'requested_at' => $deletionRequest->requestedAt(),
                 'reviewer_id' => $deletionRequest->reviewerIdentifier() ? (string) $deletionRequest->reviewerIdentifier() : null,
                 'reviewed_at' => $deletionRequest->reviewedAt(),
-                'reviewer_comment' => $deletionRequest->reviewerComment(),
+                'reject_reason' => $deletionRequest->rejectReason(),
             ];
 
             if ($existingModel !== null) {
@@ -148,7 +148,7 @@ final class ImageRepository implements ImageRepositoryInterface
             $model->requested_at->toDateTimeImmutable(),
             $model->reviewer_id ? new PrincipalIdentifier($model->reviewer_id) : null,
             $model->reviewed_at?->toDateTimeImmutable(),
-            $model->reviewer_comment,
+            $model->reject_reason,
         );
     }
 }

--- a/tests/Application/Http/Action/Wiki/Image/Command/RejectImageDeletion/RejectImageDeletionRequestTest.php
+++ b/tests/Application/Http/Action/Wiki/Image/Command/RejectImageDeletion/RejectImageDeletionRequestTest.php
@@ -10,12 +10,12 @@ use PHPUnit\Framework\TestCase;
 class RejectImageDeletionRequestTest extends TestCase
 {
     /**
-     * 正常系: reviewerComment が必須であること.
+     * 正常系: rejectReason が必須であること.
      */
-    public function testReviewerCommentIsRequired(): void
+    public function testRejectReasonIsRequired(): void
     {
         $request = new RejectImageDeletionRequest();
 
-        $this->assertSame(['required', 'string'], $request->rules()['reviewerComment']);
+        $this->assertSame(['required', 'string'], $request->rules()['rejectReason']);
     }
 }

--- a/tests/Helper/CreateImageDeletionRequest.php
+++ b/tests/Helper/CreateImageDeletionRequest.php
@@ -17,7 +17,7 @@ class CreateImageDeletionRequest
      *     requested_at?: mixed,
      *     reviewer_id?: string|null,
      *     reviewed_at?: mixed,
-     *     reviewer_comment?: string|null,
+     *     reject_reason?: string|null,
      * } $overrides
      */
     public static function create(string $requestId, array $overrides = []): void
@@ -31,7 +31,7 @@ class CreateImageDeletionRequest
             'requested_at' => $overrides['requested_at'] ?? now(),
             'reviewer_id' => $overrides['reviewer_id'] ?? null,
             'reviewed_at' => $overrides['reviewed_at'] ?? null,
-            'reviewer_comment' => $overrides['reviewer_comment'] ?? null,
+            'reject_reason' => $overrides['reject_reason'] ?? null,
         ]);
     }
 }

--- a/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionInputTest.php
@@ -25,11 +25,9 @@ class ApproveImageDeletionInputTest extends TestCase
         $input = new ApproveImageDeletionInput(
             $imageIdentifier,
             $principalIdentifier,
-            'Approved for privacy',
         );
 
         $this->assertSame((string) $imageIdentifier, (string) $input->imageIdentifier());
         $this->assertSame((string) $principalIdentifier, (string) $input->principalIdentifier());
-        $this->assertSame('Approved for privacy', $input->reviewerComment());
     }
 }

--- a/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionOutputTest.php
@@ -36,7 +36,7 @@ class ApproveImageDeletionOutputTest extends TestCase
             new DateTimeImmutable(),
             $reviewerIdentifier,
             new DateTimeImmutable(),
-            'Approved for privacy',
+            null,
         );
 
         $image = new Image(
@@ -66,7 +66,6 @@ class ApproveImageDeletionOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
-        $this->assertSame('Approved for privacy', $result['reviewerComment']);
         $this->assertTrue($result['isHidden']);
     }
 
@@ -83,7 +82,6 @@ class ApproveImageDeletionOutputTest extends TestCase
 
         $this->assertSame([
             'imageIdentifier' => null,
-            'reviewerComment' => null,
             'isHidden' => null,
         ], $result);
     }

--- a/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionTest.php
@@ -120,7 +120,7 @@ class ApproveImageDeletionTest extends TestCase
         $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
         $resource = new Resource(type: ResourceType::IMAGE);
 
-        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier, 'Approved for privacy');
+        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);
 
         $imageRepository = Mockery::mock(ImageRepositoryInterface::class);
         $imageRepository->shouldReceive('findById')
@@ -175,7 +175,7 @@ class ApproveImageDeletionTest extends TestCase
     {
         $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier, 'comment');
+        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);
 
         $imageRepository = Mockery::mock(ImageRepositoryInterface::class);
         $imageRepository->shouldReceive('findById')
@@ -212,7 +212,7 @@ class ApproveImageDeletionTest extends TestCase
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
         $resource = new Resource(type: ResourceType::IMAGE);
-        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier, 'comment');
+        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);
 
         $imageRepository = Mockery::mock(ImageRepositoryInterface::class);
         $imageRepository->shouldReceive('findById')
@@ -260,7 +260,7 @@ class ApproveImageDeletionTest extends TestCase
         $image = $this->createTestImageWithPendingDeletionRequest();
         $imageIdentifier = $image->imageIdentifier();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier, 'comment');
+        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);
 
         $imageRepository = Mockery::mock(ImageRepositoryInterface::class);
         $imageRepository->shouldReceive('findById')
@@ -303,7 +303,7 @@ class ApproveImageDeletionTest extends TestCase
         $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
         $resource = new Resource(type: ResourceType::IMAGE);
 
-        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier, 'comment');
+        $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);
 
         $imageRepository = Mockery::mock(ImageRepositoryInterface::class);
         $imageRepository->shouldReceive('findById')

--- a/tests/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionInputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionInputTest.php
@@ -30,6 +30,6 @@ class RejectImageDeletionInputTest extends TestCase
 
         $this->assertSame((string) $imageIdentifier, (string) $input->imageIdentifier());
         $this->assertSame((string) $principalIdentifier, (string) $input->principalIdentifier());
-        $this->assertSame('Not applicable', $input->reviewerComment());
+        $this->assertSame('Not applicable', $input->rejectReason());
     }
 }

--- a/tests/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionOutputTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionOutputTest.php
@@ -66,7 +66,7 @@ class RejectImageDeletionOutputTest extends TestCase
         $result = $output->toArray();
 
         $this->assertSame((string) $imageIdentifier, $result['imageIdentifier']);
-        $this->assertSame('Not applicable', $result['reviewerComment']);
+        $this->assertSame('Not applicable', $result['rejectReason']);
         $this->assertFalse($result['isHidden']);
     }
 
@@ -83,7 +83,7 @@ class RejectImageDeletionOutputTest extends TestCase
 
         $this->assertSame([
             'imageIdentifier' => null,
-            'reviewerComment' => null,
+            'rejectReason' => null,
             'isHidden' => null,
         ], $result);
     }

--- a/tests/Wiki/Image/Domain/Entity/ImageTest.php
+++ b/tests/Wiki/Image/Domain/Entity/ImageTest.php
@@ -205,12 +205,12 @@ class ImageTest extends TestCase
         $image->requestDeletion('Test Requester', 'requester@example.com', 'Privacy concern');
 
         $reviewerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $image->approveDeletionRequest($reviewerIdentifier, 'Approved for privacy');
+        $image->approveDeletionRequest($reviewerIdentifier);
 
         $this->assertNull($image->pendingDeletionRequest());
         $this->assertSame((string) $reviewerIdentifier, (string) $image->latestDeletionRequest()->reviewerIdentifier());
         $this->assertInstanceOf(DateTimeImmutable::class, $image->latestDeletionRequest()->reviewedAt());
-        $this->assertSame('Approved for privacy', $image->latestDeletionRequest()->reviewerComment());
+        $this->assertNull($image->latestDeletionRequest()->rejectReason());
         $this->assertTrue($image->isHidden());
     }
 
@@ -228,7 +228,7 @@ class ImageTest extends TestCase
         $this->assertNull($image->pendingDeletionRequest());
         $this->assertSame((string) $reviewerIdentifier, (string) $image->latestDeletionRequest()->reviewerIdentifier());
         $this->assertInstanceOf(DateTimeImmutable::class, $image->latestDeletionRequest()->reviewedAt());
-        $this->assertSame('Not applicable', $image->latestDeletionRequest()->reviewerComment());
+        $this->assertSame('Not applicable', $image->latestDeletionRequest()->rejectReason());
         $this->assertFalse($image->isHidden());
     }
 
@@ -272,7 +272,7 @@ class ImageTest extends TestCase
         $reviewerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $this->expectException(ImageDeletionRequestNotPendingException::class);
-        $image->approveDeletionRequest($reviewerIdentifier, 'comment');
+        $image->approveDeletionRequest($reviewerIdentifier);
     }
 
     /**

--- a/tests/Wiki/Image/Domain/ValueObject/DeletionRequestTest.php
+++ b/tests/Wiki/Image/Domain/ValueObject/DeletionRequestTest.php
@@ -26,7 +26,7 @@ class DeletionRequestTest extends TestCase
         $this->assertInstanceOf(DateTimeImmutable::class, $deletionRequest->requestedAt());
         $this->assertNull($deletionRequest->reviewerIdentifier());
         $this->assertNull($deletionRequest->reviewedAt());
-        $this->assertNull($deletionRequest->reviewerComment());
+        $this->assertNull($deletionRequest->rejectReason());
     }
 
     /**
@@ -37,11 +37,11 @@ class DeletionRequestTest extends TestCase
         $deletionRequest = $this->createPendingDeletionRequest();
         $reviewerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
-        $approved = $deletionRequest->approve($reviewerIdentifier, 'Approved for privacy');
+        $approved = $deletionRequest->approve($reviewerIdentifier);
 
         $this->assertSame((string) $reviewerIdentifier, (string) $approved->reviewerIdentifier());
         $this->assertInstanceOf(DateTimeImmutable::class, $approved->reviewedAt());
-        $this->assertSame('Approved for privacy', $approved->reviewerComment());
+        $this->assertNull($approved->rejectReason());
         // 元のインスタンスは変わらないこと
         $this->assertNull($deletionRequest->reviewedAt());
     }
@@ -58,7 +58,7 @@ class DeletionRequestTest extends TestCase
 
         $this->assertSame((string) $reviewerIdentifier, (string) $rejected->reviewerIdentifier());
         $this->assertInstanceOf(DateTimeImmutable::class, $rejected->reviewedAt());
-        $this->assertSame('Not applicable', $rejected->reviewerComment());
+        $this->assertSame('Not applicable', $rejected->rejectReason());
         // 元のインスタンスは変わらないこと
         $this->assertNull($deletionRequest->reviewedAt());
     }
@@ -72,7 +72,7 @@ class DeletionRequestTest extends TestCase
         $reviewerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $this->expectException(ImageDeletionRequestNotPendingException::class);
-        $deletionRequest->approve($reviewerIdentifier, 'comment');
+        $deletionRequest->approve($reviewerIdentifier);
     }
 
     /**
@@ -109,7 +109,7 @@ class DeletionRequestTest extends TestCase
             new DateTimeImmutable(),
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new DateTimeImmutable(),
-            'Approved',
+            null,
         );
     }
 }

--- a/tests/Wiki/Image/Infrastructure/Query/ListImageDeletionRequestsTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListImageDeletionRequestsTest.php
@@ -88,7 +88,7 @@ class ListImageDeletionRequestsTest extends TestCase
             'image_id' => '01965bb2-bcc9-7c6f-8b90-89f7f448f202',
             'reviewer_id' => StrTestHelper::generateUuid(),
             'reviewed_at' => '2026-05-03 00:00:00',
-            'reviewer_comment' => '対応済み',
+            'reject_reason' => '対応済み',
         ]);
 
         $payload = $this->process(new ListImageDeletionRequestsInput($principalIdentifier))->toArray();

--- a/tests/Wiki/Image/Infrastructure/Repository/ImageRepositoryTest.php
+++ b/tests/Wiki/Image/Infrastructure/Repository/ImageRepositoryTest.php
@@ -292,7 +292,7 @@ class ImageRepositoryTest extends TestCase
             'image_id' => $imageId,
             'reviewer_id' => $reviewerId,
             'reviewed_at' => $reviewedAt,
-            'reviewer_comment' => 'Reviewed',
+            'reject_reason' => 'Reviewed',
         ]);
 
         $repository = $this->app->make(ImageRepositoryInterface::class);
@@ -302,7 +302,7 @@ class ImageRepositoryTest extends TestCase
         $this->assertCount(1, $image->deletionRequests());
         $this->assertNull($image->pendingDeletionRequest());
         $this->assertSame($reviewerId, (string) $image->latestDeletionRequest()->reviewerIdentifier());
-        $this->assertSame('Reviewed', $image->latestDeletionRequest()->reviewerComment());
+        $this->assertSame('Reviewed', $image->latestDeletionRequest()->rejectReason());
     }
 
     /**
@@ -356,13 +356,13 @@ class ImageRepositoryTest extends TestCase
         $image = $repository->findById(new ImageIdentifier($imageId));
 
         $reviewerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $image->approveDeletionRequest($reviewerIdentifier, 'Approved for privacy');
+        $image->approveDeletionRequest($reviewerIdentifier);
         $repository->save($image);
 
         $this->assertDatabaseHas('image_deletion_requests', [
             'image_id' => $imageId,
             'reviewer_id' => (string) $reviewerIdentifier,
-            'reviewer_comment' => 'Approved for privacy',
+            'reject_reason' => null,
         ]);
 
     }
@@ -396,7 +396,7 @@ class ImageRepositoryTest extends TestCase
         $this->assertDatabaseHas('image_deletion_requests', [
             'image_id' => $imageId,
             'reviewer_id' => (string) $reviewerIdentifier,
-            'reviewer_comment' => 'Not applicable',
+            'reject_reason' => 'Not applicable',
         ]);
 
         $this->assertDatabaseHas('wiki_images', [

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -666,13 +666,21 @@ model ImageDeletionRequestSummary {
   isHidden: boolean;
 }
 
-@doc("Summary of an image deletion request review result.")
-model ImageDeletionReviewSummary {
+@doc("Summary of an image deletion request approval result.")
+model ImageDeletionApprovalSummary {
   @doc("Image identifier.")
   imageIdentifier: Uuid;
-  @doc("Comment left by the reviewer.")
-  reviewerComment: string;
-  @doc("Whether the image is hidden after the review.")
+  @doc("Whether the image is hidden after the approval.")
+  isHidden: boolean;
+}
+
+@doc("Summary of an image deletion request rejection result.")
+model ImageDeletionRejectionSummary {
+  @doc("Image identifier.")
+  imageIdentifier: Uuid;
+  @doc("Reason for rejecting the image deletion request.")
+  rejectReason: string;
+  @doc("Whether the image is hidden after the rejection.")
   isHidden: boolean;
 }
 

--- a/typespec/services/wiki-private-api/image.tsp
+++ b/typespec/services/wiki-private-api/image.tsp
@@ -37,10 +37,10 @@ model RequestImageDeletionRequestBody {
   reason: string;
 }
 
-@doc("Request body for reviewing an image deletion request.")
-model ReviewImageDeletionRequestBody {
-  @doc("Comment from the reviewer.")
-  reviewerComment: string;
+@doc("Request body for rejecting an image deletion request.")
+model RejectImageDeletionRequestBody {
+  @doc("Reason for rejecting the image deletion request.")
+  rejectReason: string;
 }
 
 @doc("Uploaded image item returned by the uploaded image list endpoint.")
@@ -219,10 +219,16 @@ model CreateImageDeletionRequestResponse {
   @body body: ImageDeletionRequestSummary;
 }
 
-@doc("Response returned when an image deletion request is reviewed.")
-model ReviewImageDeletionRequestResponse {
+@doc("Response returned when an image deletion request is approved.")
+model ApproveImageDeletionRequestResponse {
   @statusCode statusCode: 200;
-  @body body: ImageDeletionReviewSummary;
+  @body body: ImageDeletionApprovalSummary;
+}
+
+@doc("Response returned when an image deletion request is rejected.")
+model RejectImageDeletionRequestResponse {
+  @statusCode statusCode: 200;
+  @body body: ImageDeletionRejectionSummary;
 }
 
 @route("/image")
@@ -275,16 +281,15 @@ interface ImageOperations {
   @doc("Approve an image deletion request.")
   approveImageDeletionRequest(
     @path imageId: Uuid,
-    @body body: ReviewImageDeletionRequestBody,
-  ): ReviewImageDeletionRequestResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+  ): ApproveImageDeletionRequestResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/{imageId}/reject-deletion")
   @doc("Reject an image deletion request.")
   rejectImageDeletionRequest(
     @path imageId: Uuid,
-    @body body: ReviewImageDeletionRequestBody,
-  ): ReviewImageDeletionRequestResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+    @body body: RejectImageDeletionRequestBody,
+  ): RejectImageDeletionRequestResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }
 
 @route("/images")


### PR DESCRIPTION
## 📝 変更内容

- 画像削除承認 API ではレビューコメントを受け取らないように変更
- 画像削除拒否 API では reviewerComment を廃止し、rejectReason を必須項目に変更
- image_deletion_requests の reviewer_comment カラムを reject_reason に変更
- Domain / UseCase / Repository / Model / TypeSpec / OpenAPI / テストを新しい拒否理由の語彙に追従

## 🏷️ 変更の種類

- [x] 🔧 リファクタリング (Refactoring)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

画像削除申請のレビュー時にコメントを共通必須にするのではなく、拒否時のみ拒否理由を扱う仕様に合わせるため。

## 🧪 テスト

### テストの実行確認

- [x] task openapi を実行し、OpenAPI が再生成されることを確認
- [x] task test -- ... を実行し、既存テストがパスすることを確認
- [x] task phpstan を実行し、静的解析がパスすることを確認
- [x] 変更した挙動に対するテストを更新

## 🔍 レビューのポイント

- ApproveImageDeletion からレビューコメント入力とレスポンス項目が外れていること
- RejectImageDeletion の request / response が rejectReason に統一されていること
- DB カラム、Repository、テストヘルパが reject_reason に追従していること
- TypeSpec と生成 OpenAPI の契約が実装と一致していること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

image_deletion_requests のカラム名を reviewer_comment から reject_reason に変更しています。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した