### PR TITLE
add: PrincipalGroup一覧でメンバーIdentity情報を返す

### DIFF
--- a/application/Models/Account/PrincipalGroupMembership.php
+++ b/application/Models/Account/PrincipalGroupMembership.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $principal_id
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
+ * @property-read Principal|null $principal
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',

--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -1579,6 +1579,29 @@ components:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Identity identifier to add or remove.
       description: Request body for mutating principal group membership.
+    PrincipalGroupMemberSummary:
+      type: object
+      required:
+        - principalIdentifier
+        - identityIdentifier
+        - identityName
+        - email
+      properties:
+        principalIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Principal identifier.
+        identityIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Identity identifier.
+        identityName:
+          type: string
+          description: Identity display name.
+        email:
+          type: string
+          description: Identity email address.
+      description: Principal group member summary.
     PrincipalGroupSummary:
       type: object
       required:
@@ -1610,8 +1633,8 @@ components:
         members:
           type: array
           items:
-            $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Identity identifiers currently assigned to the group.
+            $ref: '#/components/schemas/PrincipalGroupMemberSummary'
+          description: Principal details currently assigned to the group.
       description: Principal group snapshot returned after updates.
     RejectAffiliationRequestBody:
       type: object

--- a/src/Account/Principal/Application/UseCase/Query/PrincipalGroupMemberReadModel.php
+++ b/src/Account/Principal/Application/UseCase/Query/PrincipalGroupMemberReadModel.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\UseCase\Query;
+
+readonly class PrincipalGroupMemberReadModel
+{
+    public function __construct(
+        private string $principalIdentifier,
+        private string $identityIdentifier,
+        private string $identityName,
+        private string $email,
+    ) {
+    }
+
+    public function principalIdentifier(): string
+    {
+        return $this->principalIdentifier;
+    }
+
+    public function identityIdentifier(): string
+    {
+        return $this->identityIdentifier;
+    }
+
+    public function identityName(): string
+    {
+        return $this->identityName;
+    }
+
+    public function email(): string
+    {
+        return $this->email;
+    }
+
+    /** @return array<string, string> */
+    public function toArray(): array
+    {
+        return [
+            'principalIdentifier' => $this->principalIdentifier,
+            'identityIdentifier' => $this->identityIdentifier,
+            'identityName' => $this->identityName,
+            'email' => $this->email,
+        ];
+    }
+}

--- a/src/Account/Principal/Application/UseCase/Query/PrincipalGroupReadModel.php
+++ b/src/Account/Principal/Application/UseCase/Query/PrincipalGroupReadModel.php
@@ -8,7 +8,7 @@ readonly class PrincipalGroupReadModel
 {
     /**
      * @param array<int, string> $roleIdentifiers
-     * @param array<int, string> $members
+     * @param array<int, PrincipalGroupMemberReadModel> $members
      */
     public function __construct(
         private string $principalGroupIdentifier,
@@ -46,7 +46,7 @@ readonly class PrincipalGroupReadModel
         return $this->isDefault;
     }
 
-    /** @return array<int, string> */
+    /** @return array<int, PrincipalGroupMemberReadModel> */
     public function members(): array
     {
         return $this->members;
@@ -61,7 +61,7 @@ readonly class PrincipalGroupReadModel
             'name' => $this->name,
             'roleIdentifiers' => $this->roleIdentifiers,
             'isDefault' => $this->isDefault,
-            'members' => $this->members,
+            'members' => array_map(static fn (PrincipalGroupMemberReadModel $member): array => $member->toArray(), $this->members),
         ];
     }
 }

--- a/src/Account/Principal/Infrastructure/Query/ListPrincipalGroups.php
+++ b/src/Account/Principal/Infrastructure/Query/ListPrincipalGroups.php
@@ -8,6 +8,7 @@ use Application\Models\Account\PrincipalGroup as PrincipalGroupModel;
 use Illuminate\Database\Eloquent\Collection;
 use Source\Account\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInputPort;
 use Source\Account\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInterface;
+use Source\Account\Principal\Application\UseCase\Query\PrincipalGroupMemberReadModel;
 use Source\Account\Principal\Application\UseCase\Query\PrincipalGroupReadModel;
 use Source\Account\Principal\Infrastructure\Query\Authorization\PrincipalGroupManageAuthorization;
 
@@ -25,7 +26,7 @@ readonly class ListPrincipalGroups implements ListPrincipalGroupsInterface
 
         /** @var Collection<int, PrincipalGroupModel> $groups */
         $groups = PrincipalGroupModel::query()
-            ->with(['members', 'roleAttachments'])
+            ->with(['members.principal.identity', 'roleAttachments'])
             ->where('account_id', (string) $accountIdentifier)
             ->orderBy('created_at')
             ->get();
@@ -36,7 +37,20 @@ readonly class ListPrincipalGroups implements ListPrincipalGroupsInterface
             name: $group->name,
             roleIdentifiers: $group->roleAttachments->map(static fn ($attachment): string => $attachment->role_id)->values()->all(),
             isDefault: $group->is_default,
-            members: $group->members->map(static fn ($member): string => $member->principal_id)->values()->all(),
+            members: $group->members
+                ->map(static function ($member): PrincipalGroupMemberReadModel {
+                    $principal = $member->principal;
+                    $identity = $principal->identity;
+
+                    return new PrincipalGroupMemberReadModel(
+                        principalIdentifier: $principal->id,
+                        identityIdentifier: $principal->identity_id,
+                        identityName: $identity->identity_name,
+                        email: $identity->email,
+                    );
+                })
+                ->values()
+                ->all(),
         ))->values()->all();
     }
 }

--- a/tests/Account/Principal/Application/UseCase/Query/PrincipalGroupReadModelTest.php
+++ b/tests/Account/Principal/Application/UseCase/Query/PrincipalGroupReadModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Account\Principal\Application\UseCase\Query;
 
 use PHPUnit\Framework\TestCase;
+use Source\Account\Principal\Application\UseCase\Query\PrincipalGroupMemberReadModel;
 use Source\Account\Principal\Application\UseCase\Query\PrincipalGroupReadModel;
 use Tests\Helper\StrTestHelper;
 
@@ -19,8 +20,18 @@ class PrincipalGroupReadModelTest extends TestCase
             StrTestHelper::generateUuid(),
         ];
         $members = [
-            StrTestHelper::generateUuid(),
-            StrTestHelper::generateUuid(),
+            new PrincipalGroupMemberReadModel(
+                principalIdentifier: StrTestHelper::generateUuid(),
+                identityIdentifier: StrTestHelper::generateUuid(),
+                identityName: 'alice',
+                email: 'alice@example.com',
+            ),
+            new PrincipalGroupMemberReadModel(
+                principalIdentifier: StrTestHelper::generateUuid(),
+                identityIdentifier: StrTestHelper::generateUuid(),
+                identityName: 'bob',
+                email: 'bob@example.com',
+            ),
         ];
 
         $readModel = new PrincipalGroupReadModel(
@@ -48,9 +59,15 @@ class PrincipalGroupReadModelTest extends TestCase
             StrTestHelper::generateUuid(),
             StrTestHelper::generateUuid(),
         ];
+        $principalIdentifier = StrTestHelper::generateUuid();
+        $identityIdentifier = StrTestHelper::generateUuid();
         $members = [
-            StrTestHelper::generateUuid(),
-            StrTestHelper::generateUuid(),
+            new PrincipalGroupMemberReadModel(
+                principalIdentifier: $principalIdentifier,
+                identityIdentifier: $identityIdentifier,
+                identityName: 'alice',
+                email: 'alice@example.com',
+            ),
         ];
 
         $readModel = new PrincipalGroupReadModel(
@@ -68,7 +85,14 @@ class PrincipalGroupReadModelTest extends TestCase
             'name' => 'Administrators',
             'roleIdentifiers' => $roleIdentifiers,
             'isDefault' => false,
-            'members' => $members,
+            'members' => [
+                [
+                    'principalIdentifier' => $principalIdentifier,
+                    'identityIdentifier' => $identityIdentifier,
+                    'identityName' => 'alice',
+                    'email' => 'alice@example.com',
+                ],
+            ],
         ], $readModel->toArray());
     }
 }

--- a/tests/Account/PrincipalGroup/Infrastructure/Query/ListPrincipalGroupsTest.php
+++ b/tests/Account/PrincipalGroup/Infrastructure/Query/ListPrincipalGroupsTest.php
@@ -43,10 +43,26 @@ class ListPrincipalGroupsTest extends TestCase
         $roleId = StrTestHelper::generateUuid();
         $memberId = StrTestHelper::generateUuid();
         $identityId = StrTestHelper::generateUuid();
-        CreateIdentity::create(new IdentityIdentifier($identityId), ['email' => 'member@example.com']);
+        CreateIdentity::create(new IdentityIdentifier($identityId), [
+            'identityName' => 'alice',
+            'email' => 'alice@example.com',
+        ]);
         DB::table('account_principals')->insert([
             'id' => $memberId,
             'identity_id' => $identityId,
+            'account_id' => (string) $accountIdentifier,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $secondMemberId = StrTestHelper::generateUuid();
+        $secondIdentityId = StrTestHelper::generateUuid();
+        CreateIdentity::create(new IdentityIdentifier($secondIdentityId), [
+            'identityName' => 'bob',
+            'email' => 'bob@example.com',
+        ]);
+        DB::table('account_principals')->insert([
+            'id' => $secondMemberId,
+            'identity_id' => $secondIdentityId,
             'account_id' => (string) $accountIdentifier,
             'created_at' => now(),
             'updated_at' => now(),
@@ -63,11 +79,20 @@ class ListPrincipalGroupsTest extends TestCase
             'role_id' => $roleId,
         ]);
         DB::table('account_principal_group_memberships')->insert([
-            'id' => StrTestHelper::generateUuid(),
-            'principal_group_id' => $groupId,
-            'principal_id' => $memberId,
-            'created_at' => now(),
-            'updated_at' => now(),
+            [
+                'id' => StrTestHelper::generateUuid(),
+                'principal_group_id' => $groupId,
+                'principal_id' => $memberId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => StrTestHelper::generateUuid(),
+                'principal_group_id' => $groupId,
+                'principal_id' => $secondMemberId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
         ]);
 
         /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
@@ -88,7 +113,20 @@ class ListPrincipalGroupsTest extends TestCase
             'name' => 'Admins',
             'roleIdentifiers' => [$roleId],
             'isDefault' => false,
-            'members' => [$memberId],
+            'members' => [
+                [
+                    'principalIdentifier' => $memberId,
+                    'identityIdentifier' => $identityId,
+                    'identityName' => 'alice',
+                    'email' => 'alice@example.com',
+                ],
+                [
+                    'principalIdentifier' => $secondMemberId,
+                    'identityIdentifier' => $secondIdentityId,
+                    'identityName' => 'bob',
+                    'email' => 'bob@example.com',
+                ],
+            ],
         ], $groups[0]->toArray());
     }
 

--- a/typespec/services/account-api/common.tsp
+++ b/typespec/services/account-api/common.tsp
@@ -137,6 +137,18 @@ model ListPrincipalGroupsResponseBody {
   principalGroups: PrincipalGroupSummary[];
 }
 
+@doc("Principal group member summary.")
+model PrincipalGroupMemberSummary {
+  @doc("Principal identifier.")
+  principalIdentifier: Uuid;
+  @doc("Identity identifier.")
+  identityIdentifier: Uuid;
+  @doc("Identity display name.")
+  identityName: string;
+  @doc("Identity email address.")
+  email: string;
+}
+
 @doc("Principal group snapshot returned after updates.")
 model PrincipalGroupSummary {
   @doc("Principal group identifier.")
@@ -149,8 +161,8 @@ model PrincipalGroupSummary {
   roleIdentifiers: Uuid[];
   @doc("Whether this is the default principal group.")
   isDefault: boolean;
-  @doc("Identity identifiers currently assigned to the group.")
-  members?: Uuid[];
+  @doc("Principal details currently assigned to the group.")
+  members?: PrincipalGroupMemberSummary[];
 }
 
 @doc("Principal group snapshot returned immediately after creation.")


### PR DESCRIPTION
## 📝 変更内容

- `GET /account/principal-groups` の `members` を Principal ID 配列から、Principal / Identity の詳細情報を含むオブジェクト配列へ変更しました。
- `ListPrincipalGroups` で `members.principal.identity` を eager load し、N+1 を避けながら `principalIdentifier`, `identityIdentifier`, `identityName`, `email` を返すようにしました。
- PrincipalGroup メンバー用の ReadModel を追加し、TypeSpec / OpenAPI のレスポンススキーマを更新しました。
- ReadModel 単体テストと DB Query テストを更新し、複数メンバーの Identity 情報が返ることを検証しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

PrincipalGroup 一覧 API ではグループに紐づく Principal ID のみを返していたため、画面側でメンバーの表示名やメールアドレスを表示するには追加取得が必要でした。
Account メンバー一覧 API と同様に Principal と Identity を辿った情報を返すことで、PrincipalGroup 表示・編集で必要な情報を一覧レスポンスだけで取得できるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi` を実行し、TypeSpec から OpenAPI を生成できることを確認
- [x] `docker-compose run --rm --no-deps php bash -lc './vendor/bin/phpunit --filter PrincipalGroupReadModelTest --exclude-group useDb --coverage-html coverage-html'` を実行し、ReadModel テストがパスすることを確認
- [x] `docker-compose up -d testing_db testing_redis && docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php bash -lc './vendor/bin/phpunit tests/Account/PrincipalGroup/Infrastructure/Query/ListPrincipalGroupsTest.php --coverage-html coverage-html'` を実行し、DB Query テストがパスすることを確認
- [x] `task phpstan` を実行し、静的解析がパスすることを確認
- [x] `task check` を実行し、CS Fixer / PHPStan / 全 PHPUnit がパスすることを確認（2951 tests, 9460 assertions）
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

自動テストで `account_principal_group_memberships -> account_principals -> identities` を辿り、複数メンバー分の `principalIdentifier`, `identityIdentifier`, `identityName`, `email` が返ることを確認しました。

## 🔍 レビューのポイント

- `members.principal.identity` の eager load により N+1 が発生しないこと
- PrincipalGroup 一覧 Query のスコープが対象 Account の PrincipalGroup に限定されていること
- TypeSpec / OpenAPI の `PrincipalGroupSummary.members` が実装のレスポンス形と一致していること

Review skills used / unavailable skills and alternative review performed:

- `qa-review`, `test-review`, `security-review`, `architecture-review` は Hermes グローバル、Codex、リポジトリ内で該当スキル定義が見つからなかったため、必須ワークフローに従い同期的なインラインレビューで代替しました。
- QA: Issue の受け入れ条件（詳細メンバー配列、複数メンバー、空配列維持、TypeSpec/OpenAPI更新）に沿って差分を確認しました。
- Test: ReadModel 単体テスト、DB Query テスト、`task check` の全体テストを実行して妥当性を確認しました。
- Security: Account スコープ条件を維持し、他 Account の PrincipalGroup を混入させない既存認可・where 条件が残っていることを確認しました。
- Architecture: Query 層で Eloquent relation から ReadModel へ変換する既存 `ListMembers` と同じ読み取りパターンで、Command 系レスポンスへ不要に波及させていないことを確認しました。

未対応のレビュー指摘:

- なし

## 📖 関連情報

### 関連Issue・タスク

Closes #480

## ⚠️ 注意事項

- `GET /account/principal-groups` の `members` は Principal ID 配列から詳細オブジェクト配列へ変わるため API 契約変更を含みます。Issue 指示どおり、フロントエンド未実装のため既存フロント互換は考慮していません。
- マイグレーションはありません。

## 📸 スクリーンショット・デモ

API レスポンススキーマ変更のためスクリーンショットはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
