### PR TITLE
src配下の独自例外の継承元と例外チェーン対応を整理

### DIFF
--- a/application/Http/Action/Monetization/Payment/Command/AuthorizePayment/AuthorizePaymentAction.php
+++ b/application/Http/Action/Monetization/Payment/Command/AuthorizePayment/AuthorizePaymentAction.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Source\Monetization\Account\Domain\ValueObject\MonetizationAccountIdentifier;
+use Source\Monetization\Payment\Application\Exception\ApiException;
 use Source\Monetization\Payment\Application\UseCase\Command\AuthorizePayment\AuthorizePaymentInput;
 use Source\Monetization\Payment\Application\UseCase\Command\AuthorizePayment\AuthorizePaymentInterface;
 use Source\Monetization\Payment\Application\UseCase\Command\AuthorizePayment\AuthorizePaymentOutput;
@@ -75,6 +76,11 @@ readonly class AuthorizePaymentAction
                 DB::rollBack();
 
                 throw new InternalServerErrorHttpException(detail: error_message('payment_gateway_error', $language), previous: $e);
+            } catch (ApiException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
             } catch (Throwable $e) {
                 DB::rollBack();
 

--- a/application/Http/Action/Monetization/Payment/Command/CapturePayment/CapturePaymentAction.php
+++ b/application/Http/Action/Monetization/Payment/Command/CapturePayment/CapturePaymentAction.php
@@ -12,6 +12,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Source\Monetization\Payment\Application\Exception\ApiException;
 use Source\Monetization\Payment\Application\UseCase\Command\CapturePayment\CapturePaymentInput;
 use Source\Monetization\Payment\Application\UseCase\Command\CapturePayment\CapturePaymentInterface;
 use Source\Monetization\Payment\Application\UseCase\Command\CapturePayment\CapturePaymentOutput;
@@ -69,6 +70,11 @@ readonly class CapturePaymentAction
                 $this->logger->error((string) $e);
 
                 throw new InternalServerErrorHttpException(detail: error_message('payment_gateway_error', $language), previous: $e);
+            } catch (ApiException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
             } catch (Throwable $e) {
                 DB::rollBack();
                 $this->logger->error((string) $e);

--- a/application/Http/Action/Monetization/Payment/Command/RefundPayment/RefundPaymentAction.php
+++ b/application/Http/Action/Monetization/Payment/Command/RefundPayment/RefundPaymentAction.php
@@ -12,6 +12,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Source\Monetization\Payment\Application\Exception\ApiException;
 use Source\Monetization\Payment\Application\UseCase\Command\RefundPayment\RefundPaymentInput;
 use Source\Monetization\Payment\Application\UseCase\Command\RefundPayment\RefundPaymentInterface;
 use Source\Monetization\Payment\Application\UseCase\Command\RefundPayment\RefundPaymentOutput;
@@ -85,6 +86,11 @@ readonly class RefundPaymentAction
                 $this->logger->error((string) $e);
 
                 throw new InternalServerErrorHttpException(detail: error_message('payment_gateway_error', $language), previous: $e);
+            } catch (ApiException $e) {
+                DB::rollBack();
+                $this->logger->error((string) $e);
+
+                throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
             } catch (Throwable $e) {
                 DB::rollBack();
                 $this->logger->error((string) $e);

--- a/src/Account/Account/Application/Exception/AccountAlreadyExistsException.php
+++ b/src/Account/Account/Application/Exception/AccountAlreadyExistsException.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class AccountAlreadyExistsException extends Exception
+class AccountAlreadyExistsException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Account Already Exists',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Account/Application/Exception/AccountNotFoundException.php
+++ b/src/Account/Account/Application/Exception/AccountNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class AccountNotFoundException extends Exception
+class AccountNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Account is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Account/Application/Exception/AccountUpdateForbiddenException.php
+++ b/src/Account/Account/Application/Exception/AccountUpdateForbiddenException.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class AccountUpdateForbiddenException extends Exception
+class AccountUpdateForbiddenException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Account Update Forbidden',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Account/Application/Exception/AccountVerificationAlreadyRequestedException.php
+++ b/src/Account/Account/Application/Exception/AccountVerificationAlreadyRequestedException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Account\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class AccountVerificationAlreadyRequestedException extends RuntimeException
 {
-    public function __construct(string $message = 'A verification request is already pending or under review.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'A verification request is already pending or under review.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Account/Application/Exception/AccountVerificationNotFoundException.php
+++ b/src/Account/Account/Application/Exception/AccountVerificationNotFoundException.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\Exception;
 
-use Exception;
+use RuntimeException;
 use Throwable;
 
-class AccountVerificationNotFoundException extends Exception
+class AccountVerificationNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Account verification not found.',
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Account/Account/Application/Exception/DocumentStorageFailedException.php
+++ b/src/Account/Account/Application/Exception/DocumentStorageFailedException.php
@@ -9,8 +9,10 @@ use Throwable;
 
 class DocumentStorageFailedException extends RuntimeException
 {
-    public function __construct(string $message = 'Failed to store verification documents.', ?Throwable $previous = null)
-    {
+    public function __construct(
+        string $message = 'Failed to store verification documents.',
+        ?Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Account/Application/Exception/InvalidAccountCategoryForVerificationException.php
+++ b/src/Account/Account/Application/Exception/InvalidAccountCategoryForVerificationException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Account\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class InvalidAccountCategoryForVerificationException extends RuntimeException
 {
-    public function __construct(string $message = 'Only GENERAL accounts can request verification.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Only GENERAL accounts can request verification.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Account/Application/Exception/InvalidDocumentsForVerificationException.php
+++ b/src/Account/Account/Application/Exception/InvalidDocumentsForVerificationException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Account\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class InvalidDocumentsForVerificationException extends RuntimeException
 {
-    public function __construct(string $message = 'Invalid or missing documents for verification.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Invalid or missing documents for verification.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Account/Domain/Exception/InvalidVerificationApprovalException.php
+++ b/src/Account/Account/Domain/Exception/InvalidVerificationApprovalException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Account\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidVerificationApprovalException extends DomainException
 {
-    public function __construct(string $message = 'Only pending verifications can be approved.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Only pending verifications can be approved.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Account/Domain/Exception/InvalidVerificationRejectionException.php
+++ b/src/Account/Account/Domain/Exception/InvalidVerificationRejectionException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Account\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidVerificationRejectionException extends DomainException
 {
-    public function __construct(string $message = 'Only pending verifications can be rejected.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Only pending verifications can be rejected.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Affiliation/Application/Exception/AffiliationAlreadyExistsException.php
+++ b/src/Account/Affiliation/Application/Exception/AffiliationAlreadyExistsException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class AffiliationAlreadyExistsException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Affiliation Already Exists',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Affiliation/Application/Exception/AffiliationNotFoundException.php
+++ b/src/Account/Affiliation/Application/Exception/AffiliationNotFoundException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class AffiliationNotFoundException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Affiliation Not Found',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Affiliation/Application/Exception/DisallowedAffiliationOperationException.php
+++ b/src/Account/Affiliation/Application/Exception/DisallowedAffiliationOperationException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class DisallowedAffiliationOperationException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Disallowed Affiliation Operation',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Affiliation/Application/Exception/InvalidAccountCategoryException.php
+++ b/src/Account/Affiliation/Application/Exception/InvalidAccountCategoryException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class InvalidAccountCategoryException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Invalid Account Category',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Affiliation/Application/Exception/InvalidAffiliationStatusException.php
+++ b/src/Account/Affiliation/Application/Exception/InvalidAffiliationStatusException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class InvalidAffiliationStatusException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Invalid Affiliation Status',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Affiliation/Domain/Exception/InvalidAffiliationApprovalException.php
+++ b/src/Account/Affiliation/Domain/Exception/InvalidAffiliationApprovalException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidAffiliationApprovalException extends DomainException
 {
+    public function __construct(
+        string $message = 'Invalid Affiliation Approval',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Affiliation/Domain/Exception/InvalidAffiliationTerminationException.php
+++ b/src/Account/Affiliation/Domain/Exception/InvalidAffiliationTerminationException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidAffiliationTerminationException extends DomainException
 {
+    public function __construct(
+        string $message = 'Invalid Affiliation Termination',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Affiliation/Domain/Exception/InvalidAffiliationTermsUpdateException.php
+++ b/src/Account/Affiliation/Domain/Exception/InvalidAffiliationTermsUpdateException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidAffiliationTermsUpdateException extends DomainException
 {
+    public function __construct(
+        string $message = 'Invalid Affiliation Terms Update',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Delegation/Application/Exception/DelegationNotFoundException.php
+++ b/src/Account/Delegation/Application/Exception/DelegationNotFoundException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Delegation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class DelegationNotFoundException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Delegation Not Found',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Delegation/Application/Exception/DisallowedDelegationOperationException.php
+++ b/src/Account/Delegation/Application/Exception/DisallowedDelegationOperationException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Delegation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class DisallowedDelegationOperationException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Disallowed Delegation Operation',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Delegation/Domain/Exception/InvalidDelegationApprovalException.php
+++ b/src/Account/Delegation/Domain/Exception/InvalidDelegationApprovalException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Delegation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidDelegationApprovalException extends DomainException
 {
-    public function __construct(string $message = 'Only pending delegations can be approved.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Only pending delegations can be approved.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Delegation/Domain/Exception/InvalidDelegationRevocationException.php
+++ b/src/Account/Delegation/Domain/Exception/InvalidDelegationRevocationException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Delegation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidDelegationRevocationException extends DomainException
 {
-    public function __construct(string $message = 'Only approved delegations can be revoked.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Only approved delegations can be revoked.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/DelegationPermission/Application/Exception/DelegationPermissionNotFoundException.php
+++ b/src/Account/DelegationPermission/Application/Exception/DelegationPermissionNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\DelegationPermission\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class DelegationPermissionNotFoundException extends Exception
+class DelegationPermissionNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'DelegationPermission is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Invitation/Application/Exception/DisallowedInvitationException.php
+++ b/src/Account/Invitation/Application/Exception/DisallowedInvitationException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class DisallowedInvitationException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Disallowed Invitation',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Invitation/Application/Exception/InvitationNotFoundException.php
+++ b/src/Account/Invitation/Application/Exception/InvitationNotFoundException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class InvitationNotFoundException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Invitation Not Found',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Account/Invitation/Domain/Exception/InvitationAlreadyUsedOrRevokedException.php
+++ b/src/Account/Invitation/Domain/Exception/InvitationAlreadyUsedOrRevokedException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvitationAlreadyUsedOrRevokedException extends DomainException
 {
-    public function __construct(string $message = 'This invitation has already been used or revoked.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'This invitation has already been used or revoked.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Invitation/Domain/Exception/InvitationExpiredException.php
+++ b/src/Account/Invitation/Domain/Exception/InvitationExpiredException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvitationExpiredException extends DomainException
 {
-    public function __construct(string $message = 'This invitation link has expired.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'This invitation link has expired.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Invitation/Domain/Exception/InvitationNotPendingException.php
+++ b/src/Account/Invitation/Domain/Exception/InvitationNotPendingException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvitationNotPendingException extends DomainException
 {
-    public function __construct(string $message = 'Only pending invitations can be revoked.')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Only pending invitations can be revoked.',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Principal/Application/Exception/CannotDeleteDefaultPrincipalGroupException.php
+++ b/src/Account/Principal/Application/Exception/CannotDeleteDefaultPrincipalGroupException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class CannotDeleteDefaultPrincipalGroupException extends Exception
+class CannotDeleteDefaultPrincipalGroupException extends RuntimeException
 {
     public function __construct(
         string $message = 'Cannot delete default PrincipalGroup.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Principal/Application/Exception/CannotDeleteLastOwnerGroupException.php
+++ b/src/Account/Principal/Application/Exception/CannotDeleteLastOwnerGroupException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class CannotDeleteLastOwnerGroupException extends Exception
+class CannotDeleteLastOwnerGroupException extends RuntimeException
 {
     public function __construct(
         string $message = 'Cannot delete the last OWNER group with members.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Principal/Application/Exception/CannotRemoveLastOwnerException.php
+++ b/src/Account/Principal/Application/Exception/CannotRemoveLastOwnerException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class CannotRemoveLastOwnerException extends Exception
+class CannotRemoveLastOwnerException extends RuntimeException
 {
     public function __construct(
         string $message = 'Cannot remove the last OWNER from the account.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Principal/Application/Exception/PrincipalGroupNotFoundException.php
+++ b/src/Account/Principal/Application/Exception/PrincipalGroupNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class PrincipalGroupNotFoundException extends Exception
+class PrincipalGroupNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'PrincipalGroup is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Principal/Domain/Exception/PrincipalAlreadyMemberException.php
+++ b/src/Account/Principal/Domain/Exception/PrincipalAlreadyMemberException.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class PrincipalAlreadyMemberException extends DomainException
 {
     public function __construct(
         string $message = 'Principal is already a member of this group.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Account/Principal/Domain/Exception/PrincipalNotMemberException.php
+++ b/src/Account/Principal/Domain/Exception/PrincipalNotMemberException.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class PrincipalNotMemberException extends DomainException
 {
     public function __construct(
         string $message = 'Principal is not a member of this group.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/AlreadyUserExistsException.php
+++ b/src/Identity/Domain/Exception/AlreadyUserExistsException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class AlreadyUserExistsException extends Exception
+class AlreadyUserExistsException extends DomainException
 {
     public function __construct(
         string $message = 'User already exists.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/AuthCodeExpiredException.php
+++ b/src/Identity/Domain/Exception/AuthCodeExpiredException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class AuthCodeExpiredException extends Exception
+class AuthCodeExpiredException extends DomainException
 {
     public function __construct(
         string $message = 'Auth code has expired.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/AuthCodeSessionNotFoundException.php
+++ b/src/Identity/Domain/Exception/AuthCodeSessionNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class AuthCodeSessionNotFoundException extends Exception
+class AuthCodeSessionNotFoundException extends DomainException
 {
     public function __construct(
         string $message = 'Session is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/IdentityNotFoundException.php
+++ b/src/Identity/Domain/Exception/IdentityNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class IdentityNotFoundException extends Exception
+class IdentityNotFoundException extends DomainException
 {
     public function __construct(
         string $message = 'Identity is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/InvalidAuthCodeException.php
+++ b/src/Identity/Domain/Exception/InvalidAuthCodeException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class InvalidAuthCodeException extends Exception
+class InvalidAuthCodeException extends DomainException
 {
     public function __construct(
         string $message = 'Auth code does not match.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/InvalidCredentialsException.php
+++ b/src/Identity/Domain/Exception/InvalidCredentialsException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class InvalidCredentialsException extends Exception
+class InvalidCredentialsException extends DomainException
 {
     public function __construct(
         string $message = 'Invalid credentials.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/InvalidDelegationException.php
+++ b/src/Identity/Domain/Exception/InvalidDelegationException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class InvalidDelegationException extends Exception
+class InvalidDelegationException extends DomainException
 {
     public function __construct(
         string $message = 'Delegation is not valid.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/InvalidOAuthStateException.php
+++ b/src/Identity/Domain/Exception/InvalidOAuthStateException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class InvalidOAuthStateException extends Exception
+class InvalidOAuthStateException extends DomainException
 {
     public function __construct(
         string $message = 'OAuth state is invalid or expired.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/PasswordMismatchException.php
+++ b/src/Identity/Domain/Exception/PasswordMismatchException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class PasswordMismatchException extends Exception
+class PasswordMismatchException extends DomainException
 {
     public function __construct(
         string $message = 'Passwords do not match.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/SocialConnectionAlreadyExistsException.php
+++ b/src/Identity/Domain/Exception/SocialConnectionAlreadyExistsException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class SocialConnectionAlreadyExistsException extends Exception
+class SocialConnectionAlreadyExistsException extends DomainException
 {
     public function __construct(
         string $message = 'Social connection already exists.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Identity/Domain/Exception/UnauthorizedEmailException.php
+++ b/src/Identity/Domain/Exception/UnauthorizedEmailException.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Identity\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class UnauthorizedEmailException extends Exception
+class UnauthorizedEmailException extends DomainException
 {
-    public function __construct(string $message = 'Unauthorized email.', ?Exception $previous = null)
-    {
+    public function __construct(
+        string $message = 'Unauthorized email.',
+        ?Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Monetization/Account/Application/Exception/MonetizationAccountAlreadyExistsException.php
+++ b/src/Monetization/Account/Application/Exception/MonetizationAccountAlreadyExistsException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Account\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class MonetizationAccountAlreadyExistsException extends Exception
+class MonetizationAccountAlreadyExistsException extends RuntimeException
 {
     public function __construct(
         string $message = 'Monetization account already exists.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Monetization/Account/Domain/Exception/CapabilityAlreadyGrantedException.php
+++ b/src/Monetization/Account/Domain/Exception/CapabilityAlreadyGrantedException.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Account\Domain\Exception;
 
-use Exception;
+use DomainException;
 use Source\Monetization\Account\Domain\ValueObject\Capability;
+use Throwable;
 
-class CapabilityAlreadyGrantedException extends Exception
+class CapabilityAlreadyGrantedException extends DomainException
 {
-    public function __construct(Capability $capability)
-    {
-        parent::__construct("Capability '{$capability->value}' is already granted.", 0);
+    public function __construct(
+        Capability $capability,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct("Capability '{$capability->value}' is already granted.", 0, $previous);
     }
 }

--- a/src/Monetization/Account/Domain/Exception/CapabilityNotGrantedException.php
+++ b/src/Monetization/Account/Domain/Exception/CapabilityNotGrantedException.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Account\Domain\Exception;
 
-use Exception;
+use DomainException;
 use Source\Monetization\Account\Domain\ValueObject\Capability;
+use Throwable;
 
-class CapabilityNotGrantedException extends Exception
+class CapabilityNotGrantedException extends DomainException
 {
-    public function __construct(Capability $capability)
-    {
-        parent::__construct("Capability '{$capability->value}' is not granted.", 0);
+    public function __construct(
+        Capability $capability,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct("Capability '{$capability->value}' is not granted.", 0, $previous);
     }
 }

--- a/src/Monetization/Account/Domain/Exception/ConnectedAccountAlreadyLinkedException.php
+++ b/src/Monetization/Account/Domain/Exception/ConnectedAccountAlreadyLinkedException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class ConnectedAccountAlreadyLinkedException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Stripe Connected Account already linked.', 0, $previous);
     }
 }

--- a/src/Monetization/Account/Domain/Exception/ConnectedAccountNotLinkedException.php
+++ b/src/Monetization/Account/Domain/Exception/ConnectedAccountNotLinkedException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class ConnectedAccountNotLinkedException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Stripe Connected Account is not linked.', 0, $previous);
     }
 }

--- a/src/Monetization/Account/Domain/Exception/MonetizationAccountNotFoundException.php
+++ b/src/Monetization/Account/Domain/Exception/MonetizationAccountNotFoundException.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Account\Domain\Exception;
 
-use Exception;
+use DomainException;
 use Source\Monetization\Account\Domain\ValueObject\ConnectedAccountId;
 use Source\Monetization\Account\Domain\ValueObject\MonetizationAccountIdentifier;
+use Throwable;
 
-class MonetizationAccountNotFoundException extends Exception
+class MonetizationAccountNotFoundException extends DomainException
 {
-    public function __construct(MonetizationAccountIdentifier|ConnectedAccountId $identifier)
-    {
-        parent::__construct(sprintf('Monetization account not found: %s', (string) $identifier));
+    public function __construct(
+        MonetizationAccountIdentifier|ConnectedAccountId $identifier,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(sprintf('Monetization account not found: %s', (string) $identifier), 0, $previous);
     }
 }

--- a/src/Monetization/Account/Domain/Exception/PaymentCustomerAlreadyLinkedException.php
+++ b/src/Monetization/Account/Domain/Exception/PaymentCustomerAlreadyLinkedException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class PaymentCustomerAlreadyLinkedException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Stripe Customer already linked.', 0, $previous);
     }
 }

--- a/src/Monetization/Account/Domain/Exception/PaymentCustomerNotLinkedException.php
+++ b/src/Monetization/Account/Domain/Exception/PaymentCustomerNotLinkedException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class PaymentCustomerNotLinkedException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Stripe Customer is not linked.', 0, $previous);
     }
 }

--- a/src/Monetization/Account/Infrastructure/Exception/StripeConnectException.php
+++ b/src/Monetization/Account/Infrastructure/Exception/StripeConnectException.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Account\Infrastructure\Exception;
 
-use Exception;
+use RuntimeException;
 
-class StripeConnectException extends Exception
+class StripeConnectException extends RuntimeException
 {
-    public function __construct(string $message, ?\Throwable $previous = null)
-    {
+    public function __construct(
+        string $message,
+        ?\Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Monetization/Billing/Domain/Exception/EmptyInvoiceLinesException.php
+++ b/src/Monetization/Billing/Domain/Exception/EmptyInvoiceLinesException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class EmptyInvoiceLinesException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('At least one product line is required.', 0, $previous);
     }
 }

--- a/src/Monetization/Billing/Domain/Exception/InvalidInvoiceAmountsException.php
+++ b/src/Monetization/Billing/Domain/Exception/InvalidInvoiceAmountsException.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Source\Monetization\Billing\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class InvalidInvoiceAmountsException extends DomainException
 {
-    public function __construct(string $message)
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Monetization/Billing/Domain/Exception/InvoiceNotFoundException.php
+++ b/src/Monetization/Billing/Domain/Exception/InvoiceNotFoundException.php
@@ -6,13 +6,14 @@ namespace Source\Monetization\Billing\Domain\Exception;
 
 use DomainException;
 use Source\Monetization\Billing\Domain\ValueObject\InvoiceIdentifier;
+use Throwable;
 
 class InvoiceNotFoundException extends DomainException
 {
-    public function __construct(InvoiceIdentifier $invoiceIdentifier)
-    {
-        parent::__construct(
-            sprintf('Invoice not found: %s', (string) $invoiceIdentifier)
-        );
+    public function __construct(
+        InvoiceIdentifier $invoiceIdentifier,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(sprintf('Invoice not found: %s', (string) $invoiceIdentifier), 0, $previous);
     }
 }

--- a/src/Monetization/Billing/Domain/Exception/InvoiceNotPayableException.php
+++ b/src/Monetization/Billing/Domain/Exception/InvoiceNotPayableException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class InvoiceNotPayableException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Invoice is not payable.', 0, $previous);
     }
 }

--- a/src/Monetization/Billing/Domain/Exception/InvoiceNotVoidableException.php
+++ b/src/Monetization/Billing/Domain/Exception/InvoiceNotVoidableException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class InvoiceNotVoidableException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Invoice is not voidable.', 0, $previous);
     }
 }

--- a/src/Monetization/Payment/Application/Exception/ApiException.php
+++ b/src/Monetization/Payment/Application/Exception/ApiException.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Payment\Application\Exception;
 
-use Source\Monetization\Payment\Domain\Exception\PaymentGatewayException;
+use RuntimeException;
 use Stripe\Exception\ApiErrorException;
+use Throwable;
 
-class ApiException extends PaymentGatewayException
+class ApiException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Api',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
     public static function from(ApiErrorException $e): self
     {
         return new self(

--- a/src/Monetization/Payment/Domain/Exception/PaymentNotFoundException.php
+++ b/src/Monetization/Payment/Domain/Exception/PaymentNotFoundException.php
@@ -10,12 +10,10 @@ use Throwable;
 
 class PaymentNotFoundException extends DomainException
 {
-    public function __construct(PaymentIdentifier $paymentIdentifier, ?Throwable $previous = null)
-    {
-        parent::__construct(
-            sprintf('Payment not found: %s', (string) $paymentIdentifier),
-            0,
-            $previous
-        );
+    public function __construct(
+        PaymentIdentifier $paymentIdentifier,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(sprintf('Payment not found: %s', (string) $paymentIdentifier), 0, $previous);
     }
 }

--- a/src/Monetization/Payment/Domain/Exception/RefundCurrencyMismatchException.php
+++ b/src/Monetization/Payment/Domain/Exception/RefundCurrencyMismatchException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class RefundCurrencyMismatchException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Refund currency must match payment currency.', 0, $previous);
     }
 }

--- a/src/Monetization/Payment/Domain/Exception/RefundExceedsCapturedAmountException.php
+++ b/src/Monetization/Payment/Domain/Exception/RefundExceedsCapturedAmountException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class RefundExceedsCapturedAmountException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Refund exceeds captured amount.', 0, $previous);
     }
 }

--- a/src/Monetization/Settlement/Domain/Exception/SettlementBatchNotFoundException.php
+++ b/src/Monetization/Settlement/Domain/Exception/SettlementBatchNotFoundException.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Settlement\Domain\Exception;
 
-use Exception;
+use DomainException;
 use Source\Monetization\Settlement\Domain\ValueObject\SettlementBatchIdentifier;
+use Throwable;
 
-class SettlementBatchNotFoundException extends Exception
+class SettlementBatchNotFoundException extends DomainException
 {
-    public function __construct(SettlementBatchIdentifier $settlementBatchIdentifier)
-    {
-        parent::__construct(sprintf('Settlement batch not found: %s', (string) $settlementBatchIdentifier));
+    public function __construct(
+        SettlementBatchIdentifier $settlementBatchIdentifier,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(sprintf('Settlement batch not found: %s', (string) $settlementBatchIdentifier), 0, $previous);
     }
 }

--- a/src/Monetization/Settlement/Domain/Exception/TransferGatewayException.php
+++ b/src/Monetization/Settlement/Domain/Exception/TransferGatewayException.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Settlement\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class TransferGatewayException extends Exception
+class TransferGatewayException extends DomainException
 {
+    public function __construct(
+        string $message = 'Transfer Gateway',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Monetization/Settlement/Domain/Exception/TransferNotFoundException.php
+++ b/src/Monetization/Settlement/Domain/Exception/TransferNotFoundException.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Settlement\Domain\Exception;
 
-use Exception;
+use DomainException;
 use Source\Monetization\Settlement\Domain\ValueObject\TransferIdentifier;
+use Throwable;
 
-class TransferNotFoundException extends Exception
+class TransferNotFoundException extends DomainException
 {
-    public function __construct(TransferIdentifier $transferIdentifier)
-    {
-        parent::__construct(sprintf('Transfer not found: %s', (string) $transferIdentifier));
+    public function __construct(
+        TransferIdentifier $transferIdentifier,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(sprintf('Transfer not found: %s', (string) $transferIdentifier), 0, $previous);
     }
 }

--- a/src/Monetization/Settlement/Infrastructure/Exception/StripeTransferException.php
+++ b/src/Monetization/Settlement/Infrastructure/Exception/StripeTransferException.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Monetization\Settlement\Infrastructure\Exception;
 
-use Source\Monetization\Settlement\Domain\Exception\TransferGatewayException;
+use RuntimeException;
 
-class StripeTransferException extends TransferGatewayException
+class StripeTransferException extends RuntimeException
 {
-    public function __construct(string $message, ?\Throwable $previous = null)
-    {
+    public function __construct(
+        string $message,
+        ?\Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Monetization/Settlement/Infrastructure/Service/TransferGateway.php
+++ b/src/Monetization/Settlement/Infrastructure/Service/TransferGateway.php
@@ -22,9 +22,6 @@ readonly class TransferGateway implements TransferGatewayInterface
     ) {
     }
 
-    /**
-     * @throws StripeTransferException
-     */
     public function execute(Transfer $transfer, MonetizationAccount $account): StripeTransferId
     {
         try {

--- a/src/Monetization/Shared/Exception/PaymentAmountMismatchForMatchingException.php
+++ b/src/Monetization/Shared/Exception/PaymentAmountMismatchForMatchingException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class PaymentAmountMismatchForMatchingException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Payment amount does not match invoice total.', 0, $previous);
     }
 }

--- a/src/Monetization/Shared/Exception/PaymentCurrencyMismatchForMatchingException.php
+++ b/src/Monetization/Shared/Exception/PaymentCurrencyMismatchForMatchingException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class PaymentCurrencyMismatchForMatchingException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Payment currency does not match invoice.', 0, $previous);
     }
 }

--- a/src/Monetization/Shared/Exception/PaymentNotCapturedForMatchingException.php
+++ b/src/Monetization/Shared/Exception/PaymentNotCapturedForMatchingException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class PaymentNotCapturedForMatchingException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Payment must be captured before matching to invoice.', 0, $previous);
     }
 }

--- a/src/Monetization/Shared/Exception/PaymentOrderMismatchException.php
+++ b/src/Monetization/Shared/Exception/PaymentOrderMismatchException.php
@@ -9,8 +9,9 @@ use Throwable;
 
 class PaymentOrderMismatchException extends DomainException
 {
-    public function __construct(?Throwable $previous = null)
-    {
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
         parent::__construct('Invoice and Payment are not for the same order.', 0, $previous);
     }
 }

--- a/src/Shared/Application/Exception/InvalidBase64ImageException.php
+++ b/src/Shared/Application/Exception/InvalidBase64ImageException.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Shared\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class InvalidBase64ImageException extends Exception
+class InvalidBase64ImageException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Invalid Base64 Image',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Shared/Application/Exception/InvalidRemoteImageException.php
+++ b/src/Shared/Application/Exception/InvalidRemoteImageException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Shared\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class InvalidRemoteImageException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Invalid Remote Image',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/SiteManagement/Announcement/Application/UseCase/Exception/AnnouncementNotFoundException.php
+++ b/src/SiteManagement/Announcement/Application/UseCase/Exception/AnnouncementNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\SiteManagement\Announcement\Application\UseCase\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class AnnouncementNotFoundException extends Exception
+class AnnouncementNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Announcement is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/SiteManagement/Contact/Application/UseCase/Exception/ContactNotFoundException.php
+++ b/src/SiteManagement/Contact/Application/UseCase/Exception/ContactNotFoundException.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 
 namespace Source\SiteManagement\Contact\Application\UseCase\Exception;
 
-use Exception;
+use RuntimeException;
 use Throwable;
 
-class ContactNotFoundException extends Exception
+class ContactNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Contact not found',
-        int $code = 0,
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/SiteManagement/Contact/Application/UseCase/Exception/FailedToSendEmailException.php
+++ b/src/SiteManagement/Contact/Application/UseCase/Exception/FailedToSendEmailException.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Source\SiteManagement\Contact\Application\UseCase\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class FailedToSendEmailException extends RuntimeException
 {
     public function __construct(
         string $message = 'Sending email is failed.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/SiteManagement/Shared/Domain/Exception/UnauthorizedException.php
+++ b/src/SiteManagement/Shared/Domain/Exception/UnauthorizedException.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Source\SiteManagement\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class UnauthorizedException extends Exception
+class UnauthorizedException extends DomainException
 {
-    public function __construct(string $message = 'Unauthorized action.', ?Exception $previous = null)
-    {
+    public function __construct(
+        string $message = 'Unauthorized action.',
+        ?Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
     }
 }

--- a/src/SiteManagement/User/Domain/Exception/AlreadyUserExistsException.php
+++ b/src/SiteManagement/User/Domain/Exception/AlreadyUserExistsException.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Source\SiteManagement\User\Domain\Exception;
 
-use Exception;
+use DomainException;
 use Throwable;
 
-class AlreadyUserExistsException extends Exception
+class AlreadyUserExistsException extends DomainException
 {
     public function __construct(
         string $message = 'User already exists.',

--- a/src/Wiki/Image/Application/Exception/ImageNotFoundException.php
+++ b/src/Wiki/Image/Application/Exception/ImageNotFoundException.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Image\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class ImageNotFoundException extends Exception
+class ImageNotFoundException extends RuntimeException
 {
-    public function __construct(string $message = 'Image not found')
-    {
-        parent::__construct($message);
+    public function __construct(
+        string $message = 'Image not found',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Image/Domain/Exception/ImageDeletionRequestAlreadyPendingException.php
+++ b/src/Wiki/Image/Domain/Exception/ImageDeletionRequestAlreadyPendingException.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class ImageDeletionRequestAlreadyPendingException extends DomainException
 {
-    public function __construct()
-    {
-        parent::__construct('A pending deletion request already exists for this image.');
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct('A pending deletion request already exists for this image.', 0, $previous);
     }
 }

--- a/src/Wiki/Image/Domain/Exception/ImageDeletionRequestNotPendingException.php
+++ b/src/Wiki/Image/Domain/Exception/ImageDeletionRequestNotPendingException.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Source\Wiki\Image\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class ImageDeletionRequestNotPendingException extends DomainException
 {
-    public function __construct()
-    {
-        parent::__construct('Only pending requests can be approved or rejected.');
+    public function __construct(
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct('Only pending requests can be approved or rejected.', 0, $previous);
     }
 }

--- a/src/Wiki/OfficialCertification/Application/Exception/OfficialCertificationAlreadyRequestedException.php
+++ b/src/Wiki/OfficialCertification/Application/Exception/OfficialCertificationAlreadyRequestedException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Wiki\OfficialCertification\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class OfficialCertificationAlreadyRequestedException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Official Certification Already Requested',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Wiki/OfficialCertification/Application/Exception/OfficialCertificationInvalidStatusException.php
+++ b/src/Wiki/OfficialCertification/Application/Exception/OfficialCertificationInvalidStatusException.php
@@ -5,7 +5,14 @@ declare(strict_types=1);
 namespace Source\Wiki\OfficialCertification\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class OfficialCertificationInvalidStatusException extends RuntimeException
 {
+    public function __construct(
+        string $message = 'Official Certification Invalid Status',
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
 }

--- a/src/Wiki/OfficialCertification/Application/Exception/OfficialCertificationNotFoundException.php
+++ b/src/Wiki/OfficialCertification/Application/Exception/OfficialCertificationNotFoundException.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Wiki\OfficialCertification\Application\Exception;
 
-use Exception;
+use RuntimeException;
 use Throwable;
 
-class OfficialCertificationNotFoundException extends Exception
+class OfficialCertificationNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Official Certification is not found.',
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForApprovalException.php
+++ b/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForApprovalException.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Source\Wiki\OfficialCertification\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class CertificationNotPendingForApprovalException extends DomainException
 {
     public function __construct(
         string $message = 'Only pending certifications can be approved.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForRejectionException.php
+++ b/src/Wiki/OfficialCertification/Domain/Exception/CertificationNotPendingForRejectionException.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Source\Wiki\OfficialCertification\Domain\Exception;
 
 use DomainException;
+use Throwable;
 
 class CertificationNotPendingForRejectionException extends DomainException
 {
     public function __construct(
         string $message = 'Only pending certifications can be rejected.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Application/Exception/CannotDeleteDefaultPrincipalGroupException.php
+++ b/src/Wiki/Principal/Application/Exception/CannotDeleteDefaultPrincipalGroupException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class CannotDeleteDefaultPrincipalGroupException extends Exception
+class CannotDeleteDefaultPrincipalGroupException extends RuntimeException
 {
     public function __construct(
         string $message = 'Cannot delete default PrincipalGroup.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Application/Exception/CannotDeleteSystemPolicyException.php
+++ b/src/Wiki/Principal/Application/Exception/CannotDeleteSystemPolicyException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class CannotDeleteSystemPolicyException extends Exception
+class CannotDeleteSystemPolicyException extends RuntimeException
 {
     public function __construct(
         string $message = 'Cannot delete system policy.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Application/Exception/CannotDeleteSystemRoleException.php
+++ b/src/Wiki/Principal/Application/Exception/CannotDeleteSystemRoleException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class CannotDeleteSystemRoleException extends Exception
+class CannotDeleteSystemRoleException extends RuntimeException
 {
     public function __construct(
         string $message = 'Cannot delete system role.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Application/Exception/PolicyNotFoundException.php
+++ b/src/Wiki/Principal/Application/Exception/PolicyNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class PolicyNotFoundException extends Exception
+class PolicyNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Policy not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Application/Exception/PrincipalGroupNotFoundException.php
+++ b/src/Wiki/Principal/Application/Exception/PrincipalGroupNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class PrincipalGroupNotFoundException extends Exception
+class PrincipalGroupNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'PrincipalGroup not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Application/Exception/RoleNotFoundException.php
+++ b/src/Wiki/Principal/Application/Exception/RoleNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class RoleNotFoundException extends Exception
+class RoleNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Role not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Domain/Exception/CannotChangeNonDelegatedPrincipalException.php
+++ b/src/Wiki/Principal/Domain/Exception/CannotChangeNonDelegatedPrincipalException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class CannotChangeNonDelegatedPrincipalException extends Exception
+class CannotChangeNonDelegatedPrincipalException extends DomainException
 {
     public function __construct(
         string $message = 'Cannot change enabled status of non-delegated principal.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Domain/Exception/PrincipalAlreadyExistsException.php
+++ b/src/Wiki/Principal/Domain/Exception/PrincipalAlreadyExistsException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class PrincipalAlreadyExistsException extends Exception
+class PrincipalAlreadyExistsException extends DomainException
 {
     public function __construct(
         string $message = 'Principal already exists for this identity.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Domain/Exception/PrincipalAlreadyMemberException.php
+++ b/src/Wiki/Principal/Domain/Exception/PrincipalAlreadyMemberException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class PrincipalAlreadyMemberException extends Exception
+class PrincipalAlreadyMemberException extends DomainException
 {
     public function __construct(
         string $message = 'Principal is already a member of this group.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Principal/Domain/Exception/PrincipalNotMemberException.php
+++ b/src/Wiki/Principal/Domain/Exception/PrincipalNotMemberException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class PrincipalNotMemberException extends Exception
+class PrincipalNotMemberException extends DomainException
 {
     public function __construct(
         string $message = 'Principal is not a member of this group.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Shared/Application/Exception/DuplicateSlugException.php
+++ b/src/Wiki/Shared/Application/Exception/DuplicateSlugException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class DuplicateSlugException extends Exception
+class DuplicateSlugException extends RuntimeException
 {
     public function __construct(
         string $message = 'Slug already exists.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Shared/Domain/Exception/DisallowedException.php
+++ b/src/Wiki/Shared/Domain/Exception/DisallowedException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class DisallowedException extends Exception
+class DisallowedException extends DomainException
 {
     public function __construct(
         string $message = 'Action is not allowed for this principal.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Shared/Domain/Exception/InvalidRollbackTargetVersionException.php
+++ b/src/Wiki/Shared/Domain/Exception/InvalidRollbackTargetVersionException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class InvalidRollbackTargetVersionException extends Exception
+class InvalidRollbackTargetVersionException extends DomainException
 {
     public function __construct(
         string $message = 'Target version must be less than current version.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Shared/Domain/Exception/InvalidStatusException.php
+++ b/src/Wiki/Shared/Domain/Exception/InvalidStatusException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class InvalidStatusException extends Exception
+class InvalidStatusException extends DomainException
 {
     public function __construct(
         string $message = 'Status is invalid.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Shared/Domain/Exception/PrincipalNotFoundException.php
+++ b/src/Wiki/Shared/Domain/Exception/PrincipalNotFoundException.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
 use Throwable;
 
-class PrincipalNotFoundException extends Exception
+class PrincipalNotFoundException extends DomainException
 {
     public function __construct(
         string $message = 'Principal is not found.',
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Wiki/Shared/Domain/Exception/SnapshotNotFoundException.php
+++ b/src/Wiki/Shared/Domain/Exception/SnapshotNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class SnapshotNotFoundException extends Exception
+class SnapshotNotFoundException extends DomainException
 {
     public function __construct(
         string $message = 'Snapshot is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Shared/Domain/Exception/UnauthorizedException.php
+++ b/src/Wiki/Shared/Domain/Exception/UnauthorizedException.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
 /**
  * @deprecated
  */
-class UnauthorizedException extends Exception
+class UnauthorizedException extends DomainException
 {
-    public function __construct(string $message = 'Unauthorized action.', ?Exception $previous = null)
-    {
+    public function __construct(
+        string $message = 'Unauthorized action.',
+        ?Throwable $previous = null,
+    ) {
         parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Shared/Domain/Exception/VersionMismatchException.php
+++ b/src/Wiki/Shared/Domain/Exception/VersionMismatchException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Shared\Domain\Exception;
 
-use Exception;
+use DomainException;
+use Throwable;
 
-class VersionMismatchException extends Exception
+class VersionMismatchException extends DomainException
 {
     public function __construct(
         string $message = 'Version mismatch detected in translation set.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Wiki/Application/Exception/ExistsApprovedDraftWikiException.php
+++ b/src/Wiki/Wiki/Application/Exception/ExistsApprovedDraftWikiException.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class ExistsApprovedDraftWikiException extends RuntimeException
 {
     public function __construct(
         string $message = 'There is approved draft wiki that has not yet been published.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Wiki/Application/Exception/InconsistentVersionException.php
+++ b/src/Wiki/Wiki/Application/Exception/InconsistentVersionException.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Source\Wiki\Wiki\Application\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class InconsistentVersionException extends RuntimeException
 {
     public function __construct(
         string $message = 'Published wiki versions in the translation set are not consistent.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/Wiki/Wiki/Application/Exception/WikiNotFoundException.php
+++ b/src/Wiki/Wiki/Application/Exception/WikiNotFoundException.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Wiki\Application\Exception;
 
-use Exception;
+use RuntimeException;
+use Throwable;
 
-class WikiNotFoundException extends Exception
+class WikiNotFoundException extends RuntimeException
 {
     public function __construct(
         string $message = 'Wiki is not found.',
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0);
+        parent::__construct($message, 0, $previous);
     }
 }


### PR DESCRIPTION
## 📝 変更内容

- `src` 配下の独自例外について、Domain 例外は `DomainException`、Application / Infrastructure 例外は `RuntimeException` 継承に整理しました。
- 空の独自例外を含め、各例外でメッセージと `?Throwable $previous = null` を扱い、`parent::__construct(..., 0, $previous)` で例外チェーンを維持する形に統一しました。
- `ApiException` が Application 例外として扱われるようになったことに合わせ、決済系 HTTP Action で `ApiException` を broad catch 前に HTTP 例外へ変換する catch を追加しました。
- `StripeTransferException` は Infrastructure 例外として `RuntimeException` 継承に整理し、実装側の過剰な `@throws` PHPDoc を削除して interface 側との不整合を解消しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

`src` 配下の独自例外で、空クラスのままメッセージや `previous` を扱えないものや、Domain / Application / Infrastructure の責務と継承元が揃っていないものが混在していました。
独自例外の基本形を揃え、例外チェーンを維持できるようにすることで、例外の責務と運用ルールを明確にします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
  - `composer cs-fix`: Fixed 0 of 2398 files
  - `composer phpstan`: No errors
  - `phpunit`: OK (2916 tests, 9357 assertions)
- [ ] 新しく追加した機能に対するテストを作成
  - 例外 constructor の網羅だけを目的にした単体テストは Issue の指示に従い追加していません。
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `find src -name '*Exception.php' -print0 | xargs -0 -n1 php -l` で対象例外ファイルの構文エラーがないことを確認しました。
- `src` 配下の `*Exception.php` を監査し、以下が 0 件であることを確認しました。
  - `Domain/Exception` 配下で `DomainException` 以外を継承している例外
  - Application / Infrastructure 配下で `RuntimeException` 以外を継承している例外
  - constructor / `$previous` / `parent::__construct(..., 0, $previous)` が不足している例外
  - `$code` パラメータまたは `$code` 参照が残っている例外

## 🔍 レビューのポイント

- Domain 例外と Application / Infrastructure 例外の継承元が Issue の方針通りに分かれているか。
- 既存の識別子引数や既存メッセージを維持したまま `previous` と code `0` に統一できているか。
- `ApiException` の例外変換追加が既存の HTTP Action の例外処理方針と整合しているか。
- `StripeTransferException` の `@throws` PHPDoc 調整が interface 側との型整合性を保っているか。

### Review skills used / unavailable skills and alternative review

- `qa-review`, `test-review`, `security-review`, `architecture-review` は Hermes / repo-local / Codex skill を確認しましたが利用可能な定義が見つからなかったため、代替として同一セッション内でインラインレビューを実施しました。
- QA review: Issue の受け入れ条件に対して例外ファイル監査を実施し、未対応条件はありません。
- Test review: 例外 constructor 自体だけのテストは追加しないという Issue 指示に従い、既存テストと `php -l` / PHPStan / full `task check` で回帰確認しました。
- Security review: 例外メッセージの生成を既存方針から拡張せず、例外チェーン維持のみを追加しており、新たな入力公開・認可・秘密情報露出はありません。
- Architecture review: Domain 例外 / Application 例外 / Infrastructure 例外の依存方向と継承元を整理し、HTTP 層では Source 例外を broad catch 前に HTTP 例外へ変換する形にしました。
- 未対応のレビュー指摘: ありません。

## 📖 関連情報

### 関連Issue・タスク

Closes #473

## ⚠️ 注意事項

- マイグレーションや環境変数変更はありません。
- 例外クラスの constructor シグネチャが整理されるため、今後 `$code` を任意指定する使い方はできません（Issue 方針通り code `0` 固定）。

## 📸 スクリーンショット・デモ

- API / UI の表示変更ではないため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
