### PR TITLE
Account PrincipalGroup のメンバー一括更新APIを追加

### DIFF
--- a/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersAction.php
+++ b/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersAction.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\PrincipalGroup\Command\UpdatePrincipalGroupMembers;
+
+use Application\Http\Context\AccountContext;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Principal\Application\Exception\CannotRemoveLastPrincipalGroupManagerException;
+use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Account\Principal\Application\Exception\PrincipalNotFoundException;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\PrincipalGroupMembers;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersInput;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersInterface;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersOutput;
+use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class UpdatePrincipalGroupMembersAction
+{
+    public function __construct(
+        private UpdatePrincipalGroupMembersInterface $updatePrincipalGroupMembers,
+        private AccountContext $accountContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /** @throws InternalServerErrorHttpException */
+    public function __invoke(UpdatePrincipalGroupMembersRequest $request): JsonResponse
+    {
+        try {
+            $language = $request->language();
+
+            try {
+                $input = new UpdatePrincipalGroupMembersInput(
+                    accountIdentifier: $this->accountContext->principal()->accountIdentifier(),
+                    principal: $this->accountContext->principal(),
+                    principalGroups: array_map(static fn (array $principalGroup): PrincipalGroupMembers => new PrincipalGroupMembers(
+                        new PrincipalGroupIdentifier($principalGroup['principalGroupIdentifier']),
+                        array_map(static fn (string $principalIdentifier): PrincipalIdentifier => new PrincipalIdentifier($principalIdentifier), $principalGroup['principalIdentifiers']),
+                    ), $request->principalGroups()),
+                );
+                $output = new UpdatePrincipalGroupMembersOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            try {
+                $this->updatePrincipalGroupMembers->process($input, $output);
+                DB::commit();
+            } catch (AccountUpdateForbiddenException $e) {
+                DB::rollBack();
+
+                throw new ForbiddenHttpException(detail: error_message('account_update_forbidden', $language), previous: $e);
+            } catch (PrincipalGroupNotFoundException|PrincipalNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: error_message($e instanceof PrincipalGroupNotFoundException ? 'principal_group_not_found' : 'principal_not_found', $language), previous: $e);
+            } catch (CannotRemoveLastPrincipalGroupManagerException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('cannot_remove_last_principal_group_manager', $language), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|NotFoundHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersRequest.php
+++ b/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\PrincipalGroup\Command\UpdatePrincipalGroupMembers;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePrincipalGroupMembersRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'principalGroups' => ['required', 'array'],
+            'principalGroups.*.principalGroupIdentifier' => ['required', 'uuid', 'distinct'],
+            'principalGroups.*.principalIdentifiers' => ['required', 'array'],
+            'principalGroups.*.principalIdentifiers.*' => ['required', 'uuid', 'distinct'],
+        ];
+    }
+
+    /** @return array<int, array{principalGroupIdentifier: string, principalIdentifiers: array<int, string>}> */
+    public function principalGroups(): array
+    {
+        /** @var array<int, array{principalGroupIdentifier: string, principalIdentifiers: array<int, string>}> $principalGroups */
+        $principalGroups = $this->input('principalGroups', []);
+
+        return $principalGroups;
+    }
+}

--- a/application/Providers/Account/UseCaseServiceProvider.php
+++ b/application/Providers/Account/UseCaseServiceProvider.php
@@ -47,6 +47,8 @@ use Source\Account\Principal\Application\UseCase\Command\DeletePrincipalGroup\De
 use Source\Account\Principal\Application\UseCase\Command\DeletePrincipalGroup\DeletePrincipalGroupInterface;
 use Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroup;
 use Source\Account\Principal\Application\UseCase\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupInterface;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembers;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersInterface;
 use Source\Account\Principal\Application\UseCase\Query\ListMembers\ListMembersInterface;
 use Source\Account\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInterface;
 use Source\Account\Principal\Infrastructure\Query\ListMembers;
@@ -61,6 +63,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(DeletePrincipalGroupInterface::class, DeletePrincipalGroup::class);
         $this->app->singleton(AddPrincipalToPrincipalGroupInterface::class, AddPrincipalToPrincipalGroup::class);
         $this->app->singleton(RemovePrincipalFromPrincipalGroupInterface::class, RemovePrincipalFromPrincipalGroup::class);
+        $this->app->singleton(UpdatePrincipalGroupMembersInterface::class, UpdatePrincipalGroupMembers::class);
         $this->app->singleton(ListMembersInterface::class, ListMembers::class);
         $this->app->singleton(ListPrincipalGroupsInterface::class, ListPrincipalGroups::class);
         $this->app->singleton(GrantDelegationPermissionInterface::class, GrantDelegationPermission::class);

--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -878,6 +878,54 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreatePrincipalGroupRequestBody'
+  /principal-groups/members:
+    patch:
+      operationId: PrincipalGroupOperations_updatePrincipalGroupMembers
+      description: Update members for multiple principal groups.
+      parameters: []
+      responses:
+        '200':
+          description: Response returned when multiple principal group memberships are updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPrincipalGroupsResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePrincipalGroupMembersRequestBody'
   /principal-groups/{principalGroupId}:
     delete:
       operationId: PrincipalGroupOperations_deletePrincipalGroup
@@ -1692,6 +1740,33 @@ components:
           type: string
           description: Updated account display name.
       description: Request body for updating account information.
+    UpdatePrincipalGroupMembersItem:
+      type: object
+      required:
+        - principalGroupIdentifier
+        - principalIdentifiers
+      properties:
+        principalGroupIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Principal group identifier whose members will be updated.
+        principalIdentifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Principal identifiers that should belong to the principal group after the update.
+      description: Principal group membership update item.
+    UpdatePrincipalGroupMembersRequestBody:
+      type: object
+      required:
+        - principalGroups
+      properties:
+        principalGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdatePrincipalGroupMembersItem'
+          description: Principal groups and their updated member sets.
+      description: Request body for updating multiple principal group memberships.
     VerificationDocumentSummary:
       type: object
       required:

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -56,6 +56,7 @@ return [
     'identity_already_member' => 'The identity is already a member of this group.',
     'identity_not_member' => 'The identity is not a member of this group.',
     'cannot_remove_last_owner' => 'Cannot remove the last owner from the account.',
+    'cannot_remove_last_principal_group_manager' => 'At least one principal with principal group manage permission is required.',
     'cannot_delete_default_identity_group' => 'Cannot delete the default identity group.',
     'cannot_delete_last_owner_group' => 'Cannot delete the last owner group with members.',
     'delegation_not_found' => 'The specified delegation was not found.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -56,6 +56,7 @@ return [
     'identity_already_member' => 'La identidad ya es miembro de este grupo.',
     'identity_not_member' => 'La identidad no es miembro de este grupo.',
     'cannot_remove_last_owner' => 'No se puede eliminar al último propietario de la cuenta.',
+    'cannot_remove_last_principal_group_manager' => 'Se requiere al menos un principal con permiso para administrar grupos de principales.',
     'cannot_delete_default_identity_group' => 'No se puede eliminar el grupo de identidad predeterminado.',
     'cannot_delete_last_owner_group' => 'No se puede eliminar el último grupo de propietarios con miembros.',
     'delegation_not_found' => 'No se encontró la delegación especificada.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -56,6 +56,7 @@ return [
     'identity_already_member' => 'このアイデンティティは既にこのグループのメンバーです。',
     'identity_not_member' => 'このアイデンティティはこのグループのメンバーではありません。',
     'cannot_remove_last_owner' => 'アカウントから最後のオーナーを削除することはできません。',
+    'cannot_remove_last_principal_group_manager' => 'PrincipalGroup を管理できる Principal が少なくとも1人必要です。',
     'cannot_delete_default_identity_group' => 'デフォルトのアイデンティティグループは削除できません。',
     'cannot_delete_last_owner_group' => 'メンバーがいる最後のオーナーグループは削除できません。',
     'delegation_not_found' => '指定された委任が見つかりません。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -56,6 +56,7 @@ return [
     'identity_already_member' => '해당 아이덴티티는 이미 이 그룹의 멤버입니다.',
     'identity_not_member' => '해당 아이덴티티는 이 그룹의 멤버가 아닙니다.',
     'cannot_remove_last_owner' => '계정에서 마지막 소유자를 제거할 수 없습니다.',
+    'cannot_remove_last_principal_group_manager' => 'PrincipalGroup 관리 권한을 가진 Principal이 최소 1명 필요합니다.',
     'cannot_delete_default_identity_group' => '기본 아이덴티티 그룹은 삭제할 수 없습니다.',
     'cannot_delete_last_owner_group' => '멤버가 있는 마지막 소유자 그룹은 삭제할 수 없습니다.',
     'delegation_not_found' => '지정된 위임을 찾을 수 없습니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -56,6 +56,7 @@ return [
     'identity_already_member' => '该身份已是此组的成员。',
     'identity_not_member' => '该身份不是此组的成员。',
     'cannot_remove_last_owner' => '无法移除账户的最后一个所有者。',
+    'cannot_remove_last_principal_group_manager' => '至少需要一个拥有 PrincipalGroup 管理权限的 Principal。',
     'cannot_delete_default_identity_group' => '无法删除默认身份组。',
     'cannot_delete_last_owner_group' => '无法删除有成员的最后一个所有者组。',
     'delegation_not_found' => '找不到指定的委托。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -56,6 +56,7 @@ return [
     'identity_already_member' => '該身分已是此群組的成員。',
     'identity_not_member' => '該身分不是此群組的成員。',
     'cannot_remove_last_owner' => '無法移除帳戶的最後一個擁有者。',
+    'cannot_remove_last_principal_group_manager' => '至少需要一個擁有 PrincipalGroup 管理權限的 Principal。',
     'cannot_delete_default_identity_group' => '無法刪除預設身分群組。',
     'cannot_delete_last_owner_group' => '無法刪除有成員的最後一個擁有者群組。',
     'delegation_not_found' => '找不到指定的委託。',

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -24,6 +24,7 @@ use Application\Http\Action\Account\PrincipalGroup\Command\CreatePrincipalGroup\
 use Application\Http\Action\Account\PrincipalGroup\Command\DeletePrincipalGroup\DeletePrincipalGroupAction;
 use Application\Http\Action\Account\PrincipalGroup\Query\ListPrincipalGroups\ListPrincipalGroupsAction;
 use Application\Http\Action\Account\PrincipalGroup\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupAction;
+use Application\Http\Action\Account\PrincipalGroup\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersAction;
 use Application\Http\Action\Account\Invitation\Command\InviteMember\InviteMemberAction;
 use Illuminate\Support\Facades\Route;
 
@@ -53,6 +54,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.account'])->group(funct
     Route::post('/principal-groups', CreatePrincipalGroupAction::class);
     Route::post('/principal-groups/{principalGroupId}/add-member', AddPrincipalToPrincipalGroupAction::class);
     Route::post('/principal-groups/{principalGroupId}/remove-member', RemovePrincipalFromPrincipalGroupAction::class);
+    Route::patch('/principal-groups/members', UpdatePrincipalGroupMembersAction::class);
     Route::delete('/principal-groups/{principalGroupId}', DeletePrincipalGroupAction::class);
 
     // Invitation

--- a/src/Account/Principal/Application/Exception/CannotRemoveLastPrincipalGroupManagerException.php
+++ b/src/Account/Principal/Application/Exception/CannotRemoveLastPrincipalGroupManagerException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\Exception;
+
+use RuntimeException;
+
+class CannotRemoveLastPrincipalGroupManagerException extends RuntimeException
+{
+}

--- a/src/Account/Principal/Application/Exception/PrincipalNotFoundException.php
+++ b/src/Account/Principal/Application/Exception/PrincipalNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\Exception;
+
+use RuntimeException;
+
+class PrincipalNotFoundException extends RuntimeException
+{
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/PrincipalGroupMembers.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/PrincipalGroupMembers.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+
+readonly class PrincipalGroupMembers
+{
+    /**
+     * @param array<int, PrincipalIdentifier> $principalIdentifiers
+     */
+    public function __construct(
+        private PrincipalGroupIdentifier $principalGroupIdentifier,
+        private array $principalIdentifiers,
+    ) {
+    }
+
+    public function principalGroupIdentifier(): PrincipalGroupIdentifier
+    {
+        return $this->principalGroupIdentifier;
+    }
+
+    /**
+     * @return array<int, PrincipalIdentifier>
+     */
+    public function principalIdentifiers(): array
+    {
+        return $this->principalIdentifiers;
+    }
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Principal\Application\Exception\CannotRemoveLastPrincipalGroupManagerException;
+use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Account\Principal\Application\Exception\PrincipalNotFoundException;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Effect;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Account\Principal\Domain\ValueObject\ResourceType;
+use Source\Account\Principal\Domain\ValueObject\Statement;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+readonly class UpdatePrincipalGroupMembers implements UpdatePrincipalGroupMembersInterface
+{
+    public function __construct(
+        private PrincipalGroupRepositoryInterface $principalGroupRepository,
+        private PrincipalRepositoryInterface $principalRepository,
+        private RoleRepositoryInterface $roleRepository,
+        private PolicyRepositoryInterface $policyRepository,
+        private PolicyEvaluatorInterface $policyEvaluator,
+    ) {
+    }
+
+    public function process(UpdatePrincipalGroupMembersInputPort $input, UpdatePrincipalGroupMembersOutputPort $output): void
+    {
+        $accountIdentifier = $input->accountIdentifier();
+        if ((string) $input->principal()->accountIdentifier() !== (string) $accountIdentifier
+            || ! $this->policyEvaluator->evaluate($input->principal(), Action::PRINCIPAL_GROUP_MANAGE, Resource::account($accountIdentifier))
+        ) {
+            throw new AccountUpdateForbiddenException();
+        }
+
+        $principalGroups = $this->principalGroupRepository->findByAccountId($accountIdentifier);
+        $principalGroupsById = [];
+        foreach ($principalGroups as $principalGroup) {
+            $principalGroupsById[(string) $principalGroup->principalGroupIdentifier()] = $principalGroup;
+        }
+
+        $requestedPrincipalIdentifiersByGroupId = [];
+        $allRequestedPrincipalIdentifiers = [];
+        foreach ($input->principalGroups() as $principalGroupInput) {
+            $principalGroupId = (string) $principalGroupInput->principalGroupIdentifier();
+            if (! isset($principalGroupsById[$principalGroupId])) {
+                throw new PrincipalGroupNotFoundException();
+            }
+
+            $requestedPrincipalIdentifiersByGroupId[$principalGroupId] = $principalGroupInput->principalIdentifiers();
+            foreach ($principalGroupInput->principalIdentifiers() as $principalIdentifier) {
+                $allRequestedPrincipalIdentifiers[(string) $principalIdentifier] = $principalIdentifier;
+            }
+        }
+
+        foreach ($requestedPrincipalIdentifiersByGroupId as $principalGroupId => $principalIdentifiers) {
+            $principalGroupsById[$principalGroupId]->replaceMembers($principalIdentifiers);
+        }
+
+        $principalsById = $this->principalRepository->findByIds(array_values($this->collectPrincipalIdentifiers($principalGroups)));
+        $this->assertPrincipalsBelongToAccount(array_values($allRequestedPrincipalIdentifiers), $principalsById, $accountIdentifier);
+
+        if (! $this->hasPrincipalGroupManager($principalGroups, $principalsById)) {
+            throw new CannotRemoveLastPrincipalGroupManagerException();
+        }
+
+        foreach (array_keys($requestedPrincipalIdentifiersByGroupId) as $principalGroupId) {
+            $this->principalGroupRepository->save($principalGroupsById[$principalGroupId]);
+        }
+
+        $output->setPrincipalGroups(array_values(array_intersect_key($principalGroupsById, $requestedPrincipalIdentifiersByGroupId)));
+    }
+
+    /**
+     * @param array<int, PrincipalIdentifier> $principalIdentifiers
+     * @param array<string, Principal> $principalsById
+     */
+    private function assertPrincipalsBelongToAccount(array $principalIdentifiers, array $principalsById, AccountIdentifier $accountIdentifier): void
+    {
+        foreach ($principalIdentifiers as $principalIdentifier) {
+            $principal = $principalsById[(string) $principalIdentifier] ?? null;
+            if ($principal === null || (string) $principal->accountIdentifier() !== (string) $accountIdentifier) {
+                throw new PrincipalNotFoundException();
+            }
+        }
+    }
+
+    /**
+     * @param array<int, PrincipalGroup> $principalGroups
+     * @param array<string, Principal> $principalsById
+     */
+    private function hasPrincipalGroupManager(array $principalGroups, array $principalsById): bool
+    {
+        $roleIdentifiersByPrincipalId = $this->collectRoleIdentifiersByPrincipalId($principalGroups, $principalsById);
+        if (empty($roleIdentifiersByPrincipalId)) {
+            return false;
+        }
+
+        $roles = $this->roleRepository->findByIds(array_values($this->flattenUnique($roleIdentifiersByPrincipalId)));
+        $policyIdentifiersByPrincipalId = $this->collectPolicyIdentifiersByPrincipalId($roleIdentifiersByPrincipalId, $roles);
+        if (empty($policyIdentifiersByPrincipalId)) {
+            return false;
+        }
+
+        $policies = $this->policyRepository->findByIds(array_values($this->flattenUnique($policyIdentifiersByPrincipalId)));
+
+        return array_any($policyIdentifiersByPrincipalId, fn ($policyIdentifiers) => $this->canManagePrincipalGroups($policyIdentifiers, $policies));
+    }
+
+    /**
+     * @param array<int, PrincipalGroup> $principalGroups
+     * @return array<string, PrincipalIdentifier>
+     */
+    private function collectPrincipalIdentifiers(array $principalGroups): array
+    {
+        $principalIdentifiers = [];
+        foreach ($principalGroups as $principalGroup) {
+            foreach ($principalGroup->members() as $principalIdentifier) {
+                $principalIdentifiers[(string) $principalIdentifier] = $principalIdentifier;
+            }
+        }
+
+        return $principalIdentifiers;
+    }
+
+    /**
+     * @param array<int, PrincipalGroup> $principalGroups
+     * @param array<string, Principal> $principalsById
+     * @return array<string, array<string, \Source\Account\Principal\Domain\ValueObject\RoleIdentifier>>
+     */
+    private function collectRoleIdentifiersByPrincipalId(array $principalGroups, array $principalsById): array
+    {
+        $roleIdentifiersByPrincipalId = [];
+        foreach ($principalGroups as $principalGroup) {
+            foreach ($principalGroup->roles() as $roleIdentifier) {
+                foreach ($principalGroup->members() as $principalIdentifier) {
+                    $principalId = (string) $principalIdentifier;
+                    if (! isset($principalsById[$principalId])) {
+                        continue;
+                    }
+                    $roleIdentifiersByPrincipalId[$principalId][(string) $roleIdentifier] = $roleIdentifier;
+                }
+            }
+        }
+
+        return $roleIdentifiersByPrincipalId;
+    }
+
+    /**
+     * @param array<string, array<string, \Source\Account\Principal\Domain\ValueObject\RoleIdentifier>> $roleIdentifiersByPrincipalId
+     * @param array<string, \Source\Account\Principal\Domain\Entity\Role> $roles
+     * @return array<string, array<string, \Source\Account\Principal\Domain\ValueObject\PolicyIdentifier>>
+     */
+    private function collectPolicyIdentifiersByPrincipalId(array $roleIdentifiersByPrincipalId, array $roles): array
+    {
+        $policyIdentifiersByPrincipalId = [];
+        foreach ($roleIdentifiersByPrincipalId as $principalId => $roleIdentifiers) {
+            foreach ($roleIdentifiers as $roleIdentifier) {
+                $role = $roles[(string) $roleIdentifier] ?? null;
+                if ($role === null) {
+                    continue;
+                }
+                foreach ($role->policies() as $policyIdentifier) {
+                    $policyIdentifiersByPrincipalId[$principalId][(string) $policyIdentifier] = $policyIdentifier;
+                }
+            }
+        }
+
+        return $policyIdentifiersByPrincipalId;
+    }
+
+    /**
+     * @param array<string, \Source\Account\Principal\Domain\ValueObject\PolicyIdentifier> $policyIdentifiers
+     * @param array<string, \Source\Account\Principal\Domain\Entity\Policy> $policies
+     */
+    private function canManagePrincipalGroups(array $policyIdentifiers, array $policies): bool
+    {
+        $statements = [];
+        foreach ($policyIdentifiers as $policyIdentifier) {
+            $policy = $policies[(string) $policyIdentifier] ?? null;
+            if ($policy === null) {
+                continue;
+            }
+            array_push($statements, ...$policy->statements());
+        }
+
+        $applicableStatements = array_filter(
+            $statements,
+            static fn (Statement $statement): bool =>
+            in_array(Action::PRINCIPAL_GROUP_MANAGE, $statement->actions(), true)
+            && in_array(ResourceType::ACCOUNT, $statement->resourceTypes(), true)
+        );
+
+        if (array_any($applicableStatements, static fn (Statement $statement): bool => $statement->effect() === Effect::DENY)) {
+            return false;
+        }
+
+        return array_any($applicableStatements, static fn (Statement $statement): bool => $statement->effect() === Effect::ALLOW);
+    }
+
+    /**
+     * @template T
+     * @param array<string, array<string, T>> $itemsByOwnerId
+     * @return array<string, T>
+     */
+    private function flattenUnique(array $itemsByOwnerId): array
+    {
+        $items = [];
+        foreach ($itemsByOwnerId as $ownerItems) {
+            foreach ($ownerItems as $itemId => $item) {
+                $items[$itemId] = $item;
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInput.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+readonly class UpdatePrincipalGroupMembersInput implements UpdatePrincipalGroupMembersInputPort
+{
+    /**
+     * @param array<int, PrincipalGroupMembers> $principalGroups
+     */
+    public function __construct(
+        private AccountIdentifier $accountIdentifier,
+        private Principal $principal,
+        private array $principalGroups,
+    ) {
+    }
+
+    public function accountIdentifier(): AccountIdentifier
+    {
+        return $this->accountIdentifier;
+    }
+
+    public function principal(): Principal
+    {
+        return $this->principal;
+    }
+
+    /**
+     * @return array<int, PrincipalGroupMembers>
+     */
+    public function principalGroups(): array
+    {
+        return $this->principalGroups;
+    }
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInputPort.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+interface UpdatePrincipalGroupMembersInputPort
+{
+    public function accountIdentifier(): AccountIdentifier;
+
+    public function principal(): Principal;
+
+    /**
+     * @return array<int, PrincipalGroupMembers>
+     */
+    public function principalGroups(): array;
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInterface.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Principal\Application\Exception\CannotRemoveLastPrincipalGroupManagerException;
+use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Account\Principal\Application\Exception\PrincipalNotFoundException;
+
+interface UpdatePrincipalGroupMembersInterface
+{
+    /**
+     * @throws AccountUpdateForbiddenException
+     * @throws CannotRemoveLastPrincipalGroupManagerException
+     * @throws PrincipalGroupNotFoundException
+     * @throws PrincipalNotFoundException
+     */
+    public function process(UpdatePrincipalGroupMembersInputPort $input, UpdatePrincipalGroupMembersOutputPort $output): void;
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersOutput.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersOutput.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+
+class UpdatePrincipalGroupMembersOutput implements UpdatePrincipalGroupMembersOutputPort
+{
+    /** @var array<int, PrincipalGroup> */
+    private array $principalGroups = [];
+
+    /** @param array<int, PrincipalGroup> $principalGroups */
+    public function setPrincipalGroups(array $principalGroups): void
+    {
+        $this->principalGroups = $principalGroups;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'principalGroups' => array_map(static fn (PrincipalGroup $principalGroup): array => [
+                'principalGroupIdentifier' => (string) $principalGroup->principalGroupIdentifier(),
+                'accountIdentifier' => (string) $principalGroup->accountIdentifier(),
+                'name' => $principalGroup->name(),
+                'roleIdentifiers' => array_map(static fn ($roleIdentifier): string => (string) $roleIdentifier, $principalGroup->roles()),
+                'isDefault' => $principalGroup->isDefault(),
+                'members' => array_map(
+                    static fn (PrincipalIdentifier $principalIdentifier): string => (string) $principalIdentifier,
+                    array_values($principalGroup->members()),
+                ),
+            ], $this->principalGroups),
+        ];
+    }
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersOutputPort.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersOutputPort.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+
+interface UpdatePrincipalGroupMembersOutputPort
+{
+    /** @param array<int, PrincipalGroup> $principalGroups */
+    public function setPrincipalGroups(array $principalGroups): void;
+}

--- a/src/Account/Principal/Domain/Entity/PrincipalGroup.php
+++ b/src/Account/Principal/Domain/Entity/PrincipalGroup.php
@@ -91,6 +91,18 @@ class PrincipalGroup
     }
 
     /**
+     * @param array<int, PrincipalIdentifier> $principalIdentifiers
+     */
+    public function replaceMembers(array $principalIdentifiers): void
+    {
+        $this->members = [];
+
+        foreach ($principalIdentifiers as $principalIdentifier) {
+            $this->members[(string) $principalIdentifier] = $principalIdentifier;
+        }
+    }
+
+    /**
      * @return RoleIdentifier[]
      */
     public function roles(): array

--- a/src/Account/Principal/Domain/Repository/PrincipalRepositoryInterface.php
+++ b/src/Account/Principal/Domain/Repository/PrincipalRepositoryInterface.php
@@ -13,6 +13,12 @@ interface PrincipalRepositoryInterface
 {
     public function findById(PrincipalIdentifier $principalIdentifier): ?Principal;
 
+    /**
+     * @param array<int, PrincipalIdentifier> $principalIdentifiers
+     * @return array<string, Principal>
+     */
+    public function findByIds(array $principalIdentifiers): array;
+
     public function findByIdentityIdentifier(IdentityIdentifier $identityIdentifier): ?Principal;
 
     public function findByIdentityIdentifierAndAccountIdentifier(

--- a/src/Account/Principal/Infrastructure/Repository/PrincipalRepository.php
+++ b/src/Account/Principal/Infrastructure/Repository/PrincipalRepository.php
@@ -27,6 +27,30 @@ class PrincipalRepository implements PrincipalRepositoryInterface
         return $this->toDomainEntity($eloquent);
     }
 
+    /**
+     * @param array<int, PrincipalIdentifier> $principalIdentifiers
+     * @return array<string, Principal>
+     */
+    public function findByIds(array $principalIdentifiers): array
+    {
+        if (empty($principalIdentifiers)) {
+            return [];
+        }
+
+        $ids = array_map(static fn (PrincipalIdentifier $principalIdentifier): string => (string) $principalIdentifier, $principalIdentifiers);
+
+        $eloquents = PrincipalEloquent::query()
+            ->whereIn('id', $ids)
+            ->get();
+
+        $result = [];
+        foreach ($eloquents as $eloquent) {
+            $result[$eloquent->id] = $this->toDomainEntity($eloquent);
+        }
+
+        return $result;
+    }
+
     public function findByIdentityIdentifier(IdentityIdentifier $identityIdentifier): ?Principal
     {
         $eloquent = PrincipalEloquent::query()

--- a/tests/Account/Principal/Infrastructure/Repository/PrincipalRepositoryTest.php
+++ b/tests/Account/Principal/Infrastructure/Repository/PrincipalRepositoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Principal\Infrastructure\Repository;
+
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Account\Principal\Infrastructure\Repository\PrincipalRepository;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\CreateAccount;
+use Tests\Helper\CreateIdentity;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class PrincipalRepositoryTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $repository = $this->app->make(PrincipalRepositoryInterface::class);
+
+        $this->assertInstanceOf(PrincipalRepository::class, $repository);
+    }
+
+    #[Group('useDb')]
+    public function testFindByIdsReturnsPrincipalsIndexedById(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $accountIdentifier);
+        $principalIdentifierA = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifierB = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $identityIdentifierA = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $identityIdentifierB = new IdentityIdentifier(StrTestHelper::generateUuid());
+        CreateIdentity::create($identityIdentifierA, ['email' => 'principal-a@example.com']);
+        CreateIdentity::create($identityIdentifierB, ['email' => 'principal-b@example.com']);
+        $this->createPrincipal($principalIdentifierA, $identityIdentifierA, $accountIdentifier);
+        $this->createPrincipal($principalIdentifierB, $identityIdentifierB, $accountIdentifier);
+
+        $repository = $this->app->make(PrincipalRepositoryInterface::class);
+        $principals = $repository->findByIds([$principalIdentifierA, $principalIdentifierB]);
+
+        $this->assertCount(2, $principals);
+        $this->assertContainsOnlyInstancesOf(Principal::class, $principals);
+        $this->assertArrayHasKey((string) $principalIdentifierA, $principals);
+        $this->assertArrayHasKey((string) $principalIdentifierB, $principals);
+        $this->assertSame((string) $identityIdentifierA, (string) $principals[(string) $principalIdentifierA]->identityIdentifier());
+        $this->assertSame((string) $identityIdentifierB, (string) $principals[(string) $principalIdentifierB]->identityIdentifier());
+    }
+
+    #[Group('useDb')]
+    public function testFindByIdsReturnsEmptyArrayWhenEmptyInput(): void
+    {
+        $repository = $this->app->make(PrincipalRepositoryInterface::class);
+
+        $this->assertSame([], $repository->findByIds([]));
+    }
+
+    #[Group('useDb')]
+    public function testFindByIdsExcludesMissingPrincipals(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $accountIdentifier);
+        $existingPrincipalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $missingPrincipalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        CreateIdentity::create($identityIdentifier, ['email' => 'principal-existing@example.com']);
+        $this->createPrincipal($existingPrincipalIdentifier, $identityIdentifier, $accountIdentifier);
+
+        $repository = $this->app->make(PrincipalRepositoryInterface::class);
+        $principals = $repository->findByIds([$existingPrincipalIdentifier, $missingPrincipalIdentifier]);
+
+        $this->assertCount(1, $principals);
+        $this->assertArrayHasKey((string) $existingPrincipalIdentifier, $principals);
+        $this->assertArrayNotHasKey((string) $missingPrincipalIdentifier, $principals);
+    }
+
+    private function createPrincipal(
+        PrincipalIdentifier $principalIdentifier,
+        IdentityIdentifier $identityIdentifier,
+        AccountIdentifier $accountIdentifier,
+    ): void {
+        DB::table('account_principals')->insert([
+            'id' => (string) $principalIdentifier,
+            'identity_id' => (string) $identityIdentifier,
+            'account_id' => (string) $accountIdentifier,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/PrincipalGroupMembersTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/PrincipalGroupMembersTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\PrincipalGroup\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\PrincipalGroupMembers;
+use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class PrincipalGroupMembersTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifierA = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifierB = new PrincipalIdentifier(StrTestHelper::generateUuid());
+
+        $principalGroupMembers = new PrincipalGroupMembers(
+            $principalGroupIdentifier,
+            [$principalIdentifierA, $principalIdentifierB],
+        );
+
+        $this->assertSame($principalGroupIdentifier, $principalGroupMembers->principalGroupIdentifier());
+        $this->assertSame([$principalIdentifierA, $principalIdentifierB], $principalGroupMembers->principalIdentifiers());
+    }
+}

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInputTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInputTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\PrincipalGroup\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\PrincipalGroupMembers;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersInput;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UpdatePrincipalGroupMembersInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            $accountIdentifier,
+        );
+        $principalGroupMembers = new PrincipalGroupMembers(
+            new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
+            [new PrincipalIdentifier(StrTestHelper::generateUuid())],
+        );
+
+        $input = new UpdatePrincipalGroupMembersInput($accountIdentifier, $principal, [$principalGroupMembers]);
+
+        $this->assertSame($accountIdentifier, $input->accountIdentifier());
+        $this->assertSame($principal, $input->principal());
+        $this->assertSame([$principalGroupMembers], $input->principalGroups());
+    }
+}

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersOutputTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersOutputTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\PrincipalGroup\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use DateTimeImmutable;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersOutput;
+use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Principal\Domain\ValueObject\RoleIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UpdatePrincipalGroupMembersOutputTest extends TestCase
+{
+    public function testToArrayWithPrincipalGroups(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principalGroupIdentifierA = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $principalGroupIdentifierB = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifierA = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifierB = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        $principalGroupA = new PrincipalGroup(
+            $principalGroupIdentifierA,
+            $accountIdentifier,
+            'Managers',
+            true,
+            new DateTimeImmutable(),
+        );
+        $principalGroupA->addRole($roleIdentifier);
+        $principalGroupA->addMember($principalIdentifierA);
+        $principalGroupB = new PrincipalGroup(
+            $principalGroupIdentifierB,
+            $accountIdentifier,
+            'Members',
+            false,
+            new DateTimeImmutable(),
+        );
+        $principalGroupB->addMember($principalIdentifierB);
+
+        $output = new UpdatePrincipalGroupMembersOutput();
+        $output->setPrincipalGroups([$principalGroupA, $principalGroupB]);
+
+        $result = $output->toArray();
+
+        $this->assertCount(2, $result['principalGroups']);
+        $this->assertSame((string) $principalGroupIdentifierA, $result['principalGroups'][0]['principalGroupIdentifier']);
+        $this->assertSame((string) $accountIdentifier, $result['principalGroups'][0]['accountIdentifier']);
+        $this->assertSame('Managers', $result['principalGroups'][0]['name']);
+        $this->assertSame([(string) $roleIdentifier], $result['principalGroups'][0]['roleIdentifiers']);
+        $this->assertTrue($result['principalGroups'][0]['isDefault']);
+        $this->assertSame([(string) $principalIdentifierA], $result['principalGroups'][0]['members']);
+        $this->assertSame((string) $principalGroupIdentifierB, $result['principalGroups'][1]['principalGroupIdentifier']);
+        $this->assertSame([], $result['principalGroups'][1]['roleIdentifiers']);
+        $this->assertFalse($result['principalGroups'][1]['isDefault']);
+        $this->assertSame([(string) $principalIdentifierB], $result['principalGroups'][1]['members']);
+    }
+
+    public function testToArrayWithoutPrincipalGroups(): void
+    {
+        $output = new UpdatePrincipalGroupMembersOutput();
+
+        $this->assertSame(['principalGroups' => []], $output->toArray());
+    }
+}

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\PrincipalGroup\Application\UseCase\Command\UpdatePrincipalGroupMembers;
+
+use DateTimeImmutable;
+use Mockery;
+use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Principal\Application\Exception\CannotRemoveLastPrincipalGroupManagerException;
+use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
+use Source\Account\Principal\Application\Exception\PrincipalNotFoundException;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\PrincipalGroupMembers;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembers;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersInput;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersInterface;
+use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersOutput;
+use Source\Account\Principal\Domain\Entity\Policy;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Entity\PrincipalGroup;
+use Source\Account\Principal\Domain\Entity\Role;
+use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Effect;
+use Source\Account\Principal\Domain\ValueObject\PolicyIdentifier;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Account\Principal\Domain\ValueObject\ResourceType;
+use Source\Account\Principal\Domain\ValueObject\RoleIdentifier;
+use Source\Account\Principal\Domain\ValueObject\Statement;
+use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class UpdatePrincipalGroupMembersTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, Mockery::mock(PrincipalGroupRepositoryInterface::class));
+        $this->app->instance(PrincipalRepositoryInterface::class, Mockery::mock(PrincipalRepositoryInterface::class));
+        $this->app->instance(RoleRepositoryInterface::class, Mockery::mock(RoleRepositoryInterface::class));
+        $this->app->instance(PolicyRepositoryInterface::class, Mockery::mock(PolicyRepositoryInterface::class));
+        $this->app->instance(PolicyEvaluatorInterface::class, Mockery::mock(PolicyEvaluatorInterface::class));
+
+        $this->assertInstanceOf(UpdatePrincipalGroupMembers::class, $this->app->make(UpdatePrincipalGroupMembersInterface::class));
+    }
+
+    public function testProcessUpdatesMultipleGroupMembersAndKeepsUntargetedGroup(): void
+    {
+        [$accountId, $executor, $manager, $memberA, $memberB, $groupA, $groupB, $untargetedGroup, $roleId, $policyId] = $this->fixture();
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA, $groupB, $untargetedGroup]);
+        $principalGroupRepository->shouldReceive('save')->twice()->with(Mockery::on(static fn (PrincipalGroup $group): bool => in_array((string) $group->principalGroupIdentifier(), [(string) $groupA->principalGroupIdentifier(), (string) $groupB->principalGroupIdentifier()], true)));
+
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findByIds')->once()->andReturn([
+            (string) $manager->principalIdentifier() => $manager,
+            (string) $memberA->principalIdentifier() => $memberA,
+            (string) $memberB->principalIdentifier() => $memberB,
+        ]);
+        $principalRepository->shouldNotReceive('findById');
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $principalRepository,
+            $this->roleRepository($roleId, $policyId),
+            $this->policyRepository($policyId),
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $output = new UpdatePrincipalGroupMembersOutput();
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [
+            new PrincipalGroupMembers($groupA->principalGroupIdentifier(), [$manager->principalIdentifier(), $memberA->principalIdentifier()]),
+            new PrincipalGroupMembers($groupB->principalGroupIdentifier(), [$memberB->principalIdentifier()]),
+        ]), $output);
+
+        $this->assertTrue($groupA->hasMember($manager->principalIdentifier()));
+        $this->assertTrue($groupA->hasMember($memberA->principalIdentifier()));
+        $this->assertFalse($groupA->hasMember($memberB->principalIdentifier()));
+        $this->assertTrue($groupB->hasMember($memberB->principalIdentifier()));
+        $this->assertTrue($untargetedGroup->hasMember($manager->principalIdentifier()));
+        $this->assertCount(2, $output->toArray()['principalGroups']);
+    }
+
+    public function testThrowsWhenPrincipalGroupIsOutsideAccount(): void
+    {
+        [$accountId, $executor] = $this->fixture();
+        $unknownGroupId = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([]);
+        $principalGroupRepository->shouldNotReceive('save');
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $this->emptyPrincipalRepository(),
+            $this->emptyRoleRepository(),
+            $this->emptyPolicyRepository(),
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $this->expectException(PrincipalGroupNotFoundException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [new PrincipalGroupMembers($unknownGroupId, [])]), new UpdatePrincipalGroupMembersOutput());
+    }
+
+    public function testThrowsWhenPrincipalIsOutsideAccount(): void
+    {
+        [$accountId, $executor, , $memberA, , $groupA] = $this->fixture();
+        $outsidePrincipal = new Principal($memberA->principalIdentifier(), $memberA->identityIdentifier(), new AccountIdentifier(StrTestHelper::generateUuid()));
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA]);
+        $principalGroupRepository->shouldNotReceive('save');
+
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findByIds')->once()->andReturn([
+            (string) $outsidePrincipal->principalIdentifier() => $outsidePrincipal,
+        ]);
+        $principalRepository->shouldNotReceive('findById');
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $principalRepository,
+            $this->emptyRoleRepository(),
+            $this->emptyPolicyRepository(),
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $this->expectException(PrincipalNotFoundException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [new PrincipalGroupMembers($groupA->principalGroupIdentifier(), [$memberA->principalIdentifier()])]), new UpdatePrincipalGroupMembersOutput());
+    }
+
+    public function testThrowsWhenRequestedPrincipalDoesNotExist(): void
+    {
+        [$accountId, $executor, , $memberA, , $groupA] = $this->fixture();
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA]);
+        $principalGroupRepository->shouldNotReceive('save');
+
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findByIds')->once()->andReturn([]);
+        $principalRepository->shouldNotReceive('findById');
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $principalRepository,
+            $this->emptyRoleRepository(),
+            $this->emptyPolicyRepository(),
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $this->expectException(PrincipalNotFoundException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [new PrincipalGroupMembers($groupA->principalGroupIdentifier(), [$memberA->principalIdentifier()])]), new UpdatePrincipalGroupMembersOutput());
+    }
+
+    public function testThrowsWhenExecutorCannotManagePrincipalGroups(): void
+    {
+        [$accountId, $executor] = $this->fixture();
+        /** @var PolicyEvaluatorInterface&\Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->once()->andReturnFalse();
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldNotReceive('findByAccountId');
+        $principalGroupRepository->shouldNotReceive('save');
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $this->emptyPrincipalRepository(),
+            $this->emptyRoleRepository(),
+            $this->emptyPolicyRepository(),
+            $policyEvaluator,
+        );
+
+        $this->expectException(AccountUpdateForbiddenException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, []), new UpdatePrincipalGroupMembersOutput());
+    }
+
+    public function testThrowsWhenNoManagerRemainsAfterUpdate(): void
+    {
+        [$accountId, $executor, $manager, $memberA, , $groupA, , , $roleId, $policyId] = $this->fixture();
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA]);
+        $principalGroupRepository->shouldNotReceive('save');
+
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findByIds')->once()->andReturn([
+            (string) $memberA->principalIdentifier() => $memberA,
+        ]);
+        $principalRepository->shouldNotReceive('findById');
+
+        /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findByIds')->andReturn([]);
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $principalRepository,
+            $this->roleRepositoryWithoutPolicies($roleId),
+            $policyRepository,
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $this->expectException(CannotRemoveLastPrincipalGroupManagerException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [
+            new PrincipalGroupMembers($groupA->principalGroupIdentifier(), [$memberA->principalIdentifier()]),
+        ]), new UpdatePrincipalGroupMembersOutput());
+    }
+
+    public function testThrowsWhenRemainingManagerHasDenyStatement(): void
+    {
+        [$accountId, $executor, $manager, , , $groupA, , , $roleId, $allowPolicyId] = $this->fixture();
+        $denyPolicyId = new PolicyIdentifier(StrTestHelper::generateUuid());
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA]);
+        $principalGroupRepository->shouldNotReceive('save');
+
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        $principalRepository->shouldReceive('findByIds')->once()->andReturn([
+            (string) $manager->principalIdentifier() => $manager,
+        ]);
+        $principalRepository->shouldNotReceive('findById');
+
+        /** @var RoleRepositoryInterface&\Mockery\MockInterface $roleRepository */
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findByIds')->andReturn([
+            (string) $roleId => new Role($roleId, 'Manager', [$allowPolicyId, $denyPolicyId], false),
+        ]);
+
+        /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findByIds')->andReturn([
+            (string) $allowPolicyId => new Policy(
+                $allowPolicyId,
+                'Allow manage principal groups',
+                [new Statement(Effect::ALLOW, [Action::PRINCIPAL_GROUP_MANAGE], [ResourceType::ACCOUNT])],
+                false,
+                new DateTimeImmutable(),
+            ),
+            (string) $denyPolicyId => new Policy(
+                $denyPolicyId,
+                'Deny manage principal groups',
+                [new Statement(Effect::DENY, [Action::PRINCIPAL_GROUP_MANAGE], [ResourceType::ACCOUNT])],
+                false,
+                new DateTimeImmutable(),
+            ),
+        ]);
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $principalRepository,
+            $roleRepository,
+            $policyRepository,
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $this->expectException(CannotRemoveLastPrincipalGroupManagerException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [
+            new PrincipalGroupMembers($groupA->principalGroupIdentifier(), [$manager->principalIdentifier()]),
+        ]), new UpdatePrincipalGroupMembersOutput());
+    }
+
+    /** @return array{AccountIdentifier, Principal, Principal, Principal, Principal, PrincipalGroup, PrincipalGroup, PrincipalGroup, RoleIdentifier, PolicyIdentifier} */
+    private function fixture(): array
+    {
+        $accountId = new AccountIdentifier(StrTestHelper::generateUuid());
+        $executor = $this->principal($accountId);
+        $manager = $this->principal($accountId);
+        $memberA = $this->principal($accountId);
+        $memberB = $this->principal($accountId);
+        $roleId = new RoleIdentifier(StrTestHelper::generateUuid());
+        $policyId = new PolicyIdentifier(StrTestHelper::generateUuid());
+
+        $groupA = $this->principalGroup($accountId, $roleId);
+        $groupA->addMember($manager->principalIdentifier());
+        $groupA->addMember($memberB->principalIdentifier());
+        $groupB = $this->principalGroup($accountId);
+        $groupB->addMember($memberA->principalIdentifier());
+        $untargetedGroup = $this->principalGroup($accountId, $roleId);
+        $untargetedGroup->addMember($manager->principalIdentifier());
+
+        return [$accountId, $executor, $manager, $memberA, $memberB, $groupA, $groupB, $untargetedGroup, $roleId, $policyId];
+    }
+
+    private function principal(AccountIdentifier $accountId): Principal
+    {
+        return new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), new IdentityIdentifier(StrTestHelper::generateUuid()), $accountId);
+    }
+
+    private function principalGroup(AccountIdentifier $accountId, ?RoleIdentifier $roleId = null): PrincipalGroup
+    {
+        $principalGroup = new PrincipalGroup(new PrincipalGroupIdentifier(StrTestHelper::generateUuid()), $accountId, 'Test Group', false, new DateTimeImmutable());
+        if ($roleId !== null) {
+            $principalGroup->addRole($roleId);
+        }
+
+        return $principalGroup;
+    }
+
+    private function allowedPolicyEvaluator(): PolicyEvaluatorInterface
+    {
+        /** @var PolicyEvaluatorInterface&\Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->with(Mockery::type(Principal::class), Action::PRINCIPAL_GROUP_MANAGE, Mockery::type(Resource::class))->andReturnTrue();
+
+        return $policyEvaluator;
+    }
+
+    private function roleRepository(RoleIdentifier $roleId, PolicyIdentifier $policyId): RoleRepositoryInterface
+    {
+        /** @var RoleRepositoryInterface&\Mockery\MockInterface $roleRepository */
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findByIds')->andReturn([(string) $roleId => new Role($roleId, 'Manager', [$policyId], false)]);
+
+        return $roleRepository;
+    }
+
+    private function policyRepository(PolicyIdentifier $policyId): PolicyRepositoryInterface
+    {
+        /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findByIds')->andReturn([(string) $policyId => new Policy(
+            $policyId,
+            'Manage principal groups',
+            [new Statement(Effect::ALLOW, [Action::PRINCIPAL_GROUP_MANAGE], [ResourceType::ACCOUNT])],
+            false,
+            new DateTimeImmutable(),
+        )]);
+
+        return $policyRepository;
+    }
+
+    private function roleRepositoryWithoutPolicies(RoleIdentifier $roleId): RoleRepositoryInterface
+    {
+        /** @var RoleRepositoryInterface&\Mockery\MockInterface $roleRepository */
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findByIds')->andReturn([(string) $roleId => new Role($roleId, 'Member', [], false)]);
+
+        return $roleRepository;
+    }
+
+    private function emptyPrincipalRepository(): PrincipalRepositoryInterface
+    {
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+
+        return $principalRepository;
+    }
+
+    private function emptyRoleRepository(): RoleRepositoryInterface
+    {
+        /** @var RoleRepositoryInterface&\Mockery\MockInterface $roleRepository */
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+
+        return $roleRepository;
+    }
+
+    private function emptyPolicyRepository(): PolicyRepositoryInterface
+    {
+        /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+
+        return $policyRepository;
+    }
+}

--- a/tests/Account/PrincipalGroup/Domain/Entity/PrincipalGroupTest.php
+++ b/tests/Account/PrincipalGroup/Domain/Entity/PrincipalGroupTest.php
@@ -113,6 +113,37 @@ class PrincipalGroupTest extends TestCase
         $this->assertSame(2, $principalGroup->memberCount());
     }
 
+    public function testReplaceMembers(): void
+    {
+        $principalGroup = $this->createPrincipalGroup();
+        $oldMember = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $newMemberA = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $newMemberB = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principalGroup->addMember($oldMember);
+
+        $principalGroup->replaceMembers([$newMemberA, $newMemberB, $newMemberA]);
+
+        $this->assertFalse($principalGroup->hasMember($oldMember));
+        $this->assertTrue($principalGroup->hasMember($newMemberA));
+        $this->assertTrue($principalGroup->hasMember($newMemberB));
+        $this->assertSame(2, $principalGroup->memberCount());
+        $this->assertSame([
+            (string) $newMemberA => $newMemberA,
+            (string) $newMemberB => $newMemberB,
+        ], $principalGroup->members());
+    }
+
+    public function testReplaceMembersCanClearMembers(): void
+    {
+        $principalGroup = $this->createPrincipalGroup();
+        $principalGroup->addMember(new PrincipalIdentifier(StrTestHelper::generateUuid()));
+
+        $principalGroup->replaceMembers([]);
+
+        $this->assertSame([], $principalGroup->members());
+        $this->assertSame(0, $principalGroup->memberCount());
+    }
+
     public function testAddRoleDoesNotDuplicateRole(): void
     {
         $principalGroup = $this->createPrincipalGroup();

--- a/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
+++ b/tests/Http/Middleware/AuthenticatedRouteProtectionTest.php
@@ -126,6 +126,7 @@ class AuthenticatedRouteProtectionTest extends TestCase
             'account: create invitation' => ['POST', '/api/account/invitations'],
             'account: list members' => ['GET', '/api/account/members'],
             'account: list principal groups' => ['GET', '/api/account/principal-groups'],
+            'account: update principal group members' => ['PATCH', '/api/account/principal-groups/members'],
 
             // Monetization: bootstrap/app.php のグループ設定で全 route が認証必須
             'monetization: provision account' => ['POST', '/api/monetization/accounts'],
@@ -173,6 +174,7 @@ class AuthenticatedRouteProtectionTest extends TestCase
             'account authenticated routes resolve actor and account' => ['POST', '/api/account/delegations', ['resolve.actor', 'resolve.account']],
             'account members resolve actor and account' => ['GET', '/api/account/members', ['resolve.actor', 'resolve.account']],
             'account principal groups resolve actor and account' => ['GET', '/api/account/principal-groups', ['resolve.actor', 'resolve.account']],
+            'account update principal group members resolves actor and account' => ['PATCH', '/api/account/principal-groups/members', ['resolve.actor', 'resolve.account']],
             'account get resolves actor and account' => ['GET', '/api/account/accounts/00000000-0000-0000-0000-000000000001', ['resolve.actor', 'resolve.account']],
             'account update resolves actor and account' => ['PATCH', '/api/account/accounts/00000000-0000-0000-0000-000000000001', ['resolve.actor', 'resolve.account']],
             'monetization routes resolve actor from bootstrap group' => ['POST', '/api/monetization/accounts', ['resolve.actor']],

--- a/typespec/services/account-api/principal-group.tsp
+++ b/typespec/services/account-api/principal-group.tsp
@@ -17,6 +17,20 @@ model MutatePrincipalGroupMemberRequestBody {
   principalIdentifier: Uuid;
 }
 
+@doc("Principal group membership update item.")
+model UpdatePrincipalGroupMembersItem {
+  @doc("Principal group identifier whose members will be updated.")
+  principalGroupIdentifier: Uuid;
+  @doc("Principal identifiers that should belong to the principal group after the update.")
+  principalIdentifiers: Uuid[];
+}
+
+@doc("Request body for updating multiple principal group memberships.")
+model UpdatePrincipalGroupMembersRequestBody {
+  @doc("Principal groups and their updated member sets.")
+  principalGroups: UpdatePrincipalGroupMembersItem[];
+}
+
 @doc("Response returned when an principal group is created.")
 model CreatePrincipalGroupResponse {
   @statusCode statusCode: 201;
@@ -37,6 +51,12 @@ model ListMembersResponse {
 
 @doc("Response returned when principal groups are listed.")
 model ListPrincipalGroupsResponse {
+  @statusCode statusCode: 200;
+  @body body: ListPrincipalGroupsResponseBody;
+}
+
+@doc("Response returned when multiple principal group memberships are updated.")
+model UpdatePrincipalGroupMembersResponse {
   @statusCode statusCode: 200;
   @body body: ListPrincipalGroupsResponseBody;
 }
@@ -75,6 +95,13 @@ interface PrincipalGroupOperations {
     @path principalGroupId: Uuid,
     @body body: MutatePrincipalGroupMemberRequestBody,
   ): OkPrincipalGroupResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @patch
+  @route("/members")
+  @doc("Update members for multiple principal groups.")
+  updatePrincipalGroupMembers(
+    @body body: UpdatePrincipalGroupMembersRequestBody,
+  ): UpdatePrincipalGroupMembersResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @delete
   @route("/{principalGroupId}")


### PR DESCRIPTION
## 📝 変更内容

- Account API に `PATCH /api/account/principal-groups/members` を追加し、複数 PrincipalGroup のメンバー構成を一括置換できるようにしました。
- 一括更新用の HTTP Request / Action / UseCase / Input / Output / 例外を追加しました。
- 対象 PrincipalGroup / Principal がセッション Account 配下であること、実行 Principal が `PRINCIPAL_GROUP_MANAGE` を持つこと、更新後も同権限を持つ Principal が少なくとも1人残ることを検証するようにしました。
- TypeSpec と OpenAPI 生成結果を更新しました。
- UseCase の正常系・異常系テストと、追加 route の認証・context middleware テストを追加しました。
- 更新後に管理権限者が0人になる場合のエラーメッセージを各言語リソースへ追加しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Account 単位で複数 PrincipalGroup の所属 Principal をまとめて編集できるようにし、個別 add/remove API の組み合わせによる更新途中状態や UI 側の差分計算・ロールバック負担を避けるためです。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
  - PHP CS Fixer: Fixed 0 files
  - PHPStan: No errors
  - PHPUnit: OK (2939 tests, 9410 assertions)
- [x] 新しく追加した機能に対するテストを作成
  - `ReplacePrincipalGroupMembersTest` で複数グループ置換、対象外グループ維持、Account 外 PrincipalGroup、Account 外 Principal、権限なし、更新後管理権限者0人を検証
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task openapi` を実行し、TypeSpec から OpenAPI を生成できることを確認
- 生成された `doc/openapi/KPool.AccountApi.openapi.yaml` に `/principal-groups/members` が含まれることを確認

## 🔍 レビューのポイント

- 一括更新対象の PrincipalGroup / Principal をセッション Account 配下に限定できているか
- 保存前に、更新後の PrincipalGroup membership を使って `PRINCIPAL_GROUP_MANAGE` 保有者が残ることを判定できているか
- UseCase が Infrastructure に依存せず、Domain repository / service interface 経由で実装されているか
- `PATCH /principal-groups/members` の route が `auth.api`, `resolve.actor`, `resolve.account` 配下にあるか

## 📖 関連情報

### 関連Issue・タスク

Closes #478

## ⚠️ 注意事項

- PrincipalGroup の role attachment は変更せず、members の集合のみを置換します。
- 途中失敗時に部分更新されないよう HTTP Action 側で transaction 内実行しています。
- OpenAPI 生成のため `task openapi` を実行し、生成結果もコミットに含めています。
- プロジェクトスキル `qa-review`, `test-review`, `security-review`, `architecture-review` はグローバル・Codex・repo-local で見つからなかったため、同観点のインラインレビューを実施しました。

### Review skills used / unavailable skills and alternative review performed

- `qa-review`: 未検出。代替として受け入れ条件と API 境界のインライン QA レビューを実施。
- `test-review`: 未検出。代替としてテスト観点のインラインレビューを実施し、UseCase 異常系と route protection テストを追加。
- `security-review`: 未検出。代替として認証・認可・Account 境界・部分更新防止をインラインレビュー。
- `architecture-review`: 未検出。代替として UseCase の依存方向、保存前権限判定、既存 Query/Command パターンとの整合性をインラインレビュー。

### 未対応のレビュー指摘

- なし

## 📸 スクリーンショット・デモ

- API 追加のため該当なし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
