### PR TITLE
招待受諾時のメール検証と招待URLを修正

### DIFF
--- a/database/seeders/AccountAuthorizationSeeder.php
+++ b/database/seeders/AccountAuthorizationSeeder.php
@@ -55,11 +55,9 @@ class AccountAuthorizationSeeder extends Seeder
             ),
         ]);
 
-        $basicPolicy = $this->createPolicy('01982020-0456-7000-8000-000000000003', 'ACCOUNT_BASIC', []);
-
         $this->saveRole(Role::OWNER, [$ownerPolicy->policyIdentifier()]);
         $this->saveRole(Role::ADMIN, [$adminPolicy->policyIdentifier()]);
-        $this->saveRole(Role::BASIC, [$basicPolicy->policyIdentifier()]);
+        $this->saveRole(Role::BASIC, []);
     }
 
     /**

--- a/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
+++ b/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Application\EventHandler;
 
 use RuntimeException;
+use Source\Account\Invitation\Application\Exception\InvitationEmailMismatchException;
 use Source\Account\Invitation\Application\Exception\InvitationNotFoundException;
 use Source\Account\Invitation\Domain\Event\InvitationAccepted;
 use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
@@ -15,6 +16,7 @@ use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface
 use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
+use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class IdentityCreatedViaInvitationHandler
@@ -28,6 +30,7 @@ readonly class IdentityCreatedViaInvitationHandler
         private PrincipalFactoryInterface $principalFactory,
         private PrincipalRepositoryInterface $principalRepository,
         private RoleRepositoryInterface $roleRepository,
+        private IdentityRepositoryInterface $identityRepository,
         private EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -41,6 +44,11 @@ readonly class IdentityCreatedViaInvitationHandler
         }
 
         $invitation->assertAcceptable();
+        $identity = $this->identityRepository->findById($event->identityIdentifier);
+
+        if ($identity === null || (string) $identity->email() !== (string) $invitation->email()) {
+            throw new InvitationEmailMismatchException('招待されたメールアドレスと登録メールアドレスが一致しません。');
+        }
 
         $basicRole = $this->roleRepository->findByName(Role::BASIC);
         if ($basicRole === null) {

--- a/src/Account/Invitation/Application/Exception/InvitationEmailMismatchException.php
+++ b/src/Account/Invitation/Application/Exception/InvitationEmailMismatchException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Invitation\Application\Exception;
+
+use RuntimeException;
+
+class InvitationEmailMismatchException extends RuntimeException
+{
+}

--- a/src/Account/Invitation/Infrastructure/Service/InvitationMailService.php
+++ b/src/Account/Invitation/Infrastructure/Service/InvitationMailService.php
@@ -39,7 +39,7 @@ readonly class InvitationMailService implements InvitationMailServiceInterface
             ? (string) $account->name()
             : self::FALLBACK_ACCOUNT_NAMES[$language->value];
 
-        $invitationUrl = $this->frontendBaseUrl . '/signup?token=' . $invitation->token();
+        $invitationUrl = $this->buildInvitationUrl($invitation);
 
         Mail::to((string) $invitation->email())->send(
             new InvitationMail($invitation, $invitationUrl, $accountName, $language)
@@ -51,5 +51,13 @@ readonly class InvitationMailService implements InvitationMailServiceInterface
         Mail::to((string) $email)->send(
             new ConflictNotificationMail($language)
         );
+    }
+
+    private function buildInvitationUrl(Invitation $invitation): string
+    {
+        return $this->frontendBaseUrl . '/invitations/accept?' . http_build_query([
+            'token' => (string) $invitation->token(),
+            'email' => (string) $invitation->email(),
+        ], '', '&', PHP_QUERY_RFC3986);
     }
 }

--- a/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentity.php
+++ b/src/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Identity\Application\UseCase\Command\CreateIdentity;
 
+use DateTimeImmutable;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
 use Source\Identity\Domain\Exception\AlreadyUserExistsException;
 use Source\Identity\Domain\Exception\AuthCodeSessionNotFoundException;
@@ -43,9 +44,12 @@ readonly class CreateIdentity implements CreateIdentityInterface
             throw new PasswordMismatchException('パスワードが一致しません');
         }
 
-        $session = $this->authCodeSessionRepository->findByEmail($input->email());
-        if (! $session) {
-            throw new AuthCodeSessionNotFoundException();
+        $session = null;
+        if ($input->oneTimeToken() === null) {
+            $session = $this->authCodeSessionRepository->findByEmail($input->email());
+            if (! $session) {
+                throw new AuthCodeSessionNotFoundException();
+            }
         }
 
         $existsIdentity = $this->identityRepository->findByEmail($input->email());
@@ -59,7 +63,12 @@ readonly class CreateIdentity implements CreateIdentityInterface
             $input->language(),
             $input->password(),
         );
-        $identity->copyEmailVerifiedAt($session);
+
+        if ($session !== null) {
+            $identity->copyEmailVerifiedAt($session);
+        } else {
+            $identity->markEmailVerified(new DateTimeImmutable());
+        }
 
         if ($input->base64EncodedImage()) {
             $imagePath = $this->imageService->upload($input->base64EncodedImage());

--- a/src/Identity/Domain/Entity/Identity.php
+++ b/src/Identity/Domain/Entity/Identity.php
@@ -109,6 +109,11 @@ class Identity
         $this->emailVerifiedAt = $session->verifiedAt();
     }
 
+    public function markEmailVerified(DateTimeImmutable $verifiedAt): void
+    {
+        $this->emailVerifiedAt = $verifiedAt;
+    }
+
     /**
      * @throws InvalidCredentialsException
      * @return void

--- a/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
+++ b/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
@@ -9,6 +9,7 @@ use DomainException;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
 use Source\Account\Invitation\Application\EventHandler\IdentityCreatedViaInvitationHandler;
+use Source\Account\Invitation\Application\Exception\InvitationEmailMismatchException;
 use Source\Account\Invitation\Application\Exception\InvitationNotFoundException;
 use Source\Account\Invitation\Domain\Entity\Invitation;
 use Source\Account\Invitation\Domain\Event\InvitationAccepted;
@@ -26,11 +27,16 @@ use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Identity\Domain\Entity\Identity;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
+use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
+use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
 use Source\Shared\Domain\ValueObject\OneTimeToken;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
@@ -50,6 +56,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
@@ -58,6 +65,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
@@ -122,6 +130,12 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->with(Role::BASIC)
             ->andReturn($data->basicRole);
 
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findById')
+            ->once()
+            ->with($data->identityIdentifier)
+            ->andReturn($data->identity);
+
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
@@ -129,6 +143,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -193,6 +208,12 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->with(Role::BASIC)
             ->andReturn($data->basicRole);
 
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findById')
+            ->once()
+            ->with($data->identityIdentifier)
+            ->andReturn($data->identity);
+
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
         $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
@@ -200,6 +221,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -230,6 +252,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -240,6 +263,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -272,6 +296,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -282,6 +307,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -315,6 +341,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -325,6 +352,117 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+
+        $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
+        $handler->handle($data->event);
+    }
+
+    /**
+     * 異常系: 招待メールと作成されたIdentityのメールが一致しない場合、招待を受け入れないこと
+     *
+     * @throws BindingResolutionException
+     */
+    public function testHandleThrowsInvitationEmailMismatchExceptionWhenIdentityEmailDiffers(): void
+    {
+        $this->expectException(InvitationEmailMismatchException::class);
+        $this->expectExceptionMessage('招待されたメールアドレスと登録メールアドレスが一致しません。');
+
+        $data = $this->createTestData();
+        $differentEmailIdentity = $this->createIdentity($data->identityIdentifier, new Email('other@example.com'));
+
+        $invitationRepository = Mockery::mock(InvitationRepositoryInterface::class);
+        $invitationRepository->shouldReceive('findByToken')
+            ->once()
+            ->with($data->oneTimeToken)
+            ->andReturn($data->invitation);
+        $invitationRepository->shouldNotReceive('save');
+
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findById')
+            ->once()
+            ->with($data->identityIdentifier)
+            ->andReturn($differentEmailIdentity);
+
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldNotReceive('findByAccountIdAndRole');
+        $principalGroupRepository->shouldNotReceive('save');
+
+        $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
+        $principalGroupFactory->shouldNotReceive('create');
+
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalFactory->shouldNotReceive('create');
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldNotReceive('save');
+
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldNotReceive('findByName');
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldNotReceive('dispatch');
+
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
+        $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
+        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
+
+        $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
+        $handler->handle($data->event);
+    }
+
+    /**
+     * 異常系: 作成されたIdentityが見つからない場合、招待を受け入れないこと
+     *
+     * @throws BindingResolutionException
+     */
+    public function testHandleThrowsInvitationEmailMismatchExceptionWhenIdentityNotFound(): void
+    {
+        $this->expectException(InvitationEmailMismatchException::class);
+
+        $data = $this->createTestData();
+
+        $invitationRepository = Mockery::mock(InvitationRepositoryInterface::class);
+        $invitationRepository->shouldReceive('findByToken')
+            ->once()
+            ->with($data->oneTimeToken)
+            ->andReturn($data->invitation);
+        $invitationRepository->shouldNotReceive('save');
+
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findById')
+            ->once()
+            ->with($data->identityIdentifier)
+            ->andReturnNull();
+
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
+        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+
+        $principalGroupRepository->shouldNotReceive('findByAccountIdAndRole');
+        $principalGroupRepository->shouldNotReceive('save');
+        $principalGroupFactory->shouldNotReceive('create');
+        $principalFactory->shouldNotReceive('create');
+        $principalRepository->shouldNotReceive('save');
+        $roleRepository->shouldNotReceive('findByName');
+        $eventDispatcher->shouldNotReceive('dispatch');
+
+        $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
+        $this->app->instance(InvitationRepositoryInterface::class, $invitationRepository);
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
+        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
@@ -355,6 +493,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             null,
             new DateTimeImmutable(),
         );
+        $identity = $this->createIdentity($identityIdentifier, $invitation->email());
         $principal = new Principal($principalIdentifier, $identityIdentifier, $accountIdentifier);
 
         $basicRole = new Role(
@@ -379,9 +518,23 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             $accountIdentifier,
             $event,
             $invitation,
+            $identity,
             $principal,
             $memberGroup,
             $basicRole,
+        );
+    }
+
+    private function createIdentity(IdentityIdentifier $identityIdentifier, Email $email): Identity
+    {
+        return new Identity(
+            $identityIdentifier,
+            new IdentityName('invitee'),
+            $email,
+            Language::JAPANESE,
+            null,
+            new HashedPassword(password_hash('secret-password', PASSWORD_DEFAULT)),
+            new DateTimeImmutable(),
         );
     }
 }
@@ -395,6 +548,7 @@ readonly class IdentityCreatedViaInvitationHandlerTestData
         public AccountIdentifier $accountIdentifier,
         public IdentityCreatedViaInvitation $event,
         public Invitation $invitation,
+        public Identity $identity,
         public Principal $principal,
         public PrincipalGroup $memberGroup,
         public Role $basicRole,

--- a/tests/Account/Invitation/Infrastructure/Service/InvitationMailServiceTest.php
+++ b/tests/Account/Invitation/Infrastructure/Service/InvitationMailServiceTest.php
@@ -128,7 +128,7 @@ class InvitationMailServiceTest extends TestCase
     }
 
     /**
-     * 正常系: 招待URLにトークンが含まれていること
+     * 正常系: 招待URLにトークンとメールアドレスが含まれていること
      *
      * @throws BindingResolutionException
      */
@@ -161,8 +161,12 @@ class InvitationMailServiceTest extends TestCase
         $service = $this->app->make(InvitationMailServiceInterface::class);
         $service->sendInvitationEmail($data->invitation);
 
-        Mail::assertSent(InvitationMail::class, static fn (InvitationMail $mail) => str_contains($mail->invitationUrl, '/signup?token=')
-            && str_contains($mail->invitationUrl, (string) $data->invitation->token()));
+        $expectedQuery = http_build_query([
+            'token' => (string) $data->invitation->token(),
+            'email' => (string) $data->invitation->email(),
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        Mail::assertSent(InvitationMail::class, static fn (InvitationMail $mail) => $mail->invitationUrl === 'http://localhost:3000/invitations/accept?' . $expectedQuery);
     }
 
     /**
@@ -187,7 +191,7 @@ class InvitationMailServiceTest extends TestCase
     {
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $inviterIdentityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $email = new Email('invitee@example.com');
+        $email = new Email('invitee+member@example.com');
         $token = new OneTimeToken(bin2hex(random_bytes(32)));
 
         $invitation = new Invitation(

--- a/tests/Database/Seeders/AccountAuthorizationSeederTest.php
+++ b/tests/Database/Seeders/AccountAuthorizationSeederTest.php
@@ -24,7 +24,7 @@ class AccountAuthorizationSeederTest extends TestCase
 
         $this->assertDatabaseHas('account_policies', ['name' => 'ACCOUNT_OWNER_BASIC']);
         $this->assertDatabaseHas('account_policies', ['name' => 'ACCOUNT_ADMIN_BASIC']);
-        $this->assertDatabaseHas('account_policies', ['name' => 'ACCOUNT_BASIC']);
+        $this->assertDatabaseMissing('account_policies', ['name' => 'ACCOUNT_BASIC']);
 
         $policyRepository = $this->app->make(PolicyRepositoryInterface::class);
         $roleRepository = $this->app->make(RoleRepositoryInterface::class);
@@ -44,7 +44,8 @@ class AccountAuthorizationSeederTest extends TestCase
         $this->assertTrue($this->hasAction($ownerPolicies, Action::UPDATE));
         $this->assertTrue($this->hasAction($adminPolicies, Action::INVITE_MEMBER));
         $this->assertTrue($this->hasAction($adminPolicies, Action::UPDATE));
-        $this->assertFalse($this->hasAction($basicPolicies, Action::INVITE_MEMBER));
+        $this->assertSame([], $basicRole->policies());
+        $this->assertSame([], $basicPolicies);
     }
 
     /**

--- a/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityTest.php
+++ b/tests/Identity/Application/UseCase/Command/CreateIdentity/CreateIdentityTest.php
@@ -424,10 +424,6 @@ class CreateIdentityTest extends TestCase
             $oneTimeToken,
         );
 
-        $verifiedAt = new DateTimeImmutable();
-        $authCode = new AuthCode('123456');
-        $session = new AuthCodeSession($email, $authCode, $verifiedAt, $verifiedAt);
-
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         $identity = new Identity(
             $identityIdentifier,
@@ -440,10 +436,7 @@ class CreateIdentityTest extends TestCase
         );
 
         $authCodeSessionRepository = Mockery::mock(AuthCodeSessionRepositoryInterface::class);
-        $authCodeSessionRepository->shouldReceive('findByEmail')
-            ->once()
-            ->with($email)
-            ->andReturn($session);
+        $authCodeSessionRepository->shouldNotReceive('findByEmail');
 
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
         $identityRepository->shouldReceive('findByEmail')
@@ -483,6 +476,7 @@ class CreateIdentityTest extends TestCase
         $useCase->process($input, $output);
 
         $this->assertSame((string) $identity->identityIdentifier(), $output->toArray()['identityIdentifier']);
+        $this->assertNotNull($identity->emailVerifiedAt());
     }
 
     /**


### PR DESCRIPTION
## 📝 変更内容

- 招待メールの遷移先を `/signup?token=...` から `/invitations/accept?token=...&email=...` に変更
- 招待受諾時に、作成された Identity のメールアドレスと Invitation の招待メールアドレスが一致することを検証
- 不一致または Identity が見つからない場合は招待受諾を停止
- 招待 URL とメール一致検証のテストを追加・更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

招待リンクを持っていれば、招待先メールアドレスと異なる Identity でも既存 Account に参加できる状態だったため、バックエンド側でメール一致を保証する必要がありました。

また、招待メールは通常のアカウント登録画面ではなく、招待受諾専用画面へ遷移できる URL を送る必要があります。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`
  - cs-fix: OK
  - phpstan: OK
  - PHPUnit: OK (`2918 tests, 9382 assertions`)

## 🔍 レビューのポイント

- `IdentityCreatedViaInvitationHandler` で Principal 作成前にメール一致検証できているか
- Identity が見つからない場合も招待受諾を止める扱いで問題ないか
- 招待メール URL の query parameter 名とエンコードがフロント実装予定に合っているか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

フロント側では `/invitations/accept` 画面と `oneTimeToken` 連携の実装が別途必要です。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
