### PR TITLE
Wikiプリンシパルの初期権限をコラボレータに統一

### DIFF
--- a/database/seeders/FullAccessTestAccountSeeder.php
+++ b/database/seeders/FullAccessTestAccountSeeder.php
@@ -19,6 +19,7 @@ class FullAccessTestAccountSeeder extends Seeder
             'identityId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa02',
             'principalId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa03',
             'principalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa04',
+            'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0b',
             'accountPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa05',
             'email' => 'test@example.com',
             'identityName' => 'full-access-test',
@@ -31,6 +32,7 @@ class FullAccessTestAccountSeeder extends Seeder
             'identityId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa07',
             'principalId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa08',
             'principalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa09',
+            'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0c',
             'accountPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0a',
             'email' => 'corp@example.com',
             'identityName' => 'corp-full-access-test',
@@ -54,6 +56,14 @@ class FullAccessTestAccountSeeder extends Seeder
             throw new RuntimeException('ADMINISTRATOR role not found. Please run SystemRoleSeeder first.');
         }
 
+        $collaboratorRoleId = DB::table('roles')
+            ->where('name', 'COLLABORATOR')
+            ->value('id');
+
+        if (! is_string($collaboratorRoleId)) {
+            throw new RuntimeException('COLLABORATOR role not found. Please run SystemRoleSeeder first.');
+        }
+
         $ownerRoleId = DB::table('account_roles')
             ->where('name', Role::OWNER)
             ->value('id');
@@ -65,7 +75,7 @@ class FullAccessTestAccountSeeder extends Seeder
         $now = now();
 
         foreach (self::ACCOUNTS as $account) {
-            $this->createFullAccessAccount($account, $administratorRoleId, $ownerRoleId, $now);
+            $this->createFullAccessAccount($account, $administratorRoleId, $collaboratorRoleId, $ownerRoleId, $now);
         }
     }
 
@@ -75,6 +85,7 @@ class FullAccessTestAccountSeeder extends Seeder
      *     identityId: string,
      *     principalId: string,
      *     principalGroupId: string,
+     *     wikiDefaultPrincipalGroupId: string,
      *     accountPrincipalGroupMembershipId: string,
      *     email: string,
      *     identityName: string,
@@ -86,6 +97,7 @@ class FullAccessTestAccountSeeder extends Seeder
     private function createFullAccessAccount(
         array $account,
         string $administratorRoleId,
+        string $collaboratorRoleId,
         string $ownerRoleId,
         Carbon $now,
     ): void {
@@ -172,16 +184,30 @@ class FullAccessTestAccountSeeder extends Seeder
 
         DB::table('principal_groups')->upsert([
             [
+                'id' => $account['wikiDefaultPrincipalGroupId'],
+                'account_id' => $account['accountId'],
+                'name' => 'Default',
+                'is_default' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
                 'id' => $account['principalGroupId'],
                 'account_id' => $account['accountId'],
                 'name' => $account['principalGroupName'],
-                'is_default' => true,
+                'is_default' => false,
                 'created_at' => $now,
                 'updated_at' => $now,
             ],
         ], ['id']);
 
         DB::table('principal_group_memberships')->upsert([
+            [
+                'principal_group_id' => $account['wikiDefaultPrincipalGroupId'],
+                'principal_id' => $account['principalId'],
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
             [
                 'principal_group_id' => $account['principalGroupId'],
                 'principal_id' => $account['principalId'],
@@ -191,6 +217,10 @@ class FullAccessTestAccountSeeder extends Seeder
         ], ['principal_group_id', 'principal_id']);
 
         DB::table('principal_group_role_attachments')->upsert([
+            [
+                'principal_group_id' => $account['wikiDefaultPrincipalGroupId'],
+                'role_id' => $collaboratorRoleId,
+            ],
             [
                 'principal_group_id' => $account['principalGroupId'],
                 'role_id' => $administratorRoleId,

--- a/src/Wiki/Grading/Application/UseCase/Command/ProcessRolePromotion/ProcessRolePromotion.php
+++ b/src/Wiki/Grading/Application/UseCase/Command/ProcessRolePromotion/ProcessRolePromotion.php
@@ -6,6 +6,7 @@ namespace Source\Wiki\Grading\Application\UseCase\Command\ProcessRolePromotion;
 
 use DateTimeImmutable;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Grading\Domain\Entity\DemotionWarning;
 use Source\Wiki\Grading\Domain\Event\DemotionWarningsBatchIssued;
@@ -16,9 +17,11 @@ use Source\Wiki\Grading\Domain\Repository\DemotionWarningRepositoryInterface;
 use Source\Wiki\Grading\Domain\Repository\PromotionHistoryRepositoryInterface;
 use Source\Wiki\Grading\Domain\ValueObject\Point;
 use Source\Wiki\Grading\Domain\ValueObject\YearMonth;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 use Source\Wiki\Principal\Domain\Entity\Role;
 use Source\Wiki\Principal\Domain\Event\PrincipalsBatchDemoted;
 use Source\Wiki\Principal\Domain\Event\PrincipalsBatchPromoted;
+use Source\Wiki\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Repository\RoleRepositoryInterface;
@@ -28,6 +31,7 @@ readonly class ProcessRolePromotion implements ProcessRolePromotionInterface
 {
     private const string COLLABORATOR_ROLE = 'COLLABORATOR';
     private const string SENIOR_COLLABORATOR_ROLE = 'SENIOR_COLLABORATOR';
+    private const string SENIOR_COLLABORATOR_GROUP_NAME = 'Senior Collaborator';
 
     public function __construct(
         private ContributionPointSummaryRepositoryInterface $summaryRepository,
@@ -36,6 +40,7 @@ readonly class ProcessRolePromotion implements ProcessRolePromotionInterface
         private PromotionHistoryRepositoryInterface $promotionHistoryRepository,
         private PromotionHistoryFactoryInterface $promotionHistoryFactory,
         private PrincipalGroupRepositoryInterface $principalGroupRepository,
+        private PrincipalGroupFactoryInterface $principalGroupFactory,
         private PrincipalRepositoryInterface $principalRepository,
         private RoleRepositoryInterface $roleRepository,
         private EventDispatcherInterface $eventDispatcher,
@@ -223,13 +228,18 @@ readonly class ProcessRolePromotion implements ProcessRolePromotionInterface
                 if ($warning->warningCount()->isExceedDemotionThreshold()) {
                     $principalIdentifier = new PrincipalIdentifier($principalId);
                     $principalGroups = $this->principalGroupRepository->findByPrincipalId($principalIdentifier);
+                    $defaultGroup = $this->findDefaultGroupForPrincipalGroups($principalGroups);
 
                     foreach ($principalGroups as $group) {
                         if ($group->hasRole($seniorCollaboratorRole->roleIdentifier())) {
-                            $group->removeRole($seniorCollaboratorRole->roleIdentifier());
-                            $group->addRole($collaboratorRole->roleIdentifier());
+                            $group->removeMember($principalIdentifier);
                             $this->principalGroupRepository->save($group);
                         }
+                    }
+
+                    if ($defaultGroup !== null && ! $defaultGroup->hasMember($principalIdentifier)) {
+                        $defaultGroup->addMember($principalIdentifier);
+                        $this->principalGroupRepository->save($defaultGroup);
                     }
 
                     $history = $this->promotionHistoryFactory->create(
@@ -301,13 +311,34 @@ readonly class ProcessRolePromotion implements ProcessRolePromotionInterface
             if (in_array($principalId, $collaborators, true)) {
                 $principalIdentifier = new PrincipalIdentifier($principalId);
                 $principalGroups = $this->principalGroupRepository->findByPrincipalId($principalIdentifier);
+                $defaultGroup = $this->findDefaultGroup($principalGroups);
 
-                foreach ($principalGroups as $group) {
-                    if ($group->hasRole($collaboratorRole->roleIdentifier())) {
-                        $group->removeRole($collaboratorRole->roleIdentifier());
-                        $group->addRole($seniorCollaboratorRole->roleIdentifier());
-                        $this->principalGroupRepository->save($group);
-                    }
+                if ($defaultGroup === null) {
+                    continue;
+                }
+
+                $seniorCollaboratorGroup = $this->findRoleGroupForAccount(
+                    $seniorCollaboratorRole,
+                    $defaultGroup->accountIdentifier(),
+                );
+
+                if ($seniorCollaboratorGroup === null) {
+                    $seniorCollaboratorGroup = $this->principalGroupFactory->create(
+                        $defaultGroup->accountIdentifier(),
+                        self::SENIOR_COLLABORATOR_GROUP_NAME,
+                        false,
+                    );
+                    $seniorCollaboratorGroup->addRole($seniorCollaboratorRole->roleIdentifier());
+                }
+
+                if ($defaultGroup->hasMember($principalIdentifier)) {
+                    $defaultGroup->removeMember($principalIdentifier);
+                    $this->principalGroupRepository->save($defaultGroup);
+                }
+
+                if (! $seniorCollaboratorGroup->hasMember($principalIdentifier)) {
+                    $seniorCollaboratorGroup->addMember($principalIdentifier);
+                    $this->principalGroupRepository->save($seniorCollaboratorGroup);
                 }
 
                 $points = $cumulativePoints[$principalId] ?? 0;
@@ -324,6 +355,52 @@ readonly class ProcessRolePromotion implements ProcessRolePromotionInterface
         }
 
         return $promoted;
+    }
+
+    /**
+     * @param array<PrincipalGroup> $principalGroups
+     */
+    private function findDefaultGroup(array $principalGroups): ?PrincipalGroup
+    {
+        foreach ($principalGroups as $group) {
+            if ($group->isDefault()) {
+                return $group;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<PrincipalGroup> $principalGroups
+     */
+    private function findDefaultGroupForPrincipalGroups(array $principalGroups): ?PrincipalGroup
+    {
+        $defaultGroup = $this->findDefaultGroup($principalGroups);
+        if ($defaultGroup !== null) {
+            return $defaultGroup;
+        }
+
+        foreach ($principalGroups as $group) {
+            return $this->principalGroupRepository->findDefaultByAccountId($group->accountIdentifier());
+        }
+
+        return null;
+    }
+
+    private function findRoleGroupForAccount(
+        Role $role,
+        AccountIdentifier $accountIdentifier,
+    ): ?PrincipalGroup {
+        $groups = $this->principalGroupRepository->findByRole($role->roleIdentifier());
+
+        foreach ($groups as $group) {
+            if ((string) $group->accountIdentifier() === (string) $accountIdentifier) {
+                return $group;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipal.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipal.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal;
 
-use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
-use Source\Account\Shared\Domain\ValueObject\AccountCategory;
-use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Wiki\Principal\Domain\Exception\PrincipalAlreadyExistsException;
 use Source\Wiki\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Wiki\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
@@ -17,8 +14,6 @@ use Source\Wiki\Principal\Domain\Repository\RoleRepositoryInterface;
 readonly class CreatePrincipal implements CreatePrincipalInterface
 {
     private const string DEFAULT_PRINCIPAL_GROUP_NAME = 'Default';
-    private const string AGENCY_ACTOR_ROLE = 'AGENCY_ACTOR';
-    private const string TALENT_ACTOR_ROLE = 'TALENT_ACTOR';
     private const string COLLABORATOR_ROLE = 'COLLABORATOR';
 
     public function __construct(
@@ -26,7 +21,6 @@ readonly class CreatePrincipal implements CreatePrincipalInterface
         private PrincipalFactoryInterface $principalFactory,
         private PrincipalGroupRepositoryInterface $principalGroupRepository,
         private PrincipalGroupFactoryInterface $principalGroupFactory,
-        private AccountRepositoryInterface $accountRepository,
         private RoleRepositoryInterface $roleRepository,
     ) {
     }
@@ -64,9 +58,7 @@ readonly class CreatePrincipal implements CreatePrincipalInterface
                 true,
             );
 
-            // AccountCategoryに応じたRoleを付与
-            $roleName = $this->determineRoleName($input->accountIdentifier());
-            $role = $this->roleRepository->findByName($roleName);
+            $role = $this->roleRepository->findByName(self::COLLABORATOR_ROLE);
             if ($role !== null) {
                 $defaultPrincipalGroup->addRole($role->roleIdentifier());
             }
@@ -79,20 +71,5 @@ readonly class CreatePrincipal implements CreatePrincipalInterface
         $this->principalGroupRepository->save($defaultPrincipalGroup);
 
         $output->setPrincipal($principal);
-    }
-
-    private function determineRoleName(AccountIdentifier $accountIdentifier): string
-    {
-        $account = $this->accountRepository->findById($accountIdentifier);
-
-        if ($account === null) {
-            return self::COLLABORATOR_ROLE;
-        }
-
-        return match ($account->accountCategory()) {
-            AccountCategory::AGENCY => self::AGENCY_ACTOR_ROLE,
-            AccountCategory::TALENT => self::TALENT_ACTOR_ROLE,
-            AccountCategory::GENERAL => self::COLLABORATOR_ROLE,
-        };
     }
 }

--- a/tests/Wiki/Grading/Application/UseCase/Command/ProcessRolePromotion/ProcessRolePromotionTest.php
+++ b/tests/Wiki/Grading/Application/UseCase/Command/ProcessRolePromotion/ProcessRolePromotionTest.php
@@ -111,7 +111,7 @@ class ProcessRolePromotionTest extends TestCase
         $principalGroupRepository->shouldReceive('findByPrincipalId')
             ->andReturn([$principalGroup]);
         $principalGroupRepository->shouldReceive('save')
-            ->once();
+            ->twice();
 
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldReceive('findByName')
@@ -226,7 +226,8 @@ class ProcessRolePromotionTest extends TestCase
         $collaboratorRoleId = StrTestHelper::generateUuid();
         $seniorCollaboratorRoleId = StrTestHelper::generateUuid();
         $principalId = StrTestHelper::generateUuid();
-        $groupId = StrTestHelper::generateUuid();
+        $defaultGroupId = StrTestHelper::generateUuid();
+        $seniorGroupId = StrTestHelper::generateUuid();
         $accountId = StrTestHelper::generateUuid();
         $warningId = StrTestHelper::generateUuid();
 
@@ -246,15 +247,24 @@ class ProcessRolePromotionTest extends TestCase
             new DateTimeImmutable(),
         );
 
-        $principalGroup = new PrincipalGroup(
-            new PrincipalGroupIdentifier($groupId),
+        $defaultGroup = new PrincipalGroup(
+            new PrincipalGroupIdentifier($defaultGroupId),
             new AccountIdentifier($accountId),
             'Default',
             true,
             new DateTimeImmutable(),
         );
-        $principalGroup->addMember(new PrincipalIdentifier($principalId));
-        $principalGroup->addRole(new RoleIdentifier($seniorCollaboratorRoleId));
+        $defaultGroup->addRole(new RoleIdentifier($collaboratorRoleId));
+
+        $seniorGroup = new PrincipalGroup(
+            new PrincipalGroupIdentifier($seniorGroupId),
+            new AccountIdentifier($accountId),
+            'Senior Collaborator',
+            false,
+            new DateTimeImmutable(),
+        );
+        $seniorGroup->addMember(new PrincipalIdentifier($principalId));
+        $seniorGroup->addRole(new RoleIdentifier($seniorCollaboratorRoleId));
 
         // 既存の警告（warningCount=2）
         $warning = new DemotionWarning(
@@ -297,7 +307,7 @@ class ProcessRolePromotionTest extends TestCase
             ->andReturn([]);
         $principalGroupRepository->shouldReceive('findByRole')
             ->with(Mockery::on(static fn ($r) => (string) $r === $seniorCollaboratorRoleId))
-            ->andReturn([$principalGroup]);
+            ->andReturn([$seniorGroup]);
 
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldReceive('findByName')
@@ -529,7 +539,8 @@ class ProcessRolePromotionTest extends TestCase
         $collaboratorRoleId = StrTestHelper::generateUuid();
         $seniorCollaboratorRoleId = StrTestHelper::generateUuid();
         $principalId = StrTestHelper::generateUuid();
-        $groupId = StrTestHelper::generateUuid();
+        $defaultGroupId = StrTestHelper::generateUuid();
+        $seniorGroupId = StrTestHelper::generateUuid();
         $accountId = StrTestHelper::generateUuid();
         $warningId = StrTestHelper::generateUuid();
 
@@ -549,15 +560,24 @@ class ProcessRolePromotionTest extends TestCase
             new DateTimeImmutable(),
         );
 
-        $principalGroup = new PrincipalGroup(
-            new PrincipalGroupIdentifier($groupId),
+        $defaultGroup = new PrincipalGroup(
+            new PrincipalGroupIdentifier($defaultGroupId),
             new AccountIdentifier($accountId),
             'Default',
             true,
             new DateTimeImmutable(),
         );
-        $principalGroup->addMember(new PrincipalIdentifier($principalId));
-        $principalGroup->addRole(new RoleIdentifier($seniorCollaboratorRoleId));
+        $defaultGroup->addRole(new RoleIdentifier($collaboratorRoleId));
+
+        $seniorGroup = new PrincipalGroup(
+            new PrincipalGroupIdentifier($seniorGroupId),
+            new AccountIdentifier($accountId),
+            'Senior Collaborator',
+            false,
+            new DateTimeImmutable(),
+        );
+        $seniorGroup->addMember(new PrincipalIdentifier($principalId));
+        $seniorGroup->addRole(new RoleIdentifier($seniorCollaboratorRoleId));
 
         $warning = new DemotionWarning(
             new DemotionWarningIdentifier($warningId),
@@ -596,14 +616,18 @@ class ProcessRolePromotionTest extends TestCase
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('findByRole')
             ->with(Mockery::on(static fn ($r) => (string) $r === $collaboratorRoleId))
-            ->andReturn([]);
+            ->andReturn([$defaultGroup]);
         $principalGroupRepository->shouldReceive('findByRole')
             ->with(Mockery::on(static fn ($r) => (string) $r === $seniorCollaboratorRoleId))
-            ->andReturn([$principalGroup]);
+            ->andReturn([$seniorGroup]);
         $principalGroupRepository->shouldReceive('findByPrincipalId')
-            ->andReturn([$principalGroup]);
+            ->andReturn([$seniorGroup]);
+        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
+            ->with(Mockery::on(static fn ($accountIdentifier) => (string) $accountIdentifier === $accountId))
+            ->once()
+            ->andReturn($defaultGroup);
         $principalGroupRepository->shouldReceive('save')
-            ->once();
+            ->twice();
 
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldReceive('findByName')
@@ -651,6 +675,8 @@ class ProcessRolePromotionTest extends TestCase
 
         $this->assertCount(1, $output->demoted());
         $this->assertSame($principalId, (string) $output->demoted()[0]);
+        $this->assertTrue($defaultGroup->hasMember(new PrincipalIdentifier($principalId)));
+        $this->assertFalse($seniorGroup->hasMember(new PrincipalIdentifier($principalId)));
     }
 
     /**

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalTest.php
@@ -7,15 +7,7 @@ namespace Tests\Wiki\Principal\Application\UseCase\Command\CreatePrincipal;
 use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
-use Source\Account\Account\Domain\Entity\Account;
-use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
-use Source\Account\Account\Domain\ValueObject\AccountName;
-use Source\Account\Account\Domain\ValueObject\AccountStatus;
-use Source\Account\Account\Domain\ValueObject\AccountType;
-use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
-use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
-use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInput;
 use Source\Wiki\Principal\Application\UseCase\Command\CreatePrincipal\CreatePrincipalInterface;
@@ -38,32 +30,20 @@ use Tests\TestCase;
 class CreatePrincipalTest extends TestCase
 {
     /**
-     * 正常系: 正しくプリンシパルを作成できること（Default PrincipalGroup が存在しない場合）.
+     * 正常系: Default PrincipalGroup が存在しない場合、COLLABORATORロールを持つDefaultグループを作成してPrincipalを追加すること.
      *
-     * @return void
-     * @throws PrincipalAlreadyExistsException
      * @throws BindingResolutionException
+     * @throws PrincipalAlreadyExistsException
      */
-    public function testProcess(): void
+    public function testProcessCreatesDefaultPrincipalGroupWithCollaboratorRole(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
 
-        $input = new CreatePrincipalInput(
-            $identityIdentifier,
-            $accountIdentifier,
-        );
-
-        $expectedPrincipal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
-
+        $principal = new Principal($principalIdentifier, $identityIdentifier, null, [], []);
         $defaultPrincipalGroup = new PrincipalGroup(
             $principalGroupIdentifier,
             $accountIdentifier,
@@ -71,28 +51,37 @@ class CreatePrincipalTest extends TestCase
             true,
             new DateTimeImmutable(),
         );
+        $collaboratorRole = new Role(
+            $roleIdentifier,
+            'COLLABORATOR',
+            [],
+            true,
+            new DateTimeImmutable(),
+        );
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $principalRepository->shouldReceive('findByIdentityIdentifier')
             ->with($identityIdentifier)
             ->once()
-            ->andReturn(null);
+            ->andReturnNull();
+        $principalRepository->shouldReceive('save')
+            ->with($principal)
+            ->once();
 
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalFactory->shouldReceive('create')
             ->with($identityIdentifier)
             ->once()
-            ->andReturn($expectedPrincipal);
-
-        $principalRepository->shouldReceive('save')
-            ->with($expectedPrincipal)
-            ->once();
+            ->andReturn($principal);
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('findDefaultByAccountId')
             ->with($accountIdentifier)
             ->once()
-            ->andReturn(null);
+            ->andReturnNull();
+        $principalGroupRepository->shouldReceive('save')
+            ->with($defaultPrincipalGroup)
+            ->twice();
 
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldReceive('create')
@@ -100,67 +89,44 @@ class CreatePrincipalTest extends TestCase
             ->once()
             ->andReturn($defaultPrincipalGroup);
 
-        $principalGroupRepository->shouldReceive('save')
-            ->with($defaultPrincipalGroup)
-            ->twice();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturnNull();
-
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldReceive('findByName')
             ->with('COLLABORATOR')
             ->once()
-            ->andReturnNull();
+            ->andReturn($collaboratorRole);
 
-        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
+        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
-        $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $output = new CreatePrincipalOutput();
-        $useCase->process($input, $output);
 
-        $result = $output->toArray();
-        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
-        $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
+        $output = new CreatePrincipalOutput();
+        $this->app->make(CreatePrincipalInterface::class)->process(
+            new CreatePrincipalInput($identityIdentifier, $accountIdentifier),
+            $output,
+        );
+
+        $this->assertSame((string) $principalIdentifier, $output->toArray()['principalIdentifier']);
+        $this->assertTrue($defaultPrincipalGroup->hasRole($roleIdentifier));
         $this->assertTrue($defaultPrincipalGroup->hasMember($principalIdentifier));
     }
 
     /**
-     * 正常系: Default PrincipalGroup が既に存在する場合、既存のグループに Principal を追加すること.
+     * 正常系: Default PrincipalGroup が既に存在する場合、ロール構成を変更せずPrincipalを追加すること.
      *
-     * @return void
-     * @throws PrincipalAlreadyExistsException
      * @throws BindingResolutionException
+     * @throws PrincipalAlreadyExistsException
      */
-    public function testProcessWithExistingDefaultPrincipalGroup(): void
+    public function testProcessAddsPrincipalToExistingDefaultPrincipalGroup(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
 
-        $input = new CreatePrincipalInput(
-            $identityIdentifier,
-            $accountIdentifier,
-        );
-
-        $expectedPrincipal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
-
-        $existingDefaultPrincipalGroup = new PrincipalGroup(
-            $principalGroupIdentifier,
+        $principal = new Principal($principalIdentifier, $identityIdentifier, null, [], []);
+        $defaultPrincipalGroup = new PrincipalGroup(
+            new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
             $accountIdentifier,
             'Default',
             true,
@@ -171,83 +137,70 @@ class CreatePrincipalTest extends TestCase
         $principalRepository->shouldReceive('findByIdentityIdentifier')
             ->with($identityIdentifier)
             ->once()
-            ->andReturn(null);
+            ->andReturnNull();
+        $principalRepository->shouldReceive('save')
+            ->with($principal)
+            ->once();
 
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalFactory->shouldReceive('create')
             ->with($identityIdentifier)
             ->once()
-            ->andReturn($expectedPrincipal);
-
-        $principalRepository->shouldReceive('save')
-            ->with($expectedPrincipal)
-            ->once();
+            ->andReturn($principal);
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('findDefaultByAccountId')
             ->with($accountIdentifier)
             ->once()
-            ->andReturn($existingDefaultPrincipalGroup);
+            ->andReturn($defaultPrincipalGroup);
+        $principalGroupRepository->shouldReceive('save')
+            ->with($defaultPrincipalGroup)
+            ->once();
 
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldNotReceive('create');
 
-        $principalGroupRepository->shouldReceive('save')
-            ->with($existingDefaultPrincipalGroup)
-            ->once();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldNotReceive('findById');
-
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldNotReceive('findByName');
 
-        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
+        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
-        $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $output = new CreatePrincipalOutput();
-        $useCase->process($input, $output);
 
-        $result = $output->toArray();
-        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
-        $this->assertSame((string) $identityIdentifier, $result['identityIdentifier']);
-        $this->assertTrue($existingDefaultPrincipalGroup->hasMember($principalIdentifier));
+        $output = new CreatePrincipalOutput();
+        $this->app->make(CreatePrincipalInterface::class)->process(
+            new CreatePrincipalInput($identityIdentifier, $accountIdentifier),
+            $output,
+        );
+
+        $this->assertSame((string) $principalIdentifier, $output->toArray()['principalIdentifier']);
+        $this->assertTrue($defaultPrincipalGroup->hasMember($principalIdentifier));
+        $this->assertEmpty($defaultPrincipalGroup->roles());
     }
 
     /**
-     * 異常系: すでに生成済みのプリンシパルを作成しようとした場合、例外がスローされること.
+     * 異常系: すでに生成済みのPrincipalを作成しようとした場合、例外がスローされること.
      *
-     * @return void
      * @throws BindingResolutionException
      */
     public function testProcessThrowsExceptionWhenPrincipalAlreadyExists(): void
     {
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-
-        $input = new CreatePrincipalInput(
-            $identityIdentifier,
-            $accountIdentifier,
-        );
-
-        $existingPrincipal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $principalRepository->shouldReceive('findByIdentityIdentifier')
             ->with($identityIdentifier)
             ->once()
-            ->andReturn($existingPrincipal);
+            ->andReturn(new Principal(
+                new PrincipalIdentifier(StrTestHelper::generateUuid()),
+                $identityIdentifier,
+                null,
+                [],
+                [],
+            ));
         $principalRepository->shouldNotReceive('save');
 
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
@@ -257,438 +210,17 @@ class CreatePrincipalTest extends TestCase
         $principalGroupRepository->shouldNotReceive('findDefaultByAccountId');
         $principalGroupRepository->shouldNotReceive('save');
 
-        $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
-        $principalGroupFactory->shouldNotReceive('create');
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldNotReceive('findById');
-
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldNotReceive('findByName');
+        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
+        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
+        $this->app->instance(PrincipalGroupFactoryInterface::class, Mockery::mock(PrincipalGroupFactoryInterface::class));
+        $this->app->instance(RoleRepositoryInterface::class, Mockery::mock(RoleRepositoryInterface::class));
 
         $this->expectException(PrincipalAlreadyExistsException::class);
 
-        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
-        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
-        $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $output = new CreatePrincipalOutput();
-        $useCase->process($input, $output);
-    }
-
-    /**
-     * 正常系: AccountがAGENCYの場合、AGENCY_ACTOR_ROLEが付与されること.
-     *
-     * @return void
-     * @throws PrincipalAlreadyExistsException
-     * @throws BindingResolutionException
-     */
-    public function testProcessWithAgencyAccountAssignsAgencyActorRole(): void
-    {
-        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
-        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
-
-        $input = new CreatePrincipalInput(
-            $identityIdentifier,
-            $accountIdentifier,
-        );
-
-        $expectedPrincipal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
-
-        $defaultPrincipalGroup = new PrincipalGroup(
-            $principalGroupIdentifier,
-            $accountIdentifier,
-            'Default',
-            true,
-            new DateTimeImmutable(),
-        );
-
-        $agencyAccount = $this->createAccount(AccountCategory::AGENCY);
-        $agencyActorRole = $this->createRole($roleIdentifier, 'AGENCY_ACTOR');
-
-        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $principalRepository->shouldReceive('findByIdentityIdentifier')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
-        $principalFactory->shouldReceive('create')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn($expectedPrincipal);
-
-        $principalRepository->shouldReceive('save')
-            ->with($expectedPrincipal)
-            ->once();
-
-        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
-        $principalGroupFactory->shouldReceive('create')
-            ->with($accountIdentifier, 'Default', true)
-            ->once()
-            ->andReturn($defaultPrincipalGroup);
-
-        $principalGroupRepository->shouldReceive('save')
-            ->with($defaultPrincipalGroup)
-            ->twice();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn($agencyAccount);
-
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldReceive('findByName')
-            ->with('AGENCY_ACTOR')
-            ->once()
-            ->andReturn($agencyActorRole);
-
-        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
-        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
-        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
-        $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $output = new CreatePrincipalOutput();
-        $useCase->process($input, $output);
-
-        $result = $output->toArray();
-        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
-        $this->assertTrue($defaultPrincipalGroup->hasRole($roleIdentifier));
-    }
-
-    /**
-     * 正常系: AccountがTALENTの場合、TALENT_ACTOR_ROLEが付与されること.
-     *
-     * @return void
-     * @throws PrincipalAlreadyExistsException
-     * @throws BindingResolutionException
-     */
-    public function testProcessWithTalentAccountAssignsTalentActorRole(): void
-    {
-        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
-        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
-
-        $input = new CreatePrincipalInput(
-            $identityIdentifier,
-            $accountIdentifier,
-        );
-
-        $expectedPrincipal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
-
-        $defaultPrincipalGroup = new PrincipalGroup(
-            $principalGroupIdentifier,
-            $accountIdentifier,
-            'Default',
-            true,
-            new DateTimeImmutable(),
-        );
-
-        $talentAccount = $this->createAccount(AccountCategory::TALENT);
-        $talentActorRole = $this->createRole($roleIdentifier, 'TALENT_ACTOR');
-
-        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $principalRepository->shouldReceive('findByIdentityIdentifier')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
-        $principalFactory->shouldReceive('create')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn($expectedPrincipal);
-
-        $principalRepository->shouldReceive('save')
-            ->with($expectedPrincipal)
-            ->once();
-
-        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
-        $principalGroupFactory->shouldReceive('create')
-            ->with($accountIdentifier, 'Default', true)
-            ->once()
-            ->andReturn($defaultPrincipalGroup);
-
-        $principalGroupRepository->shouldReceive('save')
-            ->with($defaultPrincipalGroup)
-            ->twice();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn($talentAccount);
-
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldReceive('findByName')
-            ->with('TALENT_ACTOR')
-            ->once()
-            ->andReturn($talentActorRole);
-
-        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
-        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
-        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
-        $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $output = new CreatePrincipalOutput();
-        $useCase->process($input, $output);
-
-        $result = $output->toArray();
-        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
-        $this->assertTrue($defaultPrincipalGroup->hasRole($roleIdentifier));
-    }
-
-    /**
-     * 正常系: AccountがGENERALの場合、COLLABORATOR_ROLEが付与されること.
-     *
-     * @return void
-     * @throws PrincipalAlreadyExistsException
-     * @throws BindingResolutionException
-     */
-    public function testProcessWithGeneralAccountAssignsCollaboratorRole(): void
-    {
-        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
-        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
-
-        $input = new CreatePrincipalInput(
-            $identityIdentifier,
-            $accountIdentifier,
-        );
-
-        $expectedPrincipal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
-
-        $defaultPrincipalGroup = new PrincipalGroup(
-            $principalGroupIdentifier,
-            $accountIdentifier,
-            'Default',
-            true,
-            new DateTimeImmutable(),
-        );
-
-        $generalAccount = $this->createAccount(AccountCategory::GENERAL);
-        $collaboratorRole = $this->createRole($roleIdentifier, 'COLLABORATOR');
-
-        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $principalRepository->shouldReceive('findByIdentityIdentifier')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
-        $principalFactory->shouldReceive('create')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn($expectedPrincipal);
-
-        $principalRepository->shouldReceive('save')
-            ->with($expectedPrincipal)
-            ->once();
-
-        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
-        $principalGroupFactory->shouldReceive('create')
-            ->with($accountIdentifier, 'Default', true)
-            ->once()
-            ->andReturn($defaultPrincipalGroup);
-
-        $principalGroupRepository->shouldReceive('save')
-            ->with($defaultPrincipalGroup)
-            ->twice();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn($generalAccount);
-
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldReceive('findByName')
-            ->with('COLLABORATOR')
-            ->once()
-            ->andReturn($collaboratorRole);
-
-        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
-        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
-        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
-        $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $output = new CreatePrincipalOutput();
-        $useCase->process($input, $output);
-
-        $result = $output->toArray();
-        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
-        $this->assertTrue($defaultPrincipalGroup->hasRole($roleIdentifier));
-    }
-
-    /**
-     * 正常系: Roleが見つからない場合、Roleはアタッチされないこと.
-     *
-     * @return void
-     * @throws PrincipalAlreadyExistsException
-     * @throws BindingResolutionException
-     */
-    public function testProcessWithRoleNotFoundDoesNotAttachRole(): void
-    {
-        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
-
-        $input = new CreatePrincipalInput(
-            $identityIdentifier,
-            $accountIdentifier,
-        );
-
-        $expectedPrincipal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
-
-        $defaultPrincipalGroup = new PrincipalGroup(
-            $principalGroupIdentifier,
-            $accountIdentifier,
-            'Default',
-            true,
-            new DateTimeImmutable(),
-        );
-
-        $agencyAccount = $this->createAccount(AccountCategory::AGENCY);
-
-        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $principalRepository->shouldReceive('findByIdentityIdentifier')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
-        $principalFactory->shouldReceive('create')
-            ->with($identityIdentifier)
-            ->once()
-            ->andReturn($expectedPrincipal);
-
-        $principalRepository->shouldReceive('save')
-            ->with($expectedPrincipal)
-            ->once();
-
-        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn(null);
-
-        $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
-        $principalGroupFactory->shouldReceive('create')
-            ->with($accountIdentifier, 'Default', true)
-            ->once()
-            ->andReturn($defaultPrincipalGroup);
-
-        $principalGroupRepository->shouldReceive('save')
-            ->with($defaultPrincipalGroup)
-            ->twice();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($accountIdentifier)
-            ->once()
-            ->andReturn($agencyAccount);
-
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldReceive('findByName')
-            ->with('AGENCY_ACTOR')
-            ->once()
-            ->andReturnNull();
-
-        $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
-        $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
-        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
-        $useCase = $this->app->make(CreatePrincipalInterface::class);
-        $output = new CreatePrincipalOutput();
-        $useCase->process($input, $output);
-
-        $result = $output->toArray();
-        $this->assertSame((string) $principalIdentifier, $result['principalIdentifier']);
-        $this->assertEmpty($defaultPrincipalGroup->roles());
-    }
-
-    private function createAccount(AccountCategory $category): Account
-    {
-        return new Account(
-            new AccountIdentifier(StrTestHelper::generateUuid()),
-            new Email('test@example.com'),
-            AccountType::CORPORATION,
-            new AccountName('Test Account'),
-            AccountStatus::ACTIVE,
-            $category,
-            DeletionReadinessChecklist::ready(),
-        );
-    }
-
-    private function createRole(RoleIdentifier $roleIdentifier, string $name): Role
-    {
-        return new Role(
-            $roleIdentifier,
-            $name,
-            [],
-            true,
-            new DateTimeImmutable(),
+        $this->app->make(CreatePrincipalInterface::class)->process(
+            new CreatePrincipalInput($identityIdentifier, $accountIdentifier),
+            new CreatePrincipalOutput(),
         );
     }
 }


### PR DESCRIPTION
## 📝 変更内容

- Wiki Principal作成時のDefault PrincipalGroup付与ロールを、Account種別に関係なくCOLLABORATORへ統一
- ローカル/テスト用フルアクセスSeederを、Defaultグループではなく別の非DefaultグループでADMINISTRATOR権限を付与する構成へ変更
- Senior Collaborator昇格/降格処理を、既存グループのロール差し替えではなくPrincipalGroup所属の移動に変更
  - 昇格時: Defaultグループから外し、Senior Collaboratorグループへ追加
  - 降格時: Senior Collaboratorグループから外し、Defaultグループへ戻す

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🚀 新機能 (Feature)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki側のDefault PrincipalGroupが強い権限を持つと、新規Principal作成時に意図せず承認権限やフルアクセスを継承し得るため、初期権限をCOLLABORATORに統一します。

## 🧪 テスト

### テストの実行確認

- [x] `task test -- tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalTest.php tests/Wiki/Grading/Application/UseCase/Command/ProcessRolePromotion/ProcessRolePromotionTest.php` を実行し、全PHPUnitがパスすることを確認
- [x] `task phpstan` を実行し、静的解析がパスすることを確認
- [x] 変更したPrincipal作成・昇格/降格処理に対するテストを更新

## 🔍 レビューのポイント

- `CreatePrincipal` がAccount種別を見ずにCOLLABORATORを付与する設計で問題ないか
- Senior Collaborator昇格/降格時のPrincipalGroup所属移動が期待する権限モデルと一致しているか
- `FullAccessTestAccountSeeder` のDefaultグループとフルアクセスグループの分離がテスト用途として妥当か

## ⚠️ 注意事項

- マイグレーションはありません
- `FullAccessTestAccountSeeder` はlocal/testing環境のみ対象です

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
