### PR TITLE
add: アカウント情報更新エンドポイントを追加

### DIFF
--- a/application/Http/Action/Account/Account/Command/UpdateAccount/UpdateAccountAction.php
+++ b/application/Http/Action/Account/Account/Command/UpdateAccount/UpdateAccountAction.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Account\Command\UpdateAccount;
+
+use Application\Http\Context\AccountContext;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInput;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInterface;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountOutput;
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class UpdateAccountAction
+{
+    public function __construct(
+        private UpdateAccountInterface $updateAccount,
+        private AccountContext $accountContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param UpdateAccountRequest $request
+     * @return JsonResponse
+     * @throws InternalServerErrorHttpException
+     */
+    public function __invoke(UpdateAccountRequest $request): JsonResponse
+    {
+        try {
+            $language = $request->language();
+
+            try {
+                $input = new UpdateAccountInput(
+                    accountIdentifier: new AccountIdentifier($request->accountId()),
+                    principal: $this->accountContext->principal(),
+                    accountName: new AccountName($request->accountName()),
+                );
+                $output = new UpdateAccountOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            try {
+                $this->updateAccount->process($input, $output);
+                DB::commit();
+            } catch (AccountNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message('account_not_found', $language), previous: $e);
+            } catch (AccountUpdateForbiddenException $e) {
+                DB::rollBack();
+
+                throw new ForbiddenHttpException(detail: error_message('account_update_forbidden', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/Account/Command/UpdateAccount/UpdateAccountRequest.php
+++ b/application/Http/Action/Account/Account/Command/UpdateAccount/UpdateAccountRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Account\Command\UpdateAccount;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateAccountRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'accountName' => ['required', 'string'],
+        ];
+    }
+
+    public function accountId(): string
+    {
+        return (string) $this->route('accountId');
+    }
+
+    public function accountName(): string
+    {
+        return (string) $this->input('accountName');
+    }
+}

--- a/application/Http/Action/Account/PrincipalGroup/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupAction.php
+++ b/application/Http/Action/Account/PrincipalGroup/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupAction.php
@@ -17,7 +17,7 @@ use Source\Account\Principal\Application\UseCase\Command\AddPrincipalToPrincipal
 use Source\Account\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup\AddPrincipalToPrincipalGroupOutput;
 use Source\Account\Principal\Domain\Exception\PrincipalAlreadyMemberException;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
@@ -40,7 +40,7 @@ readonly class AddPrincipalToPrincipalGroupAction
             try {
                 $input = new AddPrincipalToPrincipalGroupInput(
                     principalGroupIdentifier: new PrincipalGroupIdentifier($request->principalGroupId()),
-                    principalIdentifier: new IdentityIdentifier($request->principalIdentifier()),
+                    principalIdentifier: new PrincipalIdentifier($request->principalIdentifier()),
                 );
                 $output = new AddPrincipalToPrincipalGroupOutput();
             } catch (InvalidArgumentException $e) {

--- a/application/Http/Action/Account/PrincipalGroup/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupAction.php
+++ b/application/Http/Action/Account/PrincipalGroup/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupAction.php
@@ -18,7 +18,7 @@ use Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrin
 use Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupOutput;
 use Source\Account\Principal\Domain\Exception\PrincipalNotMemberException;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
@@ -41,7 +41,7 @@ readonly class RemovePrincipalFromPrincipalGroupAction
             try {
                 $input = new RemovePrincipalFromPrincipalGroupInput(
                     principalGroupIdentifier: new PrincipalGroupIdentifier($request->principalGroupId()),
-                    principalIdentifier: new IdentityIdentifier($request->principalIdentifier()),
+                    principalIdentifier: new PrincipalIdentifier($request->principalIdentifier()),
                 );
                 $output = new RemovePrincipalFromPrincipalGroupOutput();
             } catch (InvalidArgumentException $e) {

--- a/application/Http/Action/Wiki/Principal/Command/CreatePrincipal/CreatePrincipalAction.php
+++ b/application/Http/Action/Wiki/Principal/Command/CreatePrincipal/CreatePrincipalAction.php
@@ -89,8 +89,14 @@ readonly class CreatePrincipalAction
                 '=',
                 'account_principal_group_memberships.principal_group_id'
             )
+            ->join(
+                'account_principals',
+                'account_principal_group_memberships.principal_id',
+                '=',
+                'account_principals.id'
+            )
             ->where('account_principal_groups.account_id', (string) $input->accountIdentifier())
-            ->where('account_principal_group_memberships.principal_id', (string) $this->actorContext->identityIdentifier)
+            ->where('account_principals.identity_id', (string) $this->actorContext->identityIdentifier)
             ->exists();
 
         if (! $belongsToAccount) {

--- a/application/Http/Context/AccountContext.php
+++ b/application/Http/Context/AccountContext.php
@@ -4,24 +4,17 @@ declare(strict_types=1);
 
 namespace Application\Http\Context;
 
-use Source\Account\Principal\Domain\ValueObject\AccountRole;
-use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Account\Principal\Domain\Entity\Principal;
 
 readonly class AccountContext
 {
     public function __construct(
-        public AccountIdentifier $accountIdentifier,
-        public AccountRole $role,
+        private Principal $principal,
     ) {
     }
 
-    public function isOwner(): bool
+    public function principal(): Principal
     {
-        return $this->role === AccountRole::OWNER;
-    }
-
-    public function isAdmin(): bool
-    {
-        return $this->role === AccountRole::ADMIN;
+        return $this->principal;
     }
 }

--- a/application/Http/Context/AccountResolver.php
+++ b/application/Http/Context/AccountResolver.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Application\Http\Context;
 
-use Application\Models\Account\PrincipalGroup as PrincipalGroupModel;
+use Application\Models\Account\Principal as PrincipalModel;
 use Source\Account\Account\Application\Exception\AccountNotFoundException;
-use Source\Account\Principal\Domain\ValueObject\AccountRole;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 
@@ -15,25 +16,20 @@ class AccountResolver
     /** @throws AccountNotFoundException */
     public function resolve(IdentityIdentifier $identityIdentifier): AccountContext
     {
-        /** @var object{account_id: string, role: string}|null $row */
-        $row = PrincipalGroupModel::query()
-            ->select(['account_principal_groups.account_id', 'account_principal_groups.role'])
-            ->join(
-                'account_principal_group_memberships',
-                'account_principal_groups.id',
-                '=',
-                'account_principal_group_memberships.principal_group_id'
-            )
-            ->where('account_principal_group_memberships.principal_id', (string) $identityIdentifier)
+        $principal = PrincipalModel::query()
+            ->where('identity_id', (string) $identityIdentifier)
             ->first();
 
-        if ($row === null) {
+        if ($principal === null) {
             throw new AccountNotFoundException('Account context not found.');
         }
 
         return new AccountContext(
-            accountIdentifier: new AccountIdentifier($row->account_id),
-            role: AccountRole::from($row->role),
+            principal: new Principal(
+                new PrincipalIdentifier($principal->id),
+                new IdentityIdentifier($principal->identity_id),
+                new AccountIdentifier($principal->account_id),
+            ),
         );
     }
 }

--- a/application/Http/Context/AuthContextCache.php
+++ b/application/Http/Context/AuthContextCache.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Application\Http\Context;
 
 use Illuminate\Support\Facades\Redis;
-use Source\Account\Principal\Domain\ValueObject\AccountRole;
+use Source\Account\Principal\Domain\Entity\Principal as AccountPrincipal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier as AccountPrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\DelegationIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\Language;
-use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier as WikiPrincipalIdentifier;
 use Throwable;
 
 class AuthContextCache
@@ -57,9 +58,11 @@ class AuthContextCache
         }
 
         $context = $dbResolver();
+        $principal = $context->principal();
         $this->write($this->accountKey($identityIdentifier), [
-            'accountIdentifier' => (string) $context->accountIdentifier,
-            'role' => $context->role->value,
+            'principalIdentifier' => (string) $principal->principalIdentifier(),
+            'identityIdentifier' => (string) $principal->identityIdentifier(),
+            'accountIdentifier' => (string) $principal->accountIdentifier(),
         ]);
 
         return $context;
@@ -198,18 +201,20 @@ class AuthContextCache
     /** @param array<string, mixed> $payload */
     private function accountFromPayload(array $payload): ?AccountContext
     {
-        if (! is_string($payload['accountIdentifier'] ?? null) || ! is_string($payload['role'] ?? null)) {
-            return null;
-        }
-
-        $role = AccountRole::tryFrom($payload['role']);
-        if ($role === null) {
+        if (
+            ! is_string($payload['principalIdentifier'] ?? null)
+            || ! is_string($payload['identityIdentifier'] ?? null)
+            || ! is_string($payload['accountIdentifier'] ?? null)
+        ) {
             return null;
         }
 
         return new AccountContext(
-            accountIdentifier: new AccountIdentifier($payload['accountIdentifier']),
-            role: $role,
+            principal: new AccountPrincipal(
+                new AccountPrincipalIdentifier($payload['principalIdentifier']),
+                new IdentityIdentifier($payload['identityIdentifier']),
+                new AccountIdentifier($payload['accountIdentifier']),
+            ),
         );
     }
 
@@ -220,6 +225,6 @@ class AuthContextCache
             return null;
         }
 
-        return new WikiContext(new PrincipalIdentifier($payload['principalIdentifier']));
+        return new WikiContext(new WikiPrincipalIdentifier($payload['principalIdentifier']));
     }
 }

--- a/application/Models/Account/Principal.php
+++ b/application/Models/Account/Principal.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Models\Account;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $identity_id
+ * @property string $account_id
+ * @property ?Carbon $created_at
+ * @property ?Carbon $updated_at
+ */
+#[\Illuminate\Database\Eloquent\Attributes\Fillable([
+    'id',
+    'identity_id',
+    'account_id',
+])]
+#[\Illuminate\Database\Eloquent\Attributes\Table(name: 'account_principals', keyType: 'string')]
+class Principal extends Model
+{
+    public $incrementing = false;
+}

--- a/application/Providers/Account/DomainServiceProvider.php
+++ b/application/Providers/Account/DomainServiceProvider.php
@@ -29,14 +29,18 @@ use Source\Account\Invitation\Domain\Service\InvitationMailServiceInterface;
 use Source\Account\Invitation\Infrastructure\Factory\InvitationFactory;
 use Source\Account\Invitation\Infrastructure\Repository\InvitationRepository;
 use Source\Account\Invitation\Infrastructure\Service\InvitationMailService;
+use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Account\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
 use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface as PolicyEvaluatorInterface;
+use Source\Account\Principal\Infrastructure\Factory\PrincipalFactory;
 use Source\Account\Principal\Infrastructure\Factory\PrincipalGroupFactory;
 use Source\Account\Principal\Infrastructure\Repository\PolicyRepository;
 use Source\Account\Principal\Infrastructure\Repository\PrincipalGroupRepository;
+use Source\Account\Principal\Infrastructure\Repository\PrincipalRepository;
 use Source\Account\Principal\Infrastructure\Repository\RoleRepository;
 use Source\Account\Principal\Infrastructure\Service\PolicyEvaluator as PolicyEvaluator;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
@@ -47,6 +51,8 @@ class DomainServiceProvider extends ServiceProvider
     {
         $this->app->singleton(AccountFactoryInterface::class, AccountFactory::class);
         $this->app->singleton(AccountRepositoryInterface::class, AccountRepository::class);
+        $this->app->singleton(PrincipalFactoryInterface::class, PrincipalFactory::class);
+        $this->app->singleton(PrincipalRepositoryInterface::class, PrincipalRepository::class);
         $this->app->singleton(PrincipalGroupFactoryInterface::class, PrincipalGroupFactory::class);
         $this->app->singleton(PrincipalGroupRepositoryInterface::class, PrincipalGroupRepository::class);
         $this->app->singleton(PolicyRepositoryInterface::class, PolicyRepository::class);

--- a/application/Providers/Account/UseCaseServiceProvider.php
+++ b/application/Providers/Account/UseCaseServiceProvider.php
@@ -15,6 +15,8 @@ use Source\Account\Account\Application\UseCase\Command\RejectVerification\Reject
 use Source\Account\Account\Application\UseCase\Command\RejectVerification\RejectVerificationInterface;
 use Source\Account\Account\Application\UseCase\Command\RequestVerification\RequestVerification;
 use Source\Account\Account\Application\UseCase\Command\RequestVerification\RequestVerificationInterface;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccount;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInterface;
 use Source\Account\Affiliation\Application\UseCase\Command\ApproveAffiliation\ApproveAffiliation;
 use Source\Account\Affiliation\Application\UseCase\Command\ApproveAffiliation\ApproveAffiliationInterface;
 use Source\Account\Affiliation\Application\UseCase\Command\RejectAffiliation\RejectAffiliation;
@@ -56,6 +58,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(GrantDelegationPermissionInterface::class, GrantDelegationPermission::class);
         $this->app->singleton(RevokeDelegationPermissionInterfaceNew::class, RevokeDelegationPermissionUseCase::class);
         $this->app->singleton(DeleteAccountInterface::class, DeleteAccount::class);
+        $this->app->singleton(UpdateAccountInterface::class, UpdateAccount::class);
         $this->app->singleton(RevokeDelegationInterface::class, RevokeDelegation::class);
         $this->app->singleton(RequestDelegationInterface::class, RequestDelegation::class);
         $this->app->singleton(ApproveDelegationInterface::class, ApproveDelegation::class);

--- a/database/migrations/2024_01_01_000025_create_account_principal_groups_table.php
+++ b/database/migrations/2024_01_01_000025_create_account_principal_groups_table.php
@@ -11,6 +11,23 @@ return new class extends Migration
      */
     public function up(): void
     {
+        Schema::create('account_principals', static function (Blueprint $table) {
+            $table->uuid('id')->primary()->comment('Principal ID');
+            $table->uuid('identity_id')->comment('Identity ID');
+            $table->uuid('account_id')->index()->comment('アカウントID');
+            $table->timestamps();
+
+            $table->foreign('identity_id')
+                ->references('id')
+                ->on('identities')
+                ->cascadeOnDelete();
+            $table->foreign('account_id')
+                ->references('id')
+                ->on('accounts')
+                ->cascadeOnDelete();
+            $table->unique(['identity_id', 'account_id']);
+        });
+
         Schema::create('account_principal_groups', static function (Blueprint $table) {
             $table->uuid('id')->primary()->comment('PrincipalグループID');
             $table->uuid('account_id')->index()->comment('アカウントID');
@@ -38,7 +55,7 @@ return new class extends Migration
 
             $table->foreign('principal_id')
                 ->references('id')
-                ->on('identities')
+                ->on('account_principals')
                 ->cascadeOnDelete();
 
             $table->unique(['principal_group_id', 'principal_id']);
@@ -52,5 +69,6 @@ return new class extends Migration
     {
         Schema::dropIfExists('account_principal_group_memberships');
         Schema::dropIfExists('account_principal_groups');
+        Schema::dropIfExists('account_principals');
     }
 };

--- a/database/seeders/FullAccessTestAccountSeeder.php
+++ b/database/seeders/FullAccessTestAccountSeeder.php
@@ -73,6 +73,16 @@ class FullAccessTestAccountSeeder extends Seeder
             ],
         ], ['id']);
 
+        DB::table('account_principals')->upsert([
+            [
+                'id' => self::PRINCIPAL_ID,
+                'identity_id' => self::IDENTITY_ID,
+                'account_id' => self::ACCOUNT_ID,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['id']);
+
         DB::table('account_principal_groups')->upsert([
             [
                 'id' => self::PRINCIPAL_GROUP_ID,
@@ -89,7 +99,7 @@ class FullAccessTestAccountSeeder extends Seeder
             [
                 'id' => self::ACCOUNT_PRINCIPAL_GROUP_MEMBERSHIP_ID,
                 'principal_group_id' => self::PRINCIPAL_GROUP_ID,
-                'principal_id' => self::IDENTITY_ID,
+                'principal_id' => self::PRINCIPAL_ID,
                 'created_at' => $now,
                 'updated_at' => $now,
             ],

--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -171,6 +171,58 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateAccountRequestBody'
   /accounts/{accountId}:
+    patch:
+      operationId: AccountOperations_updateAccount
+      description: Update account information.
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when an account operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAccountRequestBody'
     delete:
       operationId: AccountOperations_deleteAccount
       description: Delete an account.
@@ -641,173 +693,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RevokeDelegationRequestBody'
-  /identity-groups:
-    post:
-      operationId: IdentityGroupOperations_createIdentityGroup
-      description: Create an identity group.
-      parameters: []
-      responses:
-        '201':
-          description: Response returned when an identity group is created.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreatedIdentityGroupSummary'
-        '401':
-          description: Access is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '422':
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateIdentityGroupRequestBody'
-  /identity-groups/{identityGroupId}:
-    delete:
-      operationId: IdentityGroupOperations_deleteIdentityGroup
-      description: Delete an identity group.
-      parameters:
-        - name: identityGroupId
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/KPool.Common.Uuid'
-      responses:
-        '204':
-          description: Response with no content.
-        '401':
-          description: Access is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '404':
-          description: The server cannot find the requested resource.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '422':
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-  /identity-groups/{identityGroupId}/add-member:
-    post:
-      operationId: IdentityGroupOperations_addIdentityToIdentityGroup
-      description: Add an identity to an identity group.
-      parameters:
-        - name: identityGroupId
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/KPool.Common.Uuid'
-      responses:
-        '200':
-          description: Response returned when an identity group operation succeeds.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdentityGroupSummary'
-        '401':
-          description: Access is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '404':
-          description: The server cannot find the requested resource.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '422':
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MutateIdentityGroupMemberRequestBody'
-  /identity-groups/{identityGroupId}/remove-member:
-    post:
-      operationId: IdentityGroupOperations_removeIdentityFromIdentityGroup
-      description: Remove an identity from an identity group.
-      parameters:
-        - name: identityGroupId
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/KPool.Common.Uuid'
-      responses:
-        '200':
-          description: Response returned when an identity group operation succeeds.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdentityGroupSummary'
-        '401':
-          description: Access is unauthorized.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '404':
-          description: The server cannot find the requested resource.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '422':
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-        '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MutateIdentityGroupMemberRequestBody'
   /invitations:
     post:
       operationId: InvitationOperations_createInvitation
@@ -852,6 +737,173 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateInvitationRequestBody'
+  /principal-groups:
+    post:
+      operationId: PrincipalGroupOperations_createPrincipalGroup
+      description: Create an principal group.
+      parameters: []
+      responses:
+        '201':
+          description: Response returned when an principal group is created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatedPrincipalGroupSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePrincipalGroupRequestBody'
+  /principal-groups/{principalGroupId}:
+    delete:
+      operationId: PrincipalGroupOperations_deletePrincipalGroup
+      description: Delete an principal group.
+      parameters:
+        - name: principalGroupId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '204':
+          description: Response with no content.
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+  /principal-groups/{principalGroupId}/add-member:
+    post:
+      operationId: PrincipalGroupOperations_addPrincipalToPrincipalGroup
+      description: Add an identity to an principal group.
+      parameters:
+        - name: principalGroupId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when an principal group operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipalGroupSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MutatePrincipalGroupMemberRequestBody'
+  /principal-groups/{principalGroupId}/remove-member:
+    post:
+      operationId: PrincipalGroupOperations_removePrincipalFromPrincipalGroup
+      description: Remove an identity from an principal group.
+      parameters:
+        - name: principalGroupId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when an principal group operation succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipalGroupSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MutatePrincipalGroupMemberRequestBody'
 components:
   schemas:
     AccountSummary:
@@ -1045,7 +1097,7 @@ components:
         accountName:
           type: string
           description: Account display name.
-        identityIdentifier:
+        principalIdentifier:
           type: string
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
@@ -1075,7 +1127,28 @@ components:
           type: string
           description: Account category assigned during creation.
       description: Account creation request result. Empty when the request is accepted without exposing whether an account already exists.
-    CreateIdentityGroupRequestBody:
+    CreateInvitationRequestBody:
+      type: object
+      required:
+        - accountIdentifier
+        - inviterPrincipalIdentifier
+        - emails
+      properties:
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Account identifier that owns the invitations.
+        inviterPrincipalIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Identity identifier sending the invitations.
+        emails:
+          type: array
+          items:
+            type: string
+          description: Invitee email addresses.
+      description: Request body for creating invitations.
+    CreatePrincipalGroupRequestBody:
       type: object
       required:
         - accountIdentifier
@@ -1088,32 +1161,11 @@ components:
           description: Owning account identifier.
         name:
           type: string
-          description: Identity group name.
+          description: Principal group name.
         role:
           type: string
-          description: Role assigned to the identity group.
-      description: Request body for creating an identity group.
-    CreateInvitationRequestBody:
-      type: object
-      required:
-        - accountIdentifier
-        - inviterIdentityIdentifier
-        - emails
-      properties:
-        accountIdentifier:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Account identifier that owns the invitations.
-        inviterIdentityIdentifier:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Identity identifier sending the invitations.
-        emails:
-          type: array
-          items:
-            type: string
-          description: Invitee email addresses.
-      description: Request body for creating invitations.
+          description: Role assigned to the principal group.
+      description: Request body for creating an principal group.
     CreatedAccountSummary:
       type: object
       required:
@@ -1125,7 +1177,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/AccountSummary'
       description: Account creation result.
-    CreatedIdentityGroupSummary:
+    CreatedPrincipalGroupSummary:
       type: object
       required:
         - createdAt
@@ -1133,15 +1185,15 @@ components:
         createdAt:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Timestamp'
-          description: Timestamp when the identity group was created.
+          description: Timestamp when the principal group was created.
       allOf:
-        - $ref: '#/components/schemas/IdentityGroupSummary'
-      description: Identity group snapshot returned immediately after creation.
+        - $ref: '#/components/schemas/PrincipalGroupSummary'
+      description: Principal group snapshot returned immediately after creation.
     DelegationPermissionSummary:
       type: object
       required:
         - delegationPermissionIdentifier
-        - identityGroupIdentifier
+        - principalGroupIdentifier
         - targetAccountIdentifier
         - affiliationIdentifier
         - createdAt
@@ -1150,10 +1202,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Delegation permission identifier.
-        identityGroupIdentifier:
+        principalGroupIdentifier:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Identity group identifier that owns the permission.
+          description: Principal group identifier that owns the permission.
         targetAccountIdentifier:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
@@ -1220,11 +1272,11 @@ components:
     GrantDelegationPermissionRequestBody:
       type: object
       required:
-        - identityGroupIdentifier
+        - principalGroupIdentifier
         - targetAccountIdentifier
         - affiliationIdentifier
       properties:
-        identityGroupIdentifier:
+        principalGroupIdentifier:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity group identifier receiving the permission.
@@ -1237,44 +1289,12 @@ components:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Affiliation identifier covered by the permission.
       description: Request body for granting a delegation permission.
-    IdentityGroupSummary:
-      type: object
-      required:
-        - identityGroupIdentifier
-        - accountIdentifier
-        - name
-        - role
-        - isDefault
-      properties:
-        identityGroupIdentifier:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Identity group identifier.
-        accountIdentifier:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Owning account identifier.
-        name:
-          type: string
-          description: Identity group name.
-        role:
-          type: string
-          description: Identity group role.
-        isDefault:
-          type: boolean
-          description: Whether this is the default identity group.
-        members:
-          type: array
-          items:
-            $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Identity identifiers currently assigned to the group.
-      description: Identity group snapshot returned after updates.
     InvitationSummary:
       type: object
       required:
         - invitationIdentifier
         - accountIdentifier
-        - invitedByIdentityIdentifier
+        - invitedByPrincipalIdentifier
         - email
         - token
         - status
@@ -1289,7 +1309,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Target account identifier.
-        invitedByIdentityIdentifier:
+        invitedByPrincipalIdentifier:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier that created the invitation.
@@ -1338,16 +1358,48 @@ components:
       type: string
       format: uuid
       description: UUID identifier.
-    MutateIdentityGroupMemberRequestBody:
+    MutatePrincipalGroupMemberRequestBody:
       type: object
       required:
-        - identityIdentifier
+        - principalIdentifier
       properties:
-        identityIdentifier:
+        principalIdentifier:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier to add or remove.
-      description: Request body for mutating identity group membership.
+      description: Request body for mutating principal group membership.
+    PrincipalGroupSummary:
+      type: object
+      required:
+        - principalGroupIdentifier
+        - accountIdentifier
+        - name
+        - role
+        - isDefault
+      properties:
+        principalGroupIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Principal group identifier.
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Owning account identifier.
+        name:
+          type: string
+          description: Principal group name.
+        role:
+          type: string
+          description: Principal group role.
+        isDefault:
+          type: boolean
+          description: Whether this is the default principal group.
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Identity identifiers currently assigned to the group.
+      description: Principal group snapshot returned after updates.
     RejectAffiliationRequestBody:
       type: object
       required:
@@ -1466,6 +1518,15 @@ components:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Terminator account identifier.
       description: Request body for terminating an affiliation.
+    UpdateAccountRequestBody:
+      type: object
+      required:
+        - accountName
+      properties:
+        accountName:
+          type: string
+          description: Updated account display name.
+      description: Request body for updating account information.
     VerificationDocumentSummary:
       type: object
       required:

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -50,6 +50,7 @@ return [
     // Account
     'account_already_exists' => 'The account already exists.',
     'account_not_found' => 'The specified account was not found.',
+    'account_update_forbidden' => 'The account information cannot be updated by the current actor.',
     'account_deletion_blocked' => 'The account cannot be deleted due to unresolved conditions.',
     'identity_group_not_found' => 'The specified identity group was not found.',
     'identity_already_member' => 'The identity is already a member of this group.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -50,6 +50,7 @@ return [
     // Account
     'account_already_exists' => 'La cuenta ya existe.',
     'account_not_found' => 'No se encontró la cuenta especificada.',
+    'account_update_forbidden' => 'El actor actual no puede actualizar la información de la cuenta.',
     'account_deletion_blocked' => 'La cuenta no se puede eliminar debido a condiciones no resueltas.',
     'identity_group_not_found' => 'No se encontró el grupo de identidad especificado.',
     'identity_already_member' => 'La identidad ya es miembro de este grupo.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -50,6 +50,7 @@ return [
     // Account
     'account_already_exists' => 'アカウントは既に存在します。',
     'account_not_found' => '指定されたアカウントが見つかりません。',
+    'account_update_forbidden' => '現在のアクターではアカウント情報を更新できません。',
     'account_deletion_blocked' => '未解決の条件があるため、アカウントを削除できません。',
     'identity_group_not_found' => '指定されたアイデンティティグループが見つかりません。',
     'identity_already_member' => 'このアイデンティティは既にこのグループのメンバーです。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -50,6 +50,7 @@ return [
     // Account
     'account_already_exists' => '계정이 이미 존재합니다.',
     'account_not_found' => '지정된 계정을 찾을 수 없습니다.',
+    'account_update_forbidden' => '현재 행위자는 계정 정보를 업데이트할 수 없습니다.',
     'account_deletion_blocked' => '해결되지 않은 조건이 있어 계정을 삭제할 수 없습니다.',
     'identity_group_not_found' => '지정된 아이덴티티 그룹을 찾을 수 없습니다.',
     'identity_already_member' => '해당 아이덴티티는 이미 이 그룹의 멤버입니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -50,6 +50,7 @@ return [
     // Account
     'account_already_exists' => '账户已存在。',
     'account_not_found' => '找不到指定的账户。',
+    'account_update_forbidden' => '当前操作者无法更新账户信息。',
     'account_deletion_blocked' => '由于存在未解决的条件，无法删除账户。',
     'identity_group_not_found' => '找不到指定的身份组。',
     'identity_already_member' => '该身份已是此组的成员。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -50,6 +50,7 @@ return [
     // Account
     'account_already_exists' => '帳戶已存在。',
     'account_not_found' => '找不到指定的帳戶。',
+    'account_update_forbidden' => '目前的操作者無法更新帳戶資訊。',
     'account_deletion_blocked' => '由於存在未解決的條件，無法刪除帳戶。',
     'identity_group_not_found' => '找不到指定的身分群組。',
     'identity_already_member' => '該身分已是此群組的成員。',

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Application\Http\Action\Account\Account\Command\CreateAccount\CreateAccountAction;
 use Application\Http\Action\Account\Account\Command\DeleteAccount\DeleteAccountAction;
+use Application\Http\Action\Account\Account\Command\UpdateAccount\UpdateAccountAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\ApproveVerification\ApproveVerificationAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\RejectVerification\RejectVerificationAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\RequestVerification\RequestVerificationAction;
@@ -28,6 +29,7 @@ Route::post('/accounts', CreateAccountAction::class);
 
 Route::middleware(['auth.api', 'resolve.actor', 'resolve.account'])->group(function () {
     // Account
+    Route::patch('/accounts/{accountId}', UpdateAccountAction::class);
     Route::delete('/accounts/{accountId}', DeleteAccountAction::class);
 
     // Delegation

--- a/src/Account/Account/Application/Exception/AccountUpdateForbiddenException.php
+++ b/src/Account/Account/Application/Exception/AccountUpdateForbiddenException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\Exception;
+
+use Exception;
+
+class AccountUpdateForbiddenException extends Exception
+{
+}

--- a/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
+++ b/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
@@ -8,9 +8,10 @@ use Source\Account\Account\Domain\Event\AccountCreated;
 use Source\Account\Account\Domain\Event\AccountCreationConflicted;
 use Source\Account\Account\Domain\Factory\AccountFactoryInterface;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
-use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Account\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
@@ -21,6 +22,8 @@ readonly class CreateAccount implements CreateAccountInterface
     public function __construct(
         private AccountRepositoryInterface $accountRepository,
         private AccountFactoryInterface $accountFactory,
+        private PrincipalFactoryInterface $principalFactory,
+        private PrincipalRepositoryInterface $principalRepository,
         private PrincipalGroupFactoryInterface $principalGroupFactory,
         private PrincipalGroupRepositoryInterface $principalGroupRepository,
         private EventDispatcherInterface $eventDispatcher,
@@ -61,7 +64,12 @@ readonly class CreateAccount implements CreateAccountInterface
         );
 
         if ($input->identityIdentifier() !== null) {
-            $principalGroup->addMember(new Principal($input->identityIdentifier()));
+            $principal = $this->principalFactory->create(
+                $input->identityIdentifier(),
+                $account->accountIdentifier(),
+            );
+            $this->principalRepository->save($principal);
+            $principalGroup->addMember($principal->principalIdentifier());
         }
 
         $this->principalGroupRepository->save($principalGroup);

--- a/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccount.php
+++ b/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccount.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+
+readonly class UpdateAccount implements UpdateAccountInterface
+{
+    public function __construct(
+        private AccountRepositoryInterface $accountRepository,
+        private PolicyEvaluatorInterface $policyEvaluator,
+    ) {
+    }
+
+    /**
+     * @param UpdateAccountInputPort $input
+     * @param UpdateAccountOutputPort $output
+     * @return void
+     * @throws AccountNotFoundException
+     * @throws AccountUpdateForbiddenException
+     */
+    public function process(UpdateAccountInputPort $input, UpdateAccountOutputPort $output): void
+    {
+        $account = $this->accountRepository->findById($input->accountIdentifier());
+
+        if (! $account) {
+            throw new AccountNotFoundException();
+        }
+
+        if (
+            (string) $input->principal()->accountIdentifier() !== (string) $account->accountIdentifier()
+            || ! $this->policyEvaluator->evaluate(
+                $input->principal(),
+                Action::UPDATE_NAME,
+                Resource::account($account->accountIdentifier()),
+            )
+        ) {
+            throw new AccountUpdateForbiddenException();
+        }
+
+        $account->changeName($input->accountName());
+        $this->accountRepository->save($account);
+
+        $output->setAccount($account);
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInput.php
+++ b/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInput.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+readonly class UpdateAccountInput implements UpdateAccountInputPort
+{
+    public function __construct(
+        private AccountIdentifier $accountIdentifier,
+        private Principal $principal,
+        private AccountName $accountName,
+    ) {
+    }
+
+    public function accountIdentifier(): AccountIdentifier
+    {
+        return $this->accountIdentifier;
+    }
+
+    public function principal(): Principal
+    {
+        return $this->principal;
+    }
+
+    public function accountName(): AccountName
+    {
+        return $this->accountName;
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInputPort.php
+++ b/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInputPort.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+interface UpdateAccountInputPort
+{
+    public function accountIdentifier(): AccountIdentifier;
+
+    public function principal(): Principal;
+
+    public function accountName(): AccountName;
+}

--- a/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInterface.php
+++ b/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+
+interface UpdateAccountInterface
+{
+    /**
+     * @param UpdateAccountInputPort $input
+     * @param UpdateAccountOutputPort $output
+     * @return void
+     * @throws AccountNotFoundException
+     * @throws AccountUpdateForbiddenException
+     */
+    public function process(UpdateAccountInputPort $input, UpdateAccountOutputPort $output): void;
+}

--- a/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountOutput.php
+++ b/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountOutput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use Source\Account\Account\Domain\Entity\Account;
+
+class UpdateAccountOutput implements UpdateAccountOutputPort
+{
+    private ?Account $account = null;
+
+    public function setAccount(Account $account): void
+    {
+        $this->account = $account;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if ($this->account === null) {
+            return [];
+        }
+
+        $account = $this->account;
+
+        return [
+            'accountIdentifier' => (string) $account->accountIdentifier(),
+            'email' => (string) $account->email(),
+            'type' => $account->type()->value,
+            'name' => (string) $account->name(),
+            'status' => $account->status()->value,
+            'accountCategory' => $account->accountCategory()->value,
+        ];
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountOutputPort.php
+++ b/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use Source\Account\Account\Domain\Entity\Account;
+
+interface UpdateAccountOutputPort
+{
+    public function setAccount(Account $account): void;
+}

--- a/src/Account/Account/Domain/Entity/Account.php
+++ b/src/Account/Account/Domain/Entity/Account.php
@@ -19,7 +19,7 @@ class Account
         private readonly AccountIdentifier $accountIdentifier,
         private readonly Email $email,
         private readonly AccountType $type,
-        private readonly AccountName $name,
+        private AccountName $name,
         private readonly AccountStatus $status,
         private AccountCategory $accountCategory,
         private readonly DeletionReadinessChecklist $deletionReadiness,
@@ -44,6 +44,11 @@ class Account
     public function name(): AccountName
     {
         return $this->name;
+    }
+
+    public function changeName(AccountName $name): void
+    {
+        $this->name = $name;
     }
 
     public function status(): AccountStatus

--- a/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
+++ b/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
@@ -7,8 +7,10 @@ namespace Source\Account\Invitation\Application\EventHandler;
 use Source\Account\Invitation\Application\Exception\InvitationNotFoundException;
 use Source\Account\Invitation\Domain\Event\InvitationAccepted;
 use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
+use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Account\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
@@ -21,6 +23,8 @@ readonly class IdentityCreatedViaInvitationHandler
         private InvitationRepositoryInterface $invitationRepository,
         private PrincipalGroupRepositoryInterface $principalGroupRepository,
         private PrincipalGroupFactoryInterface $principalGroupFactory,
+        private PrincipalFactoryInterface $principalFactory,
+        private PrincipalRepositoryInterface $principalRepository,
         private EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -49,7 +53,13 @@ readonly class IdentityCreatedViaInvitationHandler
             );
         }
 
-        $memberGroup->addMember($event->identityIdentifier);
+        $principal = $this->principalFactory->create(
+            $event->identityIdentifier,
+            $invitation->accountIdentifier(),
+        );
+        $this->principalRepository->save($principal);
+
+        $memberGroup->addMember($principal->principalIdentifier());
         $this->principalGroupRepository->save($memberGroup);
 
         $invitation->accept($event->identityIdentifier);

--- a/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitation.php
+++ b/src/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitation.php
@@ -8,7 +8,7 @@ use Source\Account\Invitation\Application\Exception\DisallowedInvitationExceptio
 use Source\Account\Invitation\Domain\Event\InvitationCreated;
 use Source\Account\Invitation\Domain\Factory\InvitationFactoryInterface;
 use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
-use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
 use Source\Account\Principal\Domain\ValueObject\Resource;
@@ -20,6 +20,7 @@ readonly class CreateInvitation implements CreateInvitationInterface
         private InvitationRepositoryInterface $invitationRepository,
         private InvitationFactoryInterface $invitationFactory,
         private PolicyEvaluatorInterface $policyEvaluator,
+        private PrincipalRepositoryInterface $principalRepository,
         private EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -64,8 +65,17 @@ readonly class CreateInvitation implements CreateInvitationInterface
 
     private function assertInviterHasPermission(CreateInvitationInputPort $input): void
     {
+        $principal = $this->principalRepository->findByIdentityIdentifierAndAccountIdentifier(
+            $input->inviterIdentityIdentifier(),
+            $input->accountIdentifier(),
+        );
+
+        if ($principal === null) {
+            throw new DisallowedInvitationException('招待を作成する権限がありません。');
+        }
+
         $allowed = $this->policyEvaluator->evaluate(
-            new Principal($input->inviterIdentityIdentifier()),
+            $principal,
             Action::INVITATION_CREATE,
             Resource::account($input->accountIdentifier()),
         );

--- a/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroup.php
+++ b/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroup.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
 
 use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
-use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 
 readonly class AddPrincipalToPrincipalGroup implements AddPrincipalToPrincipalGroupInterface
@@ -26,7 +25,7 @@ readonly class AddPrincipalToPrincipalGroup implements AddPrincipalToPrincipalGr
             throw new PrincipalGroupNotFoundException();
         }
 
-        $principalGroup->addMember(new Principal($input->principalIdentifier()));
+        $principalGroup->addMember($input->principalIdentifier());
 
         $this->principalGroupRepository->save($principalGroup);
 

--- a/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupInput.php
+++ b/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupInput.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
 
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 
 readonly class AddPrincipalToPrincipalGroupInput implements AddPrincipalToPrincipalGroupInputPort
 {
     public function __construct(
         private PrincipalGroupIdentifier $principalGroupIdentifier,
-        private IdentityIdentifier $principalIdentifier,
+        private PrincipalIdentifier $principalIdentifier,
     ) {
     }
 
@@ -20,7 +20,7 @@ readonly class AddPrincipalToPrincipalGroupInput implements AddPrincipalToPrinci
         return $this->principalGroupIdentifier;
     }
 
-    public function principalIdentifier(): IdentityIdentifier
+    public function principalIdentifier(): PrincipalIdentifier
     {
         return $this->principalIdentifier;
     }

--- a/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupInputPort.php
+++ b/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupInputPort.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
 
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 
 interface AddPrincipalToPrincipalGroupInputPort
 {
     public function principalGroupIdentifier(): PrincipalGroupIdentifier;
 
-    public function principalIdentifier(): IdentityIdentifier;
+    public function principalIdentifier(): PrincipalIdentifier;
 }

--- a/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutput.php
+++ b/src/Account/Principal/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutput.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Command\AddPrincipalToPrincipalGroup;
 
-use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 
 class AddPrincipalToPrincipalGroupOutput implements AddPrincipalToPrincipalGroupOutputPort
 {
@@ -34,7 +34,7 @@ class AddPrincipalToPrincipalGroupOutput implements AddPrincipalToPrincipalGroup
             'role' => $ig->role()->value,
             'isDefault' => $ig->isDefault(),
             'members' => array_map(
-                static fn (Principal $principal) => (string) $principal->principalIdentifier(),
+                static fn (PrincipalIdentifier $principalIdentifier) => (string) $principalIdentifier,
                 array_values($ig->members()),
             ),
         ];

--- a/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroup.php
+++ b/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroup.php
@@ -6,7 +6,6 @@ namespace Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFr
 
 use Source\Account\Principal\Application\Exception\CannotRemoveLastOwnerException;
 use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
-use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 
@@ -44,7 +43,7 @@ readonly class RemovePrincipalFromPrincipalGroup implements RemovePrincipalFromP
             }
         }
 
-        $principalGroup->removeMember(new Principal($input->principalIdentifier()));
+        $principalGroup->removeMember($input->principalIdentifier());
 
         $this->principalGroupRepository->save($principalGroup);
 

--- a/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupInput.php
+++ b/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupInput.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
 
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 
 readonly class RemovePrincipalFromPrincipalGroupInput implements RemovePrincipalFromPrincipalGroupInputPort
 {
     public function __construct(
         private PrincipalGroupIdentifier $principalGroupIdentifier,
-        private IdentityIdentifier $principalIdentifier,
+        private PrincipalIdentifier $principalIdentifier,
     ) {
     }
 
@@ -20,7 +20,7 @@ readonly class RemovePrincipalFromPrincipalGroupInput implements RemovePrincipal
         return $this->principalGroupIdentifier;
     }
 
-    public function principalIdentifier(): IdentityIdentifier
+    public function principalIdentifier(): PrincipalIdentifier
     {
         return $this->principalIdentifier;
     }

--- a/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupInputPort.php
+++ b/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupInputPort.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
 
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 
 interface RemovePrincipalFromPrincipalGroupInputPort
 {
     public function principalGroupIdentifier(): PrincipalGroupIdentifier;
 
-    public function principalIdentifier(): IdentityIdentifier;
+    public function principalIdentifier(): PrincipalIdentifier;
 }

--- a/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutput.php
+++ b/src/Account/Principal/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutput.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup;
 
-use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 
 class RemovePrincipalFromPrincipalGroupOutput implements RemovePrincipalFromPrincipalGroupOutputPort
 {
@@ -34,7 +34,7 @@ class RemovePrincipalFromPrincipalGroupOutput implements RemovePrincipalFromPrin
             'role' => $ig->role()->value,
             'isDefault' => $ig->isDefault(),
             'members' => array_map(
-                static fn (Principal $principal) => (string) $principal->principalIdentifier(),
+                static fn (PrincipalIdentifier $principalIdentifier) => (string) $principalIdentifier,
                 array_values($ig->members()),
             ),
         ];

--- a/src/Account/Principal/Domain/Entity/Principal.php
+++ b/src/Account/Principal/Domain/Entity/Principal.php
@@ -4,17 +4,31 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Domain\Entity;
 
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 
 readonly class Principal
 {
     public function __construct(
-        private IdentityIdentifier $principalIdentifier,
+        private PrincipalIdentifier $principalIdentifier,
+        private IdentityIdentifier $identityIdentifier,
+        private AccountIdentifier $accountIdentifier,
     ) {
     }
 
-    public function principalIdentifier(): IdentityIdentifier
+    public function principalIdentifier(): PrincipalIdentifier
     {
         return $this->principalIdentifier;
+    }
+
+    public function identityIdentifier(): IdentityIdentifier
+    {
+        return $this->identityIdentifier;
+    }
+
+    public function accountIdentifier(): AccountIdentifier
+    {
+        return $this->accountIdentifier;
     }
 }

--- a/src/Account/Principal/Domain/Entity/PrincipalGroup.php
+++ b/src/Account/Principal/Domain/Entity/PrincipalGroup.php
@@ -9,12 +9,12 @@ use Source\Account\Principal\Domain\Exception\PrincipalAlreadyMemberException;
 use Source\Account\Principal\Domain\Exception\PrincipalNotMemberException;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 
 class PrincipalGroup
 {
-    /** @var array<string, Principal> */
+    /** @var array<string, PrincipalIdentifier> */
     private array $members = [];
 
     public function __construct(
@@ -58,7 +58,7 @@ class PrincipalGroup
     }
 
     /**
-     * @return array<string, Principal>
+     * @return array<string, PrincipalIdentifier>
      */
     public function members(): array
     {
@@ -70,41 +70,26 @@ class PrincipalGroup
         return count($this->members);
     }
 
-    public function hasMember(Principal|IdentityIdentifier $principal): bool
+    public function hasMember(PrincipalIdentifier $principalIdentifier): bool
     {
-        $principal = $this->normalizePrincipal($principal);
-
-        return isset($this->members[(string) $principal->principalIdentifier()]);
+        return isset($this->members[(string) $principalIdentifier]);
     }
 
-    public function addMember(Principal|IdentityIdentifier $principal): void
+    public function addMember(PrincipalIdentifier $principalIdentifier): void
     {
-        $principal = $this->normalizePrincipal($principal);
-
-        if ($this->hasMember($principal)) {
+        if ($this->hasMember($principalIdentifier)) {
             throw new PrincipalAlreadyMemberException();
         }
 
-        $this->members[(string) $principal->principalIdentifier()] = $principal;
+        $this->members[(string) $principalIdentifier] = $principalIdentifier;
     }
 
-    public function removeMember(Principal|IdentityIdentifier $principal): void
+    public function removeMember(PrincipalIdentifier $principalIdentifier): void
     {
-        $principal = $this->normalizePrincipal($principal);
-
-        if (! $this->hasMember($principal)) {
+        if (! $this->hasMember($principalIdentifier)) {
             throw new PrincipalNotMemberException();
         }
 
-        unset($this->members[(string) $principal->principalIdentifier()]);
-    }
-
-    private function normalizePrincipal(Principal|IdentityIdentifier $principal): Principal
-    {
-        if ($principal instanceof Principal) {
-            return $principal;
-        }
-
-        return new Principal($principal);
+        unset($this->members[(string) $principalIdentifier]);
     }
 }

--- a/src/Account/Principal/Domain/Factory/PrincipalFactoryInterface.php
+++ b/src/Account/Principal/Domain/Factory/PrincipalFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Domain\Factory;
+
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+interface PrincipalFactoryInterface
+{
+    public function create(
+        IdentityIdentifier $identityIdentifier,
+        AccountIdentifier $accountIdentifier,
+    ): Principal;
+}

--- a/src/Account/Principal/Domain/Repository/PrincipalGroupRepositoryInterface.php
+++ b/src/Account/Principal/Domain/Repository/PrincipalGroupRepositoryInterface.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Domain\Repository;
 
-use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
 interface PrincipalGroupRepositoryInterface
@@ -24,14 +24,14 @@ interface PrincipalGroupRepositoryInterface
     /**
      * @return array<PrincipalGroup>
      */
-    public function findByPrincipal(Principal $principal): array;
+    public function findByPrincipalId(PrincipalIdentifier $principalIdentifier): array;
 
     /**
      * @return array<PrincipalGroup>
      */
     public function findByAccountIdAndPrincipal(
         AccountIdentifier $accountIdentifier,
-        Principal $principal
+        PrincipalIdentifier $principalIdentifier
     ): array;
 
     public function findDefaultByAccountId(AccountIdentifier $accountIdentifier): ?PrincipalGroup;

--- a/src/Account/Principal/Domain/Repository/PrincipalRepositoryInterface.php
+++ b/src/Account/Principal/Domain/Repository/PrincipalRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Domain\Repository;
+
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+interface PrincipalRepositoryInterface
+{
+    public function findById(PrincipalIdentifier $principalIdentifier): ?Principal;
+
+    public function findByIdentityIdentifier(IdentityIdentifier $identityIdentifier): ?Principal;
+
+    public function findByIdentityIdentifierAndAccountIdentifier(
+        IdentityIdentifier $identityIdentifier,
+        AccountIdentifier $accountIdentifier,
+    ): ?Principal;
+
+    public function save(Principal $principal): void;
+}

--- a/src/Account/Principal/Infrastructure/Factory/PrincipalFactory.php
+++ b/src/Account/Principal/Infrastructure/Factory/PrincipalFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Infrastructure\Factory;
+
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Application\Service\Uuid\UuidGeneratorInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+readonly class PrincipalFactory implements PrincipalFactoryInterface
+{
+    public function __construct(
+        private UuidGeneratorInterface $uuidGenerator,
+    ) {
+    }
+
+    public function create(
+        IdentityIdentifier $identityIdentifier,
+        AccountIdentifier $accountIdentifier,
+    ): Principal {
+        return new Principal(
+            new PrincipalIdentifier($this->uuidGenerator->generate()),
+            $identityIdentifier,
+            $accountIdentifier,
+        );
+    }
+}

--- a/src/Account/Principal/Infrastructure/Repository/PrincipalGroupRepository.php
+++ b/src/Account/Principal/Infrastructure/Repository/PrincipalGroupRepository.php
@@ -8,11 +8,11 @@ use Application\Http\Context\AuthContextCache;
 use Application\Models\Account\PrincipalGroup as PrincipalGroupEloquent;
 use Application\Models\Account\PrincipalGroupMembership as PrincipalGroupMembershipEloquent;
 use DateTimeImmutable;
-use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Symfony\Component\Uid\Uuid;
@@ -41,12 +41,12 @@ class PrincipalGroupRepository implements PrincipalGroupRepositoryInterface
             ->delete();
 
         $currentMemberIds = [];
-        foreach ($principalGroup->members() as $principal) {
-            $currentMemberIds[] = (string) $principal->principalIdentifier();
+        foreach ($principalGroup->members() as $principalIdentifier) {
+            $currentMemberIds[] = (string) $principalIdentifier;
             PrincipalGroupMembershipEloquent::query()->create([
                 'id' => (string) Uuid::v7(),
                 'principal_group_id' => (string) $principalGroup->principalGroupIdentifier(),
-                'principal_id' => (string) $principal->principalIdentifier(),
+                'principal_id' => (string) $principalIdentifier,
             ]);
         }
 
@@ -83,12 +83,12 @@ class PrincipalGroupRepository implements PrincipalGroupRepositoryInterface
     /**
      * @return array<PrincipalGroup>
      */
-    public function findByPrincipal(Principal $principal): array
+    public function findByPrincipalId(PrincipalIdentifier $principalIdentifier): array
     {
         $eloquents = PrincipalGroupEloquent::query()
             ->with('members')
-            ->whereHas('members', function ($query) use ($principal) {
-                $query->where('principal_id', (string) $principal->principalIdentifier());
+            ->whereHas('members', function ($query) use ($principalIdentifier) {
+                $query->where('principal_id', (string) $principalIdentifier);
             })
             ->get();
 
@@ -100,13 +100,13 @@ class PrincipalGroupRepository implements PrincipalGroupRepositoryInterface
      */
     public function findByAccountIdAndPrincipal(
         AccountIdentifier $accountIdentifier,
-        Principal $principal
+        PrincipalIdentifier $principalIdentifier
     ): array {
         $eloquents = PrincipalGroupEloquent::query()
             ->with('members')
             ->where('account_id', (string) $accountIdentifier)
-            ->whereHas('members', function ($query) use ($principal) {
-                $query->where('principal_id', (string) $principal->principalIdentifier());
+            ->whereHas('members', function ($query) use ($principalIdentifier) {
+                $query->where('principal_id', (string) $principalIdentifier);
             })
             ->get();
 
@@ -159,9 +159,14 @@ class PrincipalGroupRepository implements PrincipalGroupRepositoryInterface
         $this->forgetAccountContexts($memberIds);
     }
 
-    /** @param array<int, string> $identityIds */
-    private function forgetAccountContexts(array $identityIds): void
+    /** @param array<int, string> $principalIds */
+    private function forgetAccountContexts(array $principalIds): void
     {
+        $identityIds = \Application\Models\Account\Principal::query()
+            ->whereIn('id', $principalIds)
+            ->pluck('identity_id')
+            ->all();
+
         foreach ($identityIds as $identityId) {
             app(AuthContextCache::class)->forgetAccount(new IdentityIdentifier($identityId));
         }
@@ -180,7 +185,7 @@ class PrincipalGroupRepository implements PrincipalGroupRepositoryInterface
 
         /** @var PrincipalGroupMembershipEloquent $member */
         foreach ($eloquent->members as $member) {
-            $principalGroup->addMember(new Principal(new IdentityIdentifier($member->principal_id)));
+            $principalGroup->addMember(new PrincipalIdentifier($member->principal_id));
         }
 
         return $principalGroup;

--- a/src/Account/Principal/Infrastructure/Repository/PrincipalRepository.php
+++ b/src/Account/Principal/Infrastructure/Repository/PrincipalRepository.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Infrastructure\Repository;
+
+use Application\Http\Context\AuthContextCache;
+use Application\Models\Account\Principal as PrincipalEloquent;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+class PrincipalRepository implements PrincipalRepositoryInterface
+{
+    public function findById(PrincipalIdentifier $principalIdentifier): ?Principal
+    {
+        $eloquent = PrincipalEloquent::query()
+            ->where('id', (string) $principalIdentifier)
+            ->first();
+
+        if ($eloquent === null) {
+            return null;
+        }
+
+        return $this->toDomainEntity($eloquent);
+    }
+
+    public function findByIdentityIdentifier(IdentityIdentifier $identityIdentifier): ?Principal
+    {
+        $eloquent = PrincipalEloquent::query()
+            ->where('identity_id', (string) $identityIdentifier)
+            ->first();
+
+        if ($eloquent === null) {
+            return null;
+        }
+
+        return $this->toDomainEntity($eloquent);
+    }
+
+    public function findByIdentityIdentifierAndAccountIdentifier(
+        IdentityIdentifier $identityIdentifier,
+        AccountIdentifier $accountIdentifier,
+    ): ?Principal {
+        $eloquent = PrincipalEloquent::query()
+            ->where('identity_id', (string) $identityIdentifier)
+            ->where('account_id', (string) $accountIdentifier)
+            ->first();
+
+        if ($eloquent === null) {
+            return null;
+        }
+
+        return $this->toDomainEntity($eloquent);
+    }
+
+    public function save(Principal $principal): void
+    {
+        $previousIdentityId = PrincipalEloquent::query()
+            ->where('id', (string) $principal->principalIdentifier())
+            ->value('identity_id');
+
+        PrincipalEloquent::query()->updateOrCreate(
+            ['id' => (string) $principal->principalIdentifier()],
+            [
+                'identity_id' => (string) $principal->identityIdentifier(),
+                'account_id' => (string) $principal->accountIdentifier(),
+            ],
+        );
+
+        foreach (array_filter([$previousIdentityId, (string) $principal->identityIdentifier()]) as $identityId) {
+            app(AuthContextCache::class)->forgetAccount(new IdentityIdentifier($identityId));
+        }
+    }
+
+    private function toDomainEntity(PrincipalEloquent $eloquent): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier($eloquent->id),
+            new IdentityIdentifier($eloquent->identity_id),
+            new AccountIdentifier($eloquent->account_id),
+        );
+    }
+}

--- a/src/Account/Principal/Infrastructure/Service/PolicyEvaluator.php
+++ b/src/Account/Principal/Infrastructure/Service/PolicyEvaluator.php
@@ -54,7 +54,7 @@ readonly class PolicyEvaluator implements PolicyEvaluatorInterface
     {
         $principalGroups = $this->principalGroupRepository->findByAccountIdAndPrincipal(
             $resource->accountIdentifier(),
-            $principal,
+            $principal->principalIdentifier(),
         );
 
         if (empty($principalGroups)) {

--- a/src/Account/Shared/Domain/ValueObject/PrincipalIdentifier.php
+++ b/src/Account/Shared/Domain/ValueObject/PrincipalIdentifier.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Shared\Domain\ValueObject;
+
+use InvalidArgumentException;
+use Source\Shared\Application\Service\Uuid\UuidValidator;
+use Source\Shared\Domain\ValueObject\Foundation\StringBaseValue;
+
+class PrincipalIdentifier extends StringBaseValue
+{
+    public function __construct(string $id)
+    {
+        parent::__construct($id);
+        $this->validate($id);
+    }
+
+    protected function validate(string $value): void
+    {
+        if (! UuidValidator::isValid($value)) {
+            throw new InvalidArgumentException('Invalid PrincipalIdentifier.');
+        }
+    }
+}

--- a/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
+++ b/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
@@ -9,6 +9,8 @@ use Application\Http\Context\AccountResolver;
 use Application\Http\Context\AuthContextCache;
 use Application\Models\Identity\Identity as IdentityModel;
 use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Identity\Application\UseCase\Query\AuthenticatedIdentityReadModel;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInputPort;
 use Source\Identity\Application\UseCase\Query\GetAuthenticatedIdentity\GetAuthenticatedIdentityInterface;
@@ -20,6 +22,7 @@ readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInter
     public function __construct(
         private AccountResolver $accountResolver,
         private AuthContextCache $cache,
+        private PrincipalGroupRepositoryInterface $principalGroupRepository,
     ) {
     }
 
@@ -54,8 +57,30 @@ readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInter
             email: $model->email,
             language: $model->language,
             profileImage: ImageUrl::fromPath($model->profile_image),
-            accountIdentifier: $accountContext === null ? null : (string) $accountContext->accountIdentifier,
-            accountRole: $accountContext === null ? null : $accountContext->role->value,
+            accountIdentifier: $accountContext === null ? null : (string) $accountContext->principal()->accountIdentifier(),
+            accountRole: $accountContext === null ? null : $this->resolveAccountRole($accountContext)?->value,
         );
+    }
+
+    private function resolveAccountRole(AccountContext $accountContext): ?AccountRole
+    {
+        $principal = $accountContext->principal();
+        $principalGroups = $this->principalGroupRepository->findByAccountIdAndPrincipal(
+            $principal->accountIdentifier(),
+            $principal->principalIdentifier(),
+        );
+
+        $roles = [];
+        foreach ($principalGroups as $principalGroup) {
+            $roles[$principalGroup->role()->value] = $principalGroup->role();
+        }
+
+        foreach ([AccountRole::OWNER, AccountRole::ADMIN, AccountRole::MEMBER] as $role) {
+            if (isset($roles[$role->value])) {
+                return $role;
+            }
+        }
+
+        return array_values($roles)[0] ?? null;
     }
 }

--- a/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
@@ -19,12 +19,16 @@ use Source\Account\Account\Domain\ValueObject\AccountName;
 use Source\Account\Account\Domain\ValueObject\AccountStatus;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
+use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Account\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
@@ -44,11 +48,15 @@ class CreateAccountTest extends TestCase
     {
         $repository = Mockery::mock(AccountRepositoryInterface::class);
         $factory = Mockery::mock(AccountFactoryInterface::class);
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
@@ -81,6 +89,17 @@ class CreateAccountTest extends TestCase
             ->with($testData->email, $testData->accountType, $testData->accountName)
             ->andReturn($testData->account);
 
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalFactory->shouldReceive('create')
+            ->once()
+            ->with($testData->identityIdentifier, $testData->identifier)
+            ->andReturn($testData->principal);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('save')
+            ->once()
+            ->with($testData->principal);
+
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldReceive('create')
             ->once()
@@ -106,6 +125,8 @@ class CreateAccountTest extends TestCase
 
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
@@ -120,7 +141,7 @@ class CreateAccountTest extends TestCase
         $this->assertSame((string) $testData->email, $result['email']);
         $this->assertSame($testData->accountType->value, $result['type']);
         $this->assertSame((string) $testData->accountName, $result['name']);
-        $this->assertTrue($testData->principalGroup->hasMember($testData->identityIdentifier));
+        $this->assertTrue($testData->principalGroup->hasMember($testData->principalIdentifier));
     }
 
     /**
@@ -148,6 +169,12 @@ class CreateAccountTest extends TestCase
             ->with($testData->email, $testData->accountType, $testData->accountName)
             ->andReturn($testData->account);
 
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalFactory->shouldNotReceive('create');
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldNotReceive('save');
+
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldReceive('create')
             ->once()
@@ -173,6 +200,8 @@ class CreateAccountTest extends TestCase
 
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
@@ -207,6 +236,12 @@ class CreateAccountTest extends TestCase
         $factory = Mockery::mock(AccountFactoryInterface::class);
         $factory->shouldNotReceive('create');
 
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalFactory->shouldNotReceive('create');
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldNotReceive('save');
+
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldNotReceive('create');
 
@@ -224,6 +259,8 @@ class CreateAccountTest extends TestCase
 
         $this->app->instance(AccountRepositoryInterface::class, $repository);
         $this->app->instance(AccountFactoryInterface::class, $factory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
@@ -258,6 +295,8 @@ class CreateAccountTest extends TestCase
         );
 
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, $identityIdentifier, $identifier);
 
         $principalGroup = new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
@@ -285,6 +324,8 @@ class CreateAccountTest extends TestCase
             $account,
             $input,
             $identityIdentifier,
+            $principalIdentifier,
+            $principal,
             $principalGroup,
             $language,
         );
@@ -302,6 +343,8 @@ readonly class CreateAccountTestData
         public Account $account,
         public CreateAccountInput $input,
         public IdentityIdentifier $identityIdentifier,
+        public PrincipalIdentifier $principalIdentifier,
+        public Principal $principal,
         public PrincipalGroup $principalGroup,
         public Language $language,
     ) {

--- a/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInputTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountInputTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use PHPUnit\Framework\TestCase;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInput;
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+
+class UpdateAccountInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            $accountIdentifier,
+        );
+        $accountName = new AccountName('Updated Account');
+
+        $input = new UpdateAccountInput($accountIdentifier, $principal, $accountName);
+
+        $this->assertSame($accountIdentifier, $input->accountIdentifier());
+        $this->assertSame($principal, $input->principal());
+        $this->assertSame($accountName, $input->accountName());
+    }
+}

--- a/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountOutputTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountOutputTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use PHPUnit\Framework\TestCase;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountOutput;
+use Source\Account\Account\Domain\Entity\Account;
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Account\Account\Domain\ValueObject\AccountStatus;
+use Source\Account\Account\Domain\ValueObject\AccountType;
+use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Tests\Helper\StrTestHelper;
+
+class UpdateAccountOutputTest extends TestCase
+{
+    public function testToArrayReturnsAccountSummary(): void
+    {
+        $account = new Account(
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            new Email('test@example.com'),
+            AccountType::CORPORATION,
+            new AccountName('Updated Account'),
+            AccountStatus::ACTIVE,
+            AccountCategory::GENERAL,
+            DeletionReadinessChecklist::ready(),
+        );
+        $output = new UpdateAccountOutput();
+
+        $output->setAccount($account);
+        $result = $output->toArray();
+
+        $this->assertSame((string) $account->accountIdentifier(), $result['accountIdentifier']);
+        $this->assertSame('Updated Account', $result['name']);
+    }
+
+    public function testToArrayReturnsEmptyArrayWhenAccountIsNotSet(): void
+    {
+        $this->assertSame([], (new UpdateAccountOutput())->toArray());
+    }
+}

--- a/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Account\Application\UseCase\Command\UpdateAccount;
+
+use Mockery;
+use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccount;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInput;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInterface;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountOutput;
+use Source\Account\Account\Domain\Entity\Account;
+use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Account\Account\Domain\ValueObject\AccountStatus;
+use Source\Account\Account\Domain\ValueObject\AccountType;
+use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UpdateAccountTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
+        $this->app->instance(PolicyEvaluatorInterface::class, $policyEvaluator);
+
+        $useCase = $this->app->make(UpdateAccountInterface::class);
+
+        $this->assertInstanceOf(UpdateAccount::class, $useCase);
+    }
+
+    /**
+     * @throws AccountNotFoundException
+     * @throws AccountUpdateForbiddenException
+     */
+    public function testProcessAllowsPermittedPrincipalToUpdateAccountName(): void
+    {
+        $account = $this->createAccount();
+        $principal = $this->createPrincipal($account->accountIdentifier());
+        $newName = new AccountName('Updated Account');
+        $input = new UpdateAccountInput($account->accountIdentifier(), $principal, $newName);
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldReceive('findById')->with($account->accountIdentifier())->once()->andReturn($account);
+        $accountRepository->shouldReceive('save')->once()->with(Mockery::on(
+            fn (Account $savedAccount): bool => (string) $savedAccount->name() === (string) $newName
+        ));
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')
+            ->once()
+            ->with($principal, Action::UPDATE_NAME, Mockery::type(Resource::class))
+            ->andReturnTrue();
+
+        $useCase = new UpdateAccount($accountRepository, $policyEvaluator);
+        $output = new UpdateAccountOutput();
+        $useCase->process($input, $output);
+
+        $this->assertSame('Updated Account', $output->toArray()['name']);
+    }
+
+    public function testProcessThrowsAccountNotFoundException(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $input = new UpdateAccountInput(
+            $accountIdentifier,
+            $this->createPrincipal($accountIdentifier),
+            new AccountName('Updated Account'),
+        );
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldReceive('findById')->with($accountIdentifier)->once()->andReturnNull();
+        $accountRepository->shouldNotReceive('save');
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldNotReceive('evaluate');
+
+        $this->expectException(AccountNotFoundException::class);
+
+        (new UpdateAccount($accountRepository, $policyEvaluator))->process($input, new UpdateAccountOutput());
+    }
+
+    public function testProcessThrowsForbiddenWhenPolicyDenies(): void
+    {
+        $account = $this->createAccount();
+        $principal = $this->createPrincipal($account->accountIdentifier());
+        $input = new UpdateAccountInput(
+            $account->accountIdentifier(),
+            $principal,
+            new AccountName('Updated Account')
+        );
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldReceive('findById')->with($account->accountIdentifier())->once()->andReturn($account);
+        $accountRepository->shouldNotReceive('save');
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->once()->andReturnFalse();
+
+        $this->expectException(AccountUpdateForbiddenException::class);
+
+        (new UpdateAccount($accountRepository, $policyEvaluator))->process($input, new UpdateAccountOutput());
+    }
+
+    public function testProcessThrowsForbiddenForDifferentAccount(): void
+    {
+        $account = $this->createAccount();
+        $input = new UpdateAccountInput(
+            $account->accountIdentifier(),
+            $this->createPrincipal(new AccountIdentifier(StrTestHelper::generateUuid())),
+            new AccountName('Updated Account'),
+        );
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldReceive('findById')->with($account->accountIdentifier())->once()->andReturn($account);
+        $accountRepository->shouldNotReceive('save');
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldNotReceive('evaluate');
+
+        $this->expectException(AccountUpdateForbiddenException::class);
+
+        (new UpdateAccount($accountRepository, $policyEvaluator))->process($input, new UpdateAccountOutput());
+    }
+
+    private function createAccount(): Account
+    {
+        return new Account(
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            new Email('test@example.com'),
+            AccountType::CORPORATION,
+            new AccountName('Example Inc'),
+            AccountStatus::ACTIVE,
+            AccountCategory::GENERAL,
+            DeletionReadinessChecklist::ready(),
+        );
+    }
+
+    private function createPrincipal(AccountIdentifier $accountIdentifier): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            $accountIdentifier,
+        );
+    }
+}

--- a/tests/Account/Account/Domain/Entity/AccountTest.php
+++ b/tests/Account/Account/Domain/Entity/AccountTest.php
@@ -51,6 +51,19 @@ class AccountTest extends TestCase
     }
 
     /**
+     * 正常系: 正しくアカウント名を変更できること.
+     */
+    public function testChangeName(): void
+    {
+        $dummyAccount = $this->createDummyAccountTestData();
+        $newName = new AccountName('Updated Account');
+
+        $dummyAccount->account->changeName($newName);
+
+        $this->assertSame((string) $newName, (string) $dummyAccount->account->name());
+    }
+
+    /**
      * 正常系: 削除に必要な前提条件を満たしていれば例外が発生しないこと.
      */
     public function testAssertDeletable(): void

--- a/tests/Account/Account/Http/Action/Command/UpdateAccount/UpdateAccountActionTest.php
+++ b/tests/Account/Account/Http/Action/Command/UpdateAccount/UpdateAccountActionTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Account\Http\Action\Command\UpdateAccount;
+
+use Application\Http\Action\Account\Account\Command\UpdateAccount\UpdateAccountAction;
+use Application\Http\Action\Account\Account\Command\UpdateAccount\UpdateAccountRequest;
+use Application\Http\Context\AccountContext;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInput;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountInterface;
+use Source\Account\Account\Application\UseCase\Command\UpdateAccount\UpdateAccountOutput;
+use Source\Account\Account\Domain\Entity\Account;
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Account\Account\Domain\ValueObject\AccountStatus;
+use Source\Account\Account\Domain\ValueObject\AccountType;
+use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UpdateAccountActionTest extends TestCase
+{
+    public function testInvokeReturnsOkResponse(): void
+    {
+        $account = $this->createAccount(accountName: 'Updated Account');
+        $request = $this->request((string) $account->accountIdentifier(), 'Updated Account');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('commit')->once();
+
+        /** @var UpdateAccountInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(UpdateAccountInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->with(
+                Mockery::type(UpdateAccountInput::class),
+                Mockery::on(function ($output) use ($account): bool {
+                    if (! $output instanceof UpdateAccountOutput) {
+                        return false;
+                    }
+
+                    $output->setAccount($account);
+
+                    return true;
+                })
+            );
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('error');
+
+        $response = (new UpdateAccountAction($useCase, $this->accountContext(), $logger))($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame((string) $account->accountIdentifier(), $payload['accountIdentifier']);
+        $this->assertSame('Updated Account', $payload['name']);
+    }
+
+    public function testInvokeReturnsNotFoundResponse(): void
+    {
+        $request = $this->request(StrTestHelper::generateUuid(), 'Updated Account');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var UpdateAccountInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(UpdateAccountInterface::class);
+        $useCase->shouldReceive('process')->once()->andThrow(new AccountNotFoundException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $response = (new UpdateAccountAction($useCase, $this->accountContext(), $logger))($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(error_message('account_not_found', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsForbiddenResponse(): void
+    {
+        $request = $this->request(StrTestHelper::generateUuid(), 'Updated Account');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var UpdateAccountInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(UpdateAccountInterface::class);
+        $useCase->shouldReceive('process')->once()->andThrow(new AccountUpdateForbiddenException());
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $response = (new UpdateAccountAction($useCase, $this->accountContext(), $logger))($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame(error_message('account_update_forbidden', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsUnprocessableEntityResponseForInvalidAccountName(): void
+    {
+        $request = $this->request(StrTestHelper::generateUuid(), '   ');
+
+        DB::shouldReceive('beginTransaction')->never();
+
+        /** @var UpdateAccountInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(UpdateAccountInterface::class);
+        $useCase->shouldNotReceive('process');
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $response = (new UpdateAccountAction($useCase, $this->accountContext(), $logger))($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $payload['status']);
+    }
+
+    private function request(string $accountId, string $accountName): UpdateAccountRequest
+    {
+        /** @var UpdateAccountRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(UpdateAccountRequest::class);
+        $request->shouldReceive('accountId')->andReturn($accountId);
+        $request->shouldReceive('accountName')->andReturn($accountName);
+        $request->shouldReceive('language')->andReturn('en');
+
+        return $request;
+    }
+
+    private function accountContext(): AccountContext
+    {
+        return new AccountContext(
+            new Principal(
+                new PrincipalIdentifier(StrTestHelper::generateUuid()),
+                new IdentityIdentifier(StrTestHelper::generateUuid()),
+                new AccountIdentifier(StrTestHelper::generateUuid()),
+            ),
+        );
+    }
+
+    private function createAccount(string $accountName): Account
+    {
+        return new Account(
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            new Email('test@example.com'),
+            AccountType::CORPORATION,
+            new AccountName($accountName),
+            AccountStatus::ACTIVE,
+            AccountCategory::GENERAL,
+            DeletionReadinessChecklist::ready(),
+        );
+    }
+}

--- a/tests/Account/Account/Infrastructure/Repository/AccountRepositoryTest.php
+++ b/tests/Account/Account/Infrastructure/Repository/AccountRepositoryTest.php
@@ -136,6 +136,33 @@ class AccountRepositoryTest extends TestCase
     }
 
     /**
+     * 正常系: 保存済みAccountのnameを更新できること
+     *
+     * @throws BindingResolutionException
+     */
+    #[Group('useDb')]
+    public function testSaveUpdatesAccountName(): void
+    {
+        $accountId = StrTestHelper::generateUuid();
+        $account = $this->createTestAccount(accountId: $accountId);
+
+        $repository = $this->app->make(AccountRepositoryInterface::class);
+        $repository->save($account);
+
+        $account->changeName(new AccountName('Updated Account'));
+        $repository->save($account);
+
+        $result = $repository->findById(new AccountIdentifier($accountId));
+
+        $this->assertNotNull($result);
+        $this->assertSame('Updated Account', (string) $result->name());
+        $this->assertDatabaseHas('accounts', [
+            'id' => $accountId,
+            'name' => 'Updated Account',
+        ]);
+    }
+
+    /**
      * 正常系: 正しくAccountを削除できること
      *
      * @throws BindingResolutionException

--- a/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
+++ b/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
@@ -16,11 +16,15 @@ use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
 use Source\Account\Invitation\Domain\ValueObject\InvitationIdentifier;
 use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
+use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Account\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
@@ -41,11 +45,15 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $invitationRepository = Mockery::mock(InvitationRepositoryInterface::class);
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
@@ -93,15 +101,28 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldNotReceive('create');
 
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalFactory->shouldReceive('create')
+            ->once()
+            ->with($data->identityIdentifier, $data->accountIdentifier)
+            ->andReturn($data->principal);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('save')
+            ->once()
+            ->with($data->principal);
+
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
 
-        $this->assertTrue($data->memberGroup->hasMember($data->identityIdentifier));
+        $this->assertTrue($data->memberGroup->hasMember($data->principalIdentifier));
     }
 
     /**
@@ -144,15 +165,28 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->with($data->accountIdentifier, 'Members', AccountRole::MEMBER, false)
             ->andReturn($data->memberGroup);
 
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalFactory->shouldReceive('create')
+            ->once()
+            ->with($data->identityIdentifier, $data->accountIdentifier)
+            ->andReturn($data->principal);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('save')
+            ->once()
+            ->with($data->principal);
+
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
 
-        $this->assertTrue($data->memberGroup->hasMember($data->identityIdentifier));
+        $this->assertTrue($data->memberGroup->hasMember($data->principalIdentifier));
     }
 
     /**
@@ -175,6 +209,8 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -182,6 +218,8 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -211,6 +249,8 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -218,6 +258,8 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -248,6 +290,8 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -255,6 +299,8 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -263,6 +309,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
     private function createTestData(): IdentityCreatedViaInvitationHandlerTestData
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $invitationToken = new InvitationToken(bin2hex(random_bytes(32)));
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $inviterIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
@@ -284,6 +331,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             null,
             new DateTimeImmutable(),
         );
+        $principal = new Principal($principalIdentifier, $identityIdentifier, $accountIdentifier);
 
         $memberGroup = new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
@@ -296,10 +344,12 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
 
         return new IdentityCreatedViaInvitationHandlerTestData(
             $identityIdentifier,
+            $principalIdentifier,
             $invitationToken,
             $accountIdentifier,
             $event,
             $invitation,
+            $principal,
             $memberGroup,
         );
     }
@@ -309,10 +359,12 @@ readonly class IdentityCreatedViaInvitationHandlerTestData
 {
     public function __construct(
         public IdentityIdentifier $identityIdentifier,
+        public PrincipalIdentifier $principalIdentifier,
         public InvitationToken $invitationToken,
         public AccountIdentifier $accountIdentifier,
         public IdentityCreatedViaInvitation $event,
         public Invitation $invitation,
+        public Principal $principal,
         public PrincipalGroup $memberGroup,
     ) {
     }

--- a/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationTest.php
+++ b/tests/Account/Invitation/Application/UseCase/Command/CreateInvitation/CreateInvitationTest.php
@@ -20,9 +20,11 @@ use Source\Account\Invitation\Domain\ValueObject\InvitationIdentifier;
 use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
 use Source\Account\Invitation\Domain\ValueObject\InvitationToken;
 use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
 use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
@@ -42,6 +44,7 @@ class CreateInvitationTest extends TestCase
         $this->app->instance(InvitationRepositoryInterface::class, Mockery::mock(InvitationRepositoryInterface::class));
         $this->app->instance(InvitationFactoryInterface::class, Mockery::mock(InvitationFactoryInterface::class));
         $this->app->instance(PolicyEvaluatorInterface::class, Mockery::mock(PolicyEvaluatorInterface::class));
+        $this->app->instance(PrincipalRepositoryInterface::class, Mockery::mock(PrincipalRepositoryInterface::class));
         $this->app->instance(EventDispatcherInterface::class, Mockery::mock(EventDispatcherInterface::class));
 
         $useCase = $this->app->make(CreateInvitationInterface::class);
@@ -173,6 +176,8 @@ class CreateInvitationTest extends TestCase
     {
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $inviterIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, $inviterIdentityIdentifier, $accountIdentifier);
         $email1 = new Email('user1@example.com');
         $email2 = new Email('user2@example.com');
         $invitation1 = $this->createInvitation($accountIdentifier, $inviterIdentityIdentifier, $email1);
@@ -184,12 +189,18 @@ class CreateInvitationTest extends TestCase
             ->once()
             ->with(
                 Mockery::on(
-                    static fn (Principal $principal): bool => (string) $principal->principalIdentifier() === (string) $inviterIdentityIdentifier
+                    static fn (Principal $actual): bool => $actual === $principal
                 ),
                 Action::INVITATION_CREATE,
                 Mockery::on(static fn (Resource $resource) => (string) $resource->accountIdentifier() === (string) $accountIdentifier)
             )
             ->andReturnTrue();
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findByIdentityIdentifierAndAccountIdentifier')
+            ->once()
+            ->with($inviterIdentityIdentifier, $accountIdentifier)
+            ->andReturn($principal);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
         $eventDispatcher->shouldReceive('dispatch')
@@ -207,6 +218,7 @@ class CreateInvitationTest extends TestCase
         $invitationFactory->shouldReceive('create')->once()->with($accountIdentifier, $inviterIdentityIdentifier, $email2)->andReturn($invitation2);
 
         $this->app->instance(PolicyEvaluatorInterface::class, $policyEvaluator);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(InvitationFactoryInterface::class, $invitationFactory);
@@ -225,7 +237,7 @@ class CreateInvitationTest extends TestCase
             ->once()
             ->with(
                 Mockery::on(
-                    static fn (Principal $principal): bool => (string) $principal->principalIdentifier() === (string) $data->inviterIdentityIdentifier
+                    static fn (Principal $principal): bool => $principal === $data->principal
                 ),
                 Action::INVITATION_CREATE,
                 Mockery::on(static fn (Resource $resource) => (string) $resource->accountIdentifier() === (string) $data->accountIdentifier)
@@ -233,12 +245,21 @@ class CreateInvitationTest extends TestCase
             ->andReturn($allowed);
 
         $this->app->instance(PolicyEvaluatorInterface::class, $policyEvaluator);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findByIdentityIdentifierAndAccountIdentifier')
+            ->once()
+            ->with($data->inviterIdentityIdentifier, $data->accountIdentifier)
+            ->andReturn($data->principal);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
     }
 
     private function createTestData(): CreateInvitationTestData
     {
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $inviterIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, $inviterIdentityIdentifier, $accountIdentifier);
         $email = new Email('invitee@example.com');
         $invitation = $this->createInvitation($accountIdentifier, $inviterIdentityIdentifier, $email);
         $input = new CreateInvitationInput($accountIdentifier, $inviterIdentityIdentifier, [$email]);
@@ -246,6 +267,8 @@ class CreateInvitationTest extends TestCase
         return new CreateInvitationTestData(
             $accountIdentifier,
             $inviterIdentityIdentifier,
+            $principalIdentifier,
+            $principal,
             $email,
             $invitation,
             $input,
@@ -277,6 +300,8 @@ readonly class CreateInvitationTestData
     public function __construct(
         public AccountIdentifier $accountIdentifier,
         public IdentityIdentifier $inviterIdentityIdentifier,
+        public PrincipalIdentifier $principalIdentifier,
+        public Principal $principal,
         public Email $email,
         public Invitation $invitation,
         public CreateInvitationInput $input,

--- a/tests/Account/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
+++ b/tests/Account/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
@@ -22,6 +22,7 @@ use Source\Account\Principal\Domain\ValueObject\ResourceType;
 use Source\Account\Principal\Domain\ValueObject\Statement;
 use Source\Account\Principal\Infrastructure\Service\PolicyEvaluator;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
@@ -32,16 +33,15 @@ class PolicyEvaluatorTest extends TestCase
     public function testEvaluateAllowsWhenRolePolicyHasAllowStatement(): void
     {
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($identityIdentifier);
-        $principalGroup = $this->createPrincipalGroup($accountIdentifier, $identityIdentifier, AccountRole::OWNER);
+        $principal = $this->createPrincipal($accountIdentifier);
+        $principalGroup = $this->createPrincipalGroup($accountIdentifier, $principal->principalIdentifier(), AccountRole::OWNER);
         $policy = $this->createPolicy('ACCOUNT_OWNER_BASIC', Effect::ALLOW, [Action::INVITATION_CREATE]);
 
         /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('findByAccountIdAndPrincipal')
             ->once()
-            ->with($accountIdentifier, $principal)
+            ->with($accountIdentifier, $principal->principalIdentifier())
             ->andReturn([$principalGroup]);
 
         /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
@@ -70,14 +70,13 @@ class PolicyEvaluatorTest extends TestCase
     public function testEvaluateDeniesWhenNoPrincipalGroupExists(): void
     {
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($identityIdentifier);
+        $principal = $this->createPrincipal($accountIdentifier);
 
         /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('findByAccountIdAndPrincipal')
             ->once()
-            ->with($accountIdentifier, $principal)
+            ->with($accountIdentifier, $principal->principalIdentifier())
             ->andReturn([]);
 
         /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
@@ -100,9 +99,8 @@ class PolicyEvaluatorTest extends TestCase
     public function testEvaluatePrioritizesExplicitDeny(): void
     {
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($identityIdentifier);
-        $principalGroup = $this->createPrincipalGroup($accountIdentifier, $identityIdentifier, AccountRole::ADMIN);
+        $principal = $this->createPrincipal($accountIdentifier);
+        $principalGroup = $this->createPrincipalGroup($accountIdentifier, $principal->principalIdentifier(), AccountRole::ADMIN);
         $allowPolicy = $this->createPolicy('ALLOW_INVITATION', Effect::ALLOW, [Action::INVITATION_CREATE]);
         $denyPolicy = $this->createPolicy('DENY_INVITATION', Effect::DENY, [Action::INVITATION_CREATE]);
 
@@ -110,7 +108,7 @@ class PolicyEvaluatorTest extends TestCase
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('findByAccountIdAndPrincipal')
             ->once()
-            ->with($accountIdentifier, $principal)
+            ->with($accountIdentifier, $principal->principalIdentifier())
             ->andReturn([$principalGroup]);
 
         /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
@@ -158,9 +156,18 @@ class PolicyEvaluatorTest extends TestCase
         );
     }
 
+    private function createPrincipal(AccountIdentifier $accountIdentifier): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            $accountIdentifier,
+        );
+    }
+
     private function createPrincipalGroup(
         AccountIdentifier $accountIdentifier,
-        IdentityIdentifier $identityIdentifier,
+        PrincipalIdentifier $principalIdentifier,
         AccountRole $role,
     ): PrincipalGroup {
         $principalGroup = new PrincipalGroup(
@@ -171,7 +178,7 @@ class PolicyEvaluatorTest extends TestCase
             true,
             new DateTimeImmutable(),
         );
-        $principalGroup->addMember($identityIdentifier);
+        $principalGroup->addMember($principalIdentifier);
 
         return $principalGroup;
     }

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutputTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupOutputTest.php
@@ -9,8 +9,8 @@ use Source\Account\Principal\Application\UseCase\Command\AddPrincipalToPrincipal
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -23,7 +23,7 @@ class AddPrincipalToPrincipalGroupOutputTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/AddPrincipalToPrincipalGroup/AddPrincipalToPrincipalGroupTest.php
@@ -17,8 +17,8 @@ use Source\Account\Principal\Domain\Exception\PrincipalAlreadyMemberException;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -44,7 +44,7 @@ class AddPrincipalToPrincipalGroupTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,
@@ -84,7 +84,7 @@ class AddPrincipalToPrincipalGroupTest extends TestCase
     public function testThrowsWhenNotFound(): void
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $repository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $repository->shouldReceive('findById')
@@ -112,7 +112,7 @@ class AddPrincipalToPrincipalGroupTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/DeletePrincipalGroup/DeletePrincipalGroupTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/DeletePrincipalGroup/DeletePrincipalGroupTest.php
@@ -17,8 +17,8 @@ use Source\Account\Principal\Domain\Entity\PrincipalGroup;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -140,7 +140,7 @@ class DeletePrincipalGroupTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutputTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupOutputTest.php
@@ -9,8 +9,8 @@ use Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrin
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -23,7 +23,7 @@ class RemovePrincipalFromPrincipalGroupOutputTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $remainingMember = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $remainingMember = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/RemovePrincipalFromPrincipalGroup/RemovePrincipalFromPrincipalGroupTest.php
@@ -18,8 +18,8 @@ use Source\Account\Principal\Domain\Exception\PrincipalNotMemberException;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -45,7 +45,7 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,
@@ -86,7 +86,7 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
     public function testThrowsWhenNotFound(): void
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $repository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $repository->shouldReceive('findById')
@@ -114,7 +114,7 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,
@@ -151,7 +151,7 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,
@@ -193,8 +193,8 @@ class RemovePrincipalFromPrincipalGroupTest extends TestCase
     {
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $anotherPrincipalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $anotherPrincipalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup = new PrincipalGroup(
             $principalGroupIdentifier,

--- a/tests/Account/PrincipalGroup/Domain/Entity/PrincipalGroupTest.php
+++ b/tests/Account/PrincipalGroup/Domain/Entity/PrincipalGroupTest.php
@@ -11,8 +11,8 @@ use Source\Account\Principal\Domain\Exception\PrincipalAlreadyMemberException;
 use Source\Account\Principal\Domain\Exception\PrincipalNotMemberException;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 
 class PrincipalGroupTest extends TestCase
@@ -50,7 +50,7 @@ class PrincipalGroupTest extends TestCase
     public function testAddMember(): void
     {
         $principalGroup = $this->createPrincipalGroup();
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup->addMember($principalIdentifier);
 
@@ -64,7 +64,7 @@ class PrincipalGroupTest extends TestCase
     public function testAddMemberThrowsExceptionWhenAlreadyMember(): void
     {
         $principalGroup = $this->createPrincipalGroup();
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup->addMember($principalIdentifier);
 
@@ -78,7 +78,7 @@ class PrincipalGroupTest extends TestCase
     public function testRemoveMember(): void
     {
         $principalGroup = $this->createPrincipalGroup();
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $principalGroup->addMember($principalIdentifier);
         $principalGroup->removeMember($principalIdentifier);
@@ -93,7 +93,7 @@ class PrincipalGroupTest extends TestCase
     public function testRemoveMemberThrowsExceptionWhenNotMember(): void
     {
         $principalGroup = $this->createPrincipalGroup();
-        $principalIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
         $this->expectException(PrincipalNotMemberException::class);
         $principalGroup->removeMember($principalIdentifier);
@@ -108,8 +108,8 @@ class PrincipalGroupTest extends TestCase
 
         $this->assertSame(0, $principalGroup->memberCount());
 
-        $principalGroup->addMember(new IdentityIdentifier(StrTestHelper::generateUuid()));
-        $principalGroup->addMember(new IdentityIdentifier(StrTestHelper::generateUuid()));
+        $principalGroup->addMember(new PrincipalIdentifier(StrTestHelper::generateUuid()));
+        $principalGroup->addMember(new PrincipalIdentifier(StrTestHelper::generateUuid()));
 
         $this->assertSame(2, $principalGroup->memberCount());
     }

--- a/tests/Account/PrincipalGroup/Infrastructure/Repository/PrincipalGroupRepositoryTest.php
+++ b/tests/Account/PrincipalGroup/Infrastructure/Repository/PrincipalGroupRepositoryTest.php
@@ -6,13 +6,14 @@ namespace Tests\Account\PrincipalGroup\Infrastructure\Repository;
 
 use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Group;
-use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\AccountRole;
 use Source\Account\Principal\Infrastructure\Repository\PrincipalGroupRepository;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\CreateAccount;
@@ -99,6 +100,8 @@ class PrincipalGroupRepositoryTest extends TestCase
         $accountId = StrTestHelper::generateUuid();
         $identityId1 = StrTestHelper::generateUuid();
         $identityId2 = StrTestHelper::generateUuid();
+        $principalId1 = StrTestHelper::generateUuid();
+        $principalId2 = StrTestHelper::generateUuid();
 
         // FK制約のためIdentityを事前に作成
         CreateIdentity::create(
@@ -109,13 +112,14 @@ class PrincipalGroupRepositoryTest extends TestCase
             new IdentityIdentifier($identityId2),
             ['email' => StrTestHelper::generateSmallAlphaStr(10) . '@example.com']
         );
-
         $principalGroup = $this->createTestPrincipalGroup(
             principalGroupId: $principalGroupId,
             accountId: $accountId,
         );
-        $principalGroup->addMember(new IdentityIdentifier($identityId1));
-        $principalGroup->addMember(new IdentityIdentifier($identityId2));
+        $this->createPrincipal($principalId1, $identityId1, $accountId);
+        $this->createPrincipal($principalId2, $identityId2, $accountId);
+        $principalGroup->addMember(new PrincipalIdentifier($principalId1));
+        $principalGroup->addMember(new PrincipalIdentifier($principalId2));
 
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
         $repository->save($principalGroup);
@@ -126,12 +130,12 @@ class PrincipalGroupRepositoryTest extends TestCase
 
         $this->assertDatabaseHas('account_principal_group_memberships', [
             'principal_group_id' => $principalGroupId,
-            'principal_id' => $identityId1,
+            'principal_id' => $principalId1,
         ]);
 
         $this->assertDatabaseHas('account_principal_group_memberships', [
             'principal_group_id' => $principalGroupId,
-            'principal_id' => $identityId2,
+            'principal_id' => $principalId2,
         ]);
     }
 
@@ -179,17 +183,18 @@ class PrincipalGroupRepositoryTest extends TestCase
         $principalGroupId = StrTestHelper::generateUuid();
         $accountId = StrTestHelper::generateUuid();
         $identityId = StrTestHelper::generateUuid();
+        $principalId = StrTestHelper::generateUuid();
 
         CreateIdentity::create(
             new IdentityIdentifier($identityId),
             ['email' => StrTestHelper::generateSmallAlphaStr(10) . '@example.com']
         );
-
         $principalGroup = $this->createTestPrincipalGroup(
             principalGroupId: $principalGroupId,
             accountId: $accountId,
         );
-        $principalGroup->addMember(new IdentityIdentifier($identityId));
+        $this->createPrincipal($principalId, $identityId, $accountId);
+        $principalGroup->addMember(new PrincipalIdentifier($principalId));
 
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
         $repository->save($principalGroup);
@@ -198,7 +203,7 @@ class PrincipalGroupRepositoryTest extends TestCase
 
         $this->assertNotNull($result);
         $this->assertCount(1, $result->members());
-        $this->assertTrue($result->hasMember(new IdentityIdentifier($identityId)));
+        $this->assertTrue($result->hasMember(new PrincipalIdentifier($principalId)));
     }
 
     /**
@@ -279,16 +284,18 @@ class PrincipalGroupRepositoryTest extends TestCase
     public function testFindByIdentityId(): void
     {
         $identityId = StrTestHelper::generateUuid();
+        $principalId = StrTestHelper::generateUuid();
         CreateIdentity::create(
             new IdentityIdentifier($identityId),
             ['email' => StrTestHelper::generateSmallAlphaStr(10) . '@example.com']
         );
 
         $principalGroup1 = $this->createTestPrincipalGroup(name: 'Group 1');
-        $principalGroup1->addMember(new IdentityIdentifier($identityId));
+        $this->createPrincipal($principalId, $identityId, (string) $principalGroup1->accountIdentifier());
+        $principalGroup1->addMember(new PrincipalIdentifier($principalId));
 
         $principalGroup2 = $this->createTestPrincipalGroup(name: 'Group 2');
-        $principalGroup2->addMember(new IdentityIdentifier($identityId));
+        $principalGroup2->addMember(new PrincipalIdentifier($principalId));
 
         // このグループにはメンバーを追加しない
         $principalGroup3 = $this->createTestPrincipalGroup(name: 'Group 3');
@@ -298,7 +305,7 @@ class PrincipalGroupRepositoryTest extends TestCase
         $repository->save($principalGroup2);
         $repository->save($principalGroup3);
 
-        $result = $repository->findByPrincipal(new Principal(new IdentityIdentifier($identityId)));
+        $result = $repository->findByPrincipalId(new PrincipalIdentifier($principalId));
 
         $this->assertCount(2, $result);
         $names = array_map(static fn ($g) => $g->name(), $result);
@@ -316,7 +323,7 @@ class PrincipalGroupRepositoryTest extends TestCase
     public function testFindByIdentityIdWhenNotFound(): void
     {
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
-        $result = $repository->findByPrincipal(new Principal(new IdentityIdentifier(StrTestHelper::generateUuid())));
+        $result = $repository->findByPrincipalId(new PrincipalIdentifier(StrTestHelper::generateUuid()));
 
         $this->assertSame([], $result);
     }
@@ -331,12 +338,14 @@ class PrincipalGroupRepositoryTest extends TestCase
     {
         $accountId = StrTestHelper::generateUuid();
         $identityId = StrTestHelper::generateUuid();
+        $principalId = StrTestHelper::generateUuid();
 
         CreateAccount::create($accountId);
         CreateIdentity::create(
             new IdentityIdentifier($identityId),
             ['email' => StrTestHelper::generateSmallAlphaStr(10) . '@example.com']
         );
+        $this->createPrincipal($principalId, $identityId, $accountId);
 
         $principalGroup1 = new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
@@ -346,7 +355,7 @@ class PrincipalGroupRepositoryTest extends TestCase
             true,
             new DateTimeImmutable(),
         );
-        $principalGroup1->addMember(new IdentityIdentifier($identityId));
+        $principalGroup1->addMember(new PrincipalIdentifier($principalId));
 
         $principalGroup2 = new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
@@ -356,7 +365,7 @@ class PrincipalGroupRepositoryTest extends TestCase
             false,
             new DateTimeImmutable(),
         );
-        $principalGroup2->addMember(new IdentityIdentifier($identityId));
+        $principalGroup2->addMember(new PrincipalIdentifier($principalId));
 
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
         $repository->save($principalGroup1);
@@ -364,7 +373,7 @@ class PrincipalGroupRepositoryTest extends TestCase
 
         $result = $repository->findByAccountIdAndPrincipal(
             new AccountIdentifier($accountId),
-            new Principal(new IdentityIdentifier($identityId))
+            new PrincipalIdentifier($principalId)
         );
 
         $this->assertCount(2, $result);
@@ -384,7 +393,7 @@ class PrincipalGroupRepositoryTest extends TestCase
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
         $result = $repository->findByAccountIdAndPrincipal(
             new AccountIdentifier(StrTestHelper::generateUuid()),
-            new Principal(new IdentityIdentifier(StrTestHelper::generateUuid()))
+            new PrincipalIdentifier(StrTestHelper::generateUuid())
         );
 
         $this->assertSame([], $result);
@@ -401,6 +410,7 @@ class PrincipalGroupRepositoryTest extends TestCase
         $accountId1 = StrTestHelper::generateUuid();
         $accountId2 = StrTestHelper::generateUuid();
         $identityId = StrTestHelper::generateUuid();
+        $principalId = StrTestHelper::generateUuid();
 
         CreateAccount::create($accountId1);
         CreateAccount::create($accountId2);
@@ -408,6 +418,7 @@ class PrincipalGroupRepositoryTest extends TestCase
             new IdentityIdentifier($identityId),
             ['email' => StrTestHelper::generateSmallAlphaStr(10) . '@example.com']
         );
+        $this->createPrincipal($principalId, $identityId, $accountId1);
 
         // accountId1にidentityIdを追加
         $principalGroup = new PrincipalGroup(
@@ -418,7 +429,7 @@ class PrincipalGroupRepositoryTest extends TestCase
             true,
             new DateTimeImmutable(),
         );
-        $principalGroup->addMember(new IdentityIdentifier($identityId));
+        $principalGroup->addMember(new PrincipalIdentifier($principalId));
 
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
         $repository->save($principalGroup);
@@ -426,7 +437,7 @@ class PrincipalGroupRepositoryTest extends TestCase
         // accountId2で検索すると見つからない
         $result = $repository->findByAccountIdAndPrincipal(
             new AccountIdentifier($accountId2),
-            new Principal(new IdentityIdentifier($identityId))
+            new PrincipalIdentifier($principalId)
         );
 
         $this->assertSame([], $result);
@@ -496,6 +507,7 @@ class PrincipalGroupRepositoryTest extends TestCase
     {
         $principalGroupId = StrTestHelper::generateUuid();
         $identityId = StrTestHelper::generateUuid();
+        $principalId = StrTestHelper::generateUuid();
 
         CreateIdentity::create(
             new IdentityIdentifier($identityId),
@@ -503,7 +515,8 @@ class PrincipalGroupRepositoryTest extends TestCase
         );
 
         $principalGroup = $this->createTestPrincipalGroup(principalGroupId: $principalGroupId);
-        $principalGroup->addMember(new IdentityIdentifier($identityId));
+        $this->createPrincipal($principalId, $identityId, (string) $principalGroup->accountIdentifier());
+        $principalGroup->addMember(new PrincipalIdentifier($principalId));
 
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
         $repository->save($principalGroup);
@@ -658,6 +671,8 @@ class PrincipalGroupRepositoryTest extends TestCase
         $accountId = StrTestHelper::generateUuid();
         $identityId1 = StrTestHelper::generateUuid();
         $identityId2 = StrTestHelper::generateUuid();
+        $principalId1 = StrTestHelper::generateUuid();
+        $principalId2 = StrTestHelper::generateUuid();
 
         CreateIdentity::create(
             new IdentityIdentifier($identityId1),
@@ -667,13 +682,14 @@ class PrincipalGroupRepositoryTest extends TestCase
             new IdentityIdentifier($identityId2),
             ['email' => StrTestHelper::generateSmallAlphaStr(10) . '@example.com']
         );
-
         // 最初のメンバーで保存
         $principalGroup = $this->createTestPrincipalGroup(
             principalGroupId: $principalGroupId,
             accountId: $accountId,
         );
-        $principalGroup->addMember(new IdentityIdentifier($identityId1));
+        $this->createPrincipal($principalId1, $identityId1, $accountId);
+        $this->createPrincipal($principalId2, $identityId2, $accountId);
+        $principalGroup->addMember(new PrincipalIdentifier($principalId1));
 
         $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
         $repository->save($principalGroup);
@@ -692,7 +708,7 @@ class PrincipalGroupRepositoryTest extends TestCase
             false,
             new DateTimeImmutable(),
         );
-        $updatedGroup->addMember(new IdentityIdentifier($identityId2));
+        $updatedGroup->addMember(new PrincipalIdentifier($principalId2));
 
         $repository->save($updatedGroup);
 
@@ -703,7 +719,18 @@ class PrincipalGroupRepositoryTest extends TestCase
         $this->assertSame(AccountRole::ADMIN, $result->role());
         $this->assertFalse($result->isDefault());
         $this->assertCount(1, $result->members());
-        $this->assertTrue($result->hasMember(new IdentityIdentifier($identityId2)));
-        $this->assertFalse($result->hasMember(new IdentityIdentifier($identityId1)));
+        $this->assertTrue($result->hasMember(new PrincipalIdentifier($principalId2)));
+        $this->assertFalse($result->hasMember(new PrincipalIdentifier($principalId1)));
+    }
+
+    private function createPrincipal(string $principalId, string $identityId, string $accountId): void
+    {
+        DB::table('account_principals')->insert([
+            'id' => $principalId,
+            'identity_id' => $identityId,
+            'account_id' => $accountId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 }

--- a/tests/Http/Context/AuthContextCacheTest.php
+++ b/tests/Http/Context/AuthContextCacheTest.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Http\Context;
 
+use Application\Http\Context\AccountContext;
 use Application\Http\Context\ActorContext;
 use Application\Http\Context\AuthContextCache;
 use Application\Http\Context\WikiContext;
 use Illuminate\Support\Facades\Redis;
 use RuntimeException;
-use Source\Account\Principal\Domain\ValueObject\AccountRole;
+use Source\Account\Principal\Domain\Entity\Principal as AccountPrincipal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier as AccountPrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Shared\Domain\ValueObject\Language;
-use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier as WikiPrincipalIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -102,11 +104,13 @@ class AuthContextCacheTest extends TestCase
     public function testResolveAccountSerializesAndDeserializes(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new AccountPrincipalIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
 
         Redis::shouldReceive('get')->once()->andReturn(json_encode([
+            'principalIdentifier' => (string) $principalIdentifier,
+            'identityIdentifier' => (string) $identityIdentifier,
             'accountIdentifier' => (string) $accountIdentifier,
-            'role' => 'admin',
         ]));
         Redis::shouldReceive('setex')->never();
 
@@ -115,14 +119,51 @@ class AuthContextCacheTest extends TestCase
             fn () => throw new RuntimeException('DB resolver must not be called'),
         );
 
-        $this->assertSame((string) $accountIdentifier, (string) $context->accountIdentifier);
-        $this->assertSame(AccountRole::ADMIN, $context->role);
+        $this->assertSame((string) $principalIdentifier, (string) $context->principal()->principalIdentifier());
+        $this->assertSame((string) $identityIdentifier, (string) $context->principal()->identityIdentifier());
+        $this->assertSame((string) $accountIdentifier, (string) $context->principal()->accountIdentifier());
+    }
+
+    public function testResolveAccountFallsBackToDbAndStoresPrincipalContextOnOldPayload(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new AccountPrincipalIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+
+        Redis::shouldReceive('get')->once()->andReturn(json_encode([
+            'accountIdentifier' => (string) $accountIdentifier,
+            'role' => 'admin',
+        ]));
+        Redis::shouldReceive('setex')
+            ->once()
+            ->withArgs(function (
+                string $key,
+                int $ttl,
+                string $payload,
+            ) use ($identityIdentifier, $principalIdentifier, $accountIdentifier): bool {
+                $decoded = json_decode($payload, true);
+
+                return $key === 'auth-context:account:' . $identityIdentifier
+                    && $ttl === 3600
+                    && $decoded['principalIdentifier'] === (string) $principalIdentifier
+                    && $decoded['identityIdentifier'] === (string) $identityIdentifier
+                    && $decoded['accountIdentifier'] === (string) $accountIdentifier;
+            });
+
+        $context = (new AuthContextCache())->resolveAccount(
+            $identityIdentifier,
+            fn () => new AccountContext(
+                new AccountPrincipal($principalIdentifier, $identityIdentifier, $accountIdentifier),
+            ),
+        );
+
+        $this->assertSame((string) $principalIdentifier, (string) $context->principal()->principalIdentifier());
     }
 
     public function testResolveWikiSerializesAndDeserializes(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new WikiPrincipalIdentifier(StrTestHelper::generateUuid());
 
         Redis::shouldReceive('get')->once()->andReturn(json_encode([
             'principalIdentifier' => (string) $principalIdentifier,
@@ -131,7 +172,7 @@ class AuthContextCacheTest extends TestCase
 
         $context = (new AuthContextCache())->resolveWiki(
             $identityIdentifier,
-            fn () => new WikiContext(new PrincipalIdentifier(StrTestHelper::generateUuid())),
+            fn () => new WikiContext(new WikiPrincipalIdentifier(StrTestHelper::generateUuid())),
         );
 
         $this->assertSame((string) $principalIdentifier, (string) $context->principalIdentifier);

--- a/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
+++ b/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
@@ -119,6 +119,7 @@ class AuthenticatedRouteProtectionTest extends TestCase
             'identity: update me' => ['PATCH', '/api/identity/identities/me'],
 
             // Account: signup 用の POST /accounts 以外は認証必須
+            'account: update account' => ['PATCH', '/api/account/accounts/00000000-0000-0000-0000-000000000001'],
             'account: delete account' => ['DELETE', '/api/account/accounts/00000000-0000-0000-0000-000000000001'],
             'account: request delegation' => ['POST', '/api/account/delegations'],
             'account: create invitation' => ['POST', '/api/account/invitations'],
@@ -167,6 +168,7 @@ class AuthenticatedRouteProtectionTest extends TestCase
         return [
             'identity authenticated routes resolve actor for me' => ['GET', '/api/identity/auth/me', ['resolve.actor']],
             'account authenticated routes resolve actor and account' => ['POST', '/api/account/delegations', ['resolve.actor', 'resolve.account']],
+            'account update resolves actor' => ['PATCH', '/api/account/accounts/00000000-0000-0000-0000-000000000001', ['resolve.actor']],
             'monetization routes resolve actor from bootstrap group' => ['POST', '/api/monetization/accounts', ['resolve.actor']],
             'wiki commands resolve actor and wiki' => ['POST', '/api/wiki/wiki/create', ['resolve.actor', 'resolve.wiki']],
             'wiki my draft resolves actor and wiki' => ['GET', '/api/wiki/wiki/ja/group/group-slug/my/draft', ['resolve.actor', 'resolve.wiki']],

--- a/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
+++ b/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
@@ -26,6 +26,7 @@ class GetAuthenticatedIdentityTest extends TestCase
     {
         $accountIdentifier = new AccountIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5aa');
         $principalGroupIdentifier = new PrincipalGroupIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5bb');
+        $principalIdentifier = '019de7f3-78f3-7b55-9ed5-17f63e14d5cc';
         $identityIdentifier = new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5fe');
         CreateAccount::create((string) $accountIdentifier);
         CreateIdentity::create($identityIdentifier, [
@@ -35,10 +36,17 @@ class GetAuthenticatedIdentityTest extends TestCase
             'profile_image' => 'profile/test.png',
         ]);
         CreateAccountPrincipalGroup::create($principalGroupIdentifier, $accountIdentifier);
+        DB::table('account_principals')->insert([
+            'id' => $principalIdentifier,
+            'identity_id' => (string) $identityIdentifier,
+            'account_id' => (string) $accountIdentifier,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
         DB::table('account_principal_group_memberships')->insert([
             'id' => StrTestHelper::generateUuid(),
             'principal_group_id' => (string) $principalGroupIdentifier,
-            'principal_id' => (string) $identityIdentifier,
+            'principal_id' => $principalIdentifier,
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/tests/Wiki/Principal/Http/Action/Command/CreatePrincipal/CreatePrincipalActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/CreatePrincipal/CreatePrincipalActionTest.php
@@ -183,13 +183,22 @@ class CreatePrincipalActionTest extends TestCase
                 'account_principal_group_memberships.principal_group_id'
             )
             ->andReturnSelf();
+        $query->shouldReceive('join')
+            ->once()
+            ->with(
+                'account_principals',
+                'account_principal_group_memberships.principal_id',
+                '=',
+                'account_principals.id'
+            )
+            ->andReturnSelf();
         $query->shouldReceive('where')
             ->once()
             ->with('account_principal_groups.account_id', $accountIdentifier)
             ->andReturnSelf();
         $query->shouldReceive('where')
             ->once()
-            ->with('account_principal_group_memberships.principal_id', $identityIdentifier)
+            ->with('account_principals.identity_id', $identityIdentifier)
             ->andReturnSelf();
         $query->shouldReceive('exists')
             ->once()

--- a/typespec/services/account-api/account.tsp
+++ b/typespec/services/account-api/account.tsp
@@ -3,6 +3,12 @@ using KPool.Common;
 
 namespace KPool.AccountApi;
 
+@doc("Request body for updating account information.")
+model UpdateAccountRequestBody {
+  @doc("Updated account display name.")
+  accountName: string;
+}
+
 @doc("Request body for creating an account.")
 model CreateAccountRequestBody {
   @doc("Account email address.")
@@ -34,6 +40,14 @@ interface AccountOperations {
   createAccount(
     @body body: CreateAccountRequestBody,
   ): CreateAccountResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @patch
+  @route("/{accountId}")
+  @doc("Update account information.")
+  updateAccount(
+    @path accountId: Uuid,
+    @body body: UpdateAccountRequestBody,
+  ): OkAccountResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @delete
   @route("/{accountId}")


### PR DESCRIPTION
## 📝 変更内容

- `PATCH /api/account/accounts/{accountId}` を追加し、`accountName` の更新に対応しました。
- `UpdateAccount` UseCase を追加し、対象 Account に所属する `owner` / `admin` の actor のみ更新できるようにしました。
- `Account` entity に `changeName()` を追加し、既存 `AccountRepository::save()` で更新後の `name` が保存されることを確認するテストを追加しました。
- TypeSpec と `doc/openapi/KPool.AccountApi.openapi.yaml` を更新しました。
- 追加ルートが `auth.api` / `resolve.actor` 配下であることを `AuthenticatedRouteProtectionTest` で検証しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

アカウント作成後にアカウント名を更新する Account API が存在しなかったため、初期スコープとして `accountName` のみを更新できるアカウント情報更新エンドポイントを追加しました。

権限判定は対象 Account 内の principal group 所属を参照し、別 Account の owner/admin では更新できないようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `pnpm run typespec:compile` を実行し、OpenAPI が生成できることを確認
- [x] `docker-compose run --rm --no-deps php ./vendor/bin/phpunit --exclude-group useDb tests/Account/Account/Domain/Entity/AccountTest.php tests/Account/Account/Application/UseCase/Command/UpdateAccount tests/Account/Account/Http/Action/Command/UpdateAccount/UpdateAccountActionTest.php tests/Http/Middleware/AuthenticatedRouteProtectionTest.php` を実行し、追加・関連テストがパスすることを確認
- [x] `docker-compose up -d testing_db testing_redis && sleep 5 && docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php ./vendor/bin/phpunit tests/Account/Account/Infrastructure/Repository/AccountRepositoryTest.php` を実行し、Repository の DB テストがパスすることを確認
- [x] `task check` を実行し、CS Fixer / PHPStan / 全 PHPUnit テストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`: OK (PHPStan No errors、PHPUnit 2864 tests / 9098 assertions)
- `pnpm run typespec:compile`: Compilation completed successfully

## 🔍 レビューのポイント

- `UpdateAccount` UseCase の権限判定が「対象 Account に所属する owner/admin」に限定されていること
- `UpdateAccountAction` の例外変換が not found / forbidden / validation error を適切な ProblemDetails にしていること
- TypeSpec / OpenAPI の `PATCH /accounts/{accountId}` と request/response 定義が API 実装と一致していること
- 追加ルートが `auth.api` / `resolve.actor` middleware 配下にあること

## 📖 関連情報

### 関連Issue・タスク

Closes #462

## ⚠️ 注意事項

- 初期スコープに合わせて更新対象は `accountName` のみに限定しています。
- マイグレーションはありません。
- 指定の `qa-review` / `test-review` / `security-review` / `architecture-review` スキルは Hermes グローバル、Codex、リポジトリローカルで見つからなかったため、代替として同観点のインラインレビューを実施しました。
  - QA: 受け入れ条件（成功、not found、validation、権限なし、ルート保護）を追加テストで確認しました。
  - Test: UseCase / Domain / Repository / HTTP Action / Route middleware テストを追加し、`task check` まで通しました。
  - Security: 更新ルートを `auth.api` / `resolve.actor` 配下に追加し、対象 Account 所属 owner/admin のみ許可する実装を確認しました。
  - Architecture: 既存 command UseCase / Action / FormRequest / Output の構成に合わせ、Repository は既存 `save()` を再利用しました。
- 未対応のレビュー指摘はありません。

## 📸 スクリーンショット・デモ

API のバックエンド変更のため、スクリーンショットはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
