### PR TITLE
PrincipalGroup所属とテストアカウント権限を整理

### DIFF
--- a/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersAction.php
+++ b/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersAction.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
 use Source\Account\Principal\Application\Exception\CannotRemoveLastPrincipalGroupManagerException;
+use Source\Account\Principal\Application\Exception\PrincipalAlreadyAssignedToPrincipalGroupException;
 use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
 use Source\Account\Principal\Application\Exception\PrincipalNotFoundException;
 use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\PrincipalGroupMembers;
@@ -72,6 +73,10 @@ readonly class UpdatePrincipalGroupMembersAction
                 DB::rollBack();
 
                 throw new UnprocessableEntityHttpException(detail: error_message('cannot_remove_last_principal_group_manager', $language), previous: $e);
+            } catch (PrincipalAlreadyAssignedToPrincipalGroupException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: error_message('principal_already_assigned_to_principal_group', $language), previous: $e);
             } catch (Throwable $e) {
                 DB::rollBack();
 

--- a/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersRequest.php
+++ b/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersRequest.php
@@ -17,7 +17,7 @@ class UpdatePrincipalGroupMembersRequest extends FormRequest
         return [
             'principalGroups' => ['required', 'array'],
             'principalGroups.*.principalGroupIdentifier' => ['required', 'uuid', 'distinct'],
-            'principalGroups.*.principalIdentifiers' => ['required', 'array'],
+            'principalGroups.*.principalIdentifiers' => ['present', 'array'],
             'principalGroups.*.principalIdentifiers.*' => ['required', 'uuid', 'distinct'],
         ];
     }

--- a/database/seeders/AccountAuthorizationSeeder.php
+++ b/database/seeders/AccountAuthorizationSeeder.php
@@ -59,7 +59,6 @@ class AccountAuthorizationSeeder extends Seeder
 
         $this->saveRole(Role::OWNER, [$ownerPolicy->policyIdentifier()]);
         $this->saveRole(Role::ADMIN, [$adminPolicy->policyIdentifier()]);
-        $this->saveRole(Role::BASIC, []);
     }
 
     /**

--- a/database/seeders/FullAccessTestAccountSeeder.php
+++ b/database/seeders/FullAccessTestAccountSeeder.php
@@ -21,11 +21,11 @@ class FullAccessTestAccountSeeder extends Seeder
             'accountDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0d',
             'principalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa04',
             'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0b',
-            'accountPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa05',
+            'accountOwnerPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa05',
             'email' => 'test@example.com',
             'identityName' => 'full-access-test',
             'accountName' => 'Full Access Test Account',
-            'principalGroupName' => 'Full Access Test Group',
+            'wikiPrincipalGroupName' => 'Full Access Test Group',
             'accountType' => 'individual',
         ],
         [
@@ -35,11 +35,11 @@ class FullAccessTestAccountSeeder extends Seeder
             'accountDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0f',
             'principalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa09',
             'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0c',
-            'accountPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0a',
+            'accountOwnerPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0a',
             'email' => 'corp@example.com',
             'identityName' => 'corp-full-access-test',
             'accountName' => 'Corporate Full Access Test Account',
-            'principalGroupName' => 'Corporate Full Access Test Group',
+            'wikiPrincipalGroupName' => 'Corporate Full Access Test Group',
             'accountType' => 'corporation',
         ],
     ];
@@ -89,11 +89,11 @@ class FullAccessTestAccountSeeder extends Seeder
      *     accountDefaultPrincipalGroupId: string,
      *     principalGroupId: string,
      *     wikiDefaultPrincipalGroupId: string,
-     *     accountPrincipalGroupMembershipId: string,
+     *     accountOwnerPrincipalGroupMembershipId: string,
      *     email: string,
      *     identityName: string,
      *     accountName: string,
-     *     principalGroupName: string,
+     *     wikiPrincipalGroupName: string,
      *     accountType: string
      * } $account
      */
@@ -169,7 +169,7 @@ class FullAccessTestAccountSeeder extends Seeder
             [
                 'id' => $account['principalGroupId'],
                 'account_id' => $account['accountId'],
-                'name' => $account['principalGroupName'],
+                'name' => 'Owners',
                 'is_default' => false,
                 'created_at' => $now,
                 'updated_at' => $now,
@@ -183,7 +183,7 @@ class FullAccessTestAccountSeeder extends Seeder
 
         DB::table('account_principal_group_memberships')->upsert([
             [
-                'id' => $account['accountPrincipalGroupMembershipId'],
+                'id' => $account['accountOwnerPrincipalGroupMembershipId'],
                 'principal_group_id' => $account['principalGroupId'],
                 'principal_id' => $account['principalId'],
                 'created_at' => $now,
@@ -210,7 +210,7 @@ class FullAccessTestAccountSeeder extends Seeder
             [
                 'id' => $account['principalGroupId'],
                 'account_id' => $account['accountId'],
-                'name' => $account['principalGroupName'],
+                'name' => $account['wikiPrincipalGroupName'],
                 'is_default' => false,
                 'created_at' => $now,
                 'updated_at' => $now,

--- a/database/seeders/FullAccessTestAccountSeeder.php
+++ b/database/seeders/FullAccessTestAccountSeeder.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
+use Application\Http\Context\AuthContextCache;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use RuntimeException;
 use Source\Account\Principal\Domain\Entity\Role;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 
 class FullAccessTestAccountSeeder extends Seeder
 {
@@ -241,5 +243,10 @@ class FullAccessTestAccountSeeder extends Seeder
                 'role_id' => $administratorRoleId,
             ],
         ], ['principal_group_id', 'role_id']);
+
+        $identityIdentifier = new IdentityIdentifier($account['identityId']);
+        $authContextCache = app(AuthContextCache::class);
+        $authContextCache->forgetAccount($identityIdentifier);
+        $authContextCache->forgetWiki($identityIdentifier);
     }
 }

--- a/database/seeders/FullAccessTestAccountSeeder.php
+++ b/database/seeders/FullAccessTestAccountSeeder.php
@@ -18,6 +18,7 @@ class FullAccessTestAccountSeeder extends Seeder
             'accountId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa01',
             'identityId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa02',
             'principalId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa03',
+            'accountDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0d',
             'principalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa04',
             'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0b',
             'accountPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa05',
@@ -31,6 +32,7 @@ class FullAccessTestAccountSeeder extends Seeder
             'accountId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa06',
             'identityId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa07',
             'principalId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa08',
+            'accountDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0f',
             'principalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa09',
             'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0c',
             'accountPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0a',
@@ -84,6 +86,7 @@ class FullAccessTestAccountSeeder extends Seeder
      *     accountId: string,
      *     identityId: string,
      *     principalId: string,
+     *     accountDefaultPrincipalGroupId: string,
      *     principalGroupId: string,
      *     wikiDefaultPrincipalGroupId: string,
      *     accountPrincipalGroupMembershipId: string,
@@ -156,14 +159,27 @@ class FullAccessTestAccountSeeder extends Seeder
 
         DB::table('account_principal_groups')->upsert([
             [
-                'id' => $account['principalGroupId'],
+                'id' => $account['accountDefaultPrincipalGroupId'],
                 'account_id' => $account['accountId'],
-                'name' => $account['principalGroupName'],
+                'name' => 'Default',
                 'is_default' => true,
                 'created_at' => $now,
                 'updated_at' => $now,
             ],
+            [
+                'id' => $account['principalGroupId'],
+                'account_id' => $account['accountId'],
+                'name' => $account['principalGroupName'],
+                'is_default' => false,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
         ], ['id']);
+
+        DB::table('account_principal_group_memberships')
+            ->where('principal_group_id', $account['accountDefaultPrincipalGroupId'])
+            ->where('principal_id', $account['principalId'])
+            ->delete();
 
         DB::table('account_principal_group_memberships')->upsert([
             [
@@ -201,13 +217,12 @@ class FullAccessTestAccountSeeder extends Seeder
             ],
         ], ['id']);
 
+        DB::table('principal_group_memberships')
+            ->where('principal_group_id', $account['wikiDefaultPrincipalGroupId'])
+            ->where('principal_id', $account['principalId'])
+            ->delete();
+
         DB::table('principal_group_memberships')->upsert([
-            [
-                'principal_group_id' => $account['wikiDefaultPrincipalGroupId'],
-                'principal_id' => $account['principalId'],
-                'created_at' => $now,
-                'updated_at' => $now,
-            ],
             [
                 'principal_group_id' => $account['principalGroupId'],
                 'principal_id' => $account['principalId'],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,8 @@ services:
 
   redis:
     image: redis:8-alpine
+    ports:
+      - "6379:6379"
     networks:
       - kpool-network
 

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -57,6 +57,7 @@ return [
     'identity_not_member' => 'The identity is not a member of this group.',
     'cannot_remove_last_owner' => 'Cannot remove the last owner from the account.',
     'cannot_remove_last_principal_group_manager' => 'At least one principal with principal group manage permission is required.',
+    'principal_already_assigned_to_principal_group' => 'A principal can belong to only one principal group in an account.',
     'cannot_delete_default_identity_group' => 'Cannot delete the default identity group.',
     'cannot_delete_last_owner_group' => 'Cannot delete the last owner group with members.',
     'delegation_not_found' => 'The specified delegation was not found.',

--- a/resources/lang/es/errors.php
+++ b/resources/lang/es/errors.php
@@ -57,6 +57,7 @@ return [
     'identity_not_member' => 'La identidad no es miembro de este grupo.',
     'cannot_remove_last_owner' => 'No se puede eliminar al último propietario de la cuenta.',
     'cannot_remove_last_principal_group_manager' => 'Se requiere al menos un principal con permiso para administrar grupos de principales.',
+    'principal_already_assigned_to_principal_group' => 'Un principal solo puede pertenecer a un grupo de principales dentro de una cuenta.',
     'cannot_delete_default_identity_group' => 'No se puede eliminar el grupo de identidad predeterminado.',
     'cannot_delete_last_owner_group' => 'No se puede eliminar el último grupo de propietarios con miembros.',
     'delegation_not_found' => 'No se encontró la delegación especificada.',

--- a/resources/lang/ja/errors.php
+++ b/resources/lang/ja/errors.php
@@ -57,6 +57,7 @@ return [
     'identity_not_member' => 'このアイデンティティはこのグループのメンバーではありません。',
     'cannot_remove_last_owner' => 'アカウントから最後のオーナーを削除することはできません。',
     'cannot_remove_last_principal_group_manager' => 'PrincipalGroup を管理できる Principal が少なくとも1人必要です。',
+    'principal_already_assigned_to_principal_group' => 'Principal はアカウント内で1つの PrincipalGroup にのみ所属できます。',
     'cannot_delete_default_identity_group' => 'デフォルトのアイデンティティグループは削除できません。',
     'cannot_delete_last_owner_group' => 'メンバーがいる最後のオーナーグループは削除できません。',
     'delegation_not_found' => '指定された委任が見つかりません。',

--- a/resources/lang/ko/errors.php
+++ b/resources/lang/ko/errors.php
@@ -57,6 +57,7 @@ return [
     'identity_not_member' => '해당 아이덴티티는 이 그룹의 멤버가 아닙니다.',
     'cannot_remove_last_owner' => '계정에서 마지막 소유자를 제거할 수 없습니다.',
     'cannot_remove_last_principal_group_manager' => 'PrincipalGroup 관리 권한을 가진 Principal이 최소 1명 필요합니다.',
+    'principal_already_assigned_to_principal_group' => 'Principal은 계정 내에서 하나의 PrincipalGroup에만 속할 수 있습니다.',
     'cannot_delete_default_identity_group' => '기본 아이덴티티 그룹은 삭제할 수 없습니다.',
     'cannot_delete_last_owner_group' => '멤버가 있는 마지막 소유자 그룹은 삭제할 수 없습니다.',
     'delegation_not_found' => '지정된 위임을 찾을 수 없습니다.',

--- a/resources/lang/zh_CN/errors.php
+++ b/resources/lang/zh_CN/errors.php
@@ -57,6 +57,7 @@ return [
     'identity_not_member' => '该身份不是此组的成员。',
     'cannot_remove_last_owner' => '无法移除账户的最后一个所有者。',
     'cannot_remove_last_principal_group_manager' => '至少需要一个拥有 PrincipalGroup 管理权限的 Principal。',
+    'principal_already_assigned_to_principal_group' => 'Principal 在一个账户内只能属于一个 PrincipalGroup。',
     'cannot_delete_default_identity_group' => '无法删除默认身份组。',
     'cannot_delete_last_owner_group' => '无法删除有成员的最后一个所有者组。',
     'delegation_not_found' => '找不到指定的委托。',

--- a/resources/lang/zh_TW/errors.php
+++ b/resources/lang/zh_TW/errors.php
@@ -57,6 +57,7 @@ return [
     'identity_not_member' => '該身分不是此群組的成員。',
     'cannot_remove_last_owner' => '無法移除帳戶的最後一個擁有者。',
     'cannot_remove_last_principal_group_manager' => '至少需要一個擁有 PrincipalGroup 管理權限的 Principal。',
+    'principal_already_assigned_to_principal_group' => 'Principal 在一個帳戶內只能屬於一個 PrincipalGroup。',
     'cannot_delete_default_identity_group' => '無法刪除預設身分群組。',
     'cannot_delete_last_owner_group' => '無法刪除有成員的最後一個擁有者群組。',
     'delegation_not_found' => '找不到指定的委託。',

--- a/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
+++ b/src/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccount.php
@@ -19,7 +19,8 @@ use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class CreateAccount implements CreateAccountInterface
 {
-    private const string DEFAULT_IDENTITY_GROUP_NAME = 'Owners';
+    private const string DEFAULT_GROUP_NAME = 'Default';
+    private const string OWNER_GROUP_NAME = 'Owners';
 
     public function __construct(
         private AccountRepositoryInterface $accountRepository,
@@ -59,16 +60,23 @@ readonly class CreateAccount implements CreateAccountInterface
 
         $this->accountRepository->save($account);
 
-        $principalGroup = $this->principalGroupFactory->create(
+        $defaultPrincipalGroup = $this->principalGroupFactory->create(
             $account->accountIdentifier(),
-            self::DEFAULT_IDENTITY_GROUP_NAME,
+            self::DEFAULT_GROUP_NAME,
             true,
         );
+
+        $ownerPrincipalGroup = $this->principalGroupFactory->create(
+            $account->accountIdentifier(),
+            self::OWNER_GROUP_NAME,
+            false,
+        );
+
         $ownerRole = $this->roleRepository->findByName(Role::OWNER);
         if ($ownerRole === null) {
             throw new RuntimeException('Owner account role is not found.');
         }
-        $principalGroup->addRole($ownerRole->roleIdentifier());
+        $ownerPrincipalGroup->addRole($ownerRole->roleIdentifier());
 
         if ($input->identityIdentifier() !== null) {
             $principal = $this->principalFactory->create(
@@ -76,10 +84,11 @@ readonly class CreateAccount implements CreateAccountInterface
                 $account->accountIdentifier(),
             );
             $this->principalRepository->save($principal);
-            $principalGroup->addMember($principal->principalIdentifier());
+            $ownerPrincipalGroup->addMember($principal->principalIdentifier());
         }
 
-        $this->principalGroupRepository->save($principalGroup);
+        $this->principalGroupRepository->save($defaultPrincipalGroup);
+        $this->principalGroupRepository->save($ownerPrincipalGroup);
 
         $this->eventDispatcher->dispatch(new AccountCreated(
             accountIdentifier: $account->accountIdentifier(),

--- a/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
+++ b/src/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandler.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace Source\Account\Invitation\Application\EventHandler;
 
-use RuntimeException;
 use Source\Account\Invitation\Application\Exception\InvitationEmailMismatchException;
 use Source\Account\Invitation\Application\Exception\InvitationNotFoundException;
 use Source\Account\Invitation\Domain\Event\InvitationAccepted;
 use Source\Account\Invitation\Domain\Repository\InvitationRepositoryInterface;
-use Source\Account\Principal\Domain\Entity\Role;
 use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Account\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
-use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
 use Source\Identity\Domain\Event\IdentityCreatedViaInvitation;
 use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class IdentityCreatedViaInvitationHandler
 {
-    private const string MEMBER_GROUP_NAME = 'Members';
+    private const string DEFAULT_GROUP_NAME = 'Default';
 
     public function __construct(
         private InvitationRepositoryInterface $invitationRepository,
@@ -29,7 +26,6 @@ readonly class IdentityCreatedViaInvitationHandler
         private PrincipalGroupFactoryInterface $principalGroupFactory,
         private PrincipalFactoryInterface $principalFactory,
         private PrincipalRepositoryInterface $principalRepository,
-        private RoleRepositoryInterface $roleRepository,
         private IdentityRepositoryInterface $identityRepository,
         private EventDispatcherInterface $eventDispatcher,
     ) {
@@ -50,23 +46,14 @@ readonly class IdentityCreatedViaInvitationHandler
             throw new InvitationEmailMismatchException('招待されたメールアドレスと登録メールアドレスが一致しません。');
         }
 
-        $basicRole = $this->roleRepository->findByName(Role::BASIC);
-        if ($basicRole === null) {
-            throw new RuntimeException('Basic account role is not found.');
-        }
+        $defaultGroup = $this->principalGroupRepository->findDefaultByAccountId($invitation->accountIdentifier());
 
-        $memberGroup = $this->principalGroupRepository->findByAccountIdAndRole(
-            $invitation->accountIdentifier(),
-            $basicRole->roleIdentifier()
-        );
-
-        if ($memberGroup === null) {
-            $memberGroup = $this->principalGroupFactory->create(
+        if ($defaultGroup === null) {
+            $defaultGroup = $this->principalGroupFactory->create(
                 $invitation->accountIdentifier(),
-                self::MEMBER_GROUP_NAME,
-                false,
+                self::DEFAULT_GROUP_NAME,
+                true,
             );
-            $memberGroup->addRole($basicRole->roleIdentifier());
         }
 
         $principal = $this->principalFactory->create(
@@ -75,8 +62,8 @@ readonly class IdentityCreatedViaInvitationHandler
         );
         $this->principalRepository->save($principal);
 
-        $memberGroup->addMember($principal->principalIdentifier());
-        $this->principalGroupRepository->save($memberGroup);
+        $defaultGroup->addMember($principal->principalIdentifier());
+        $this->principalGroupRepository->save($defaultGroup);
 
         $invitation->accept($event->identityIdentifier);
         $this->invitationRepository->save($invitation);

--- a/src/Account/Principal/Application/Exception/PrincipalAlreadyAssignedToPrincipalGroupException.php
+++ b/src/Account/Principal/Application/Exception/PrincipalAlreadyAssignedToPrincipalGroupException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Application\Exception;
+
+use RuntimeException;
+
+class PrincipalAlreadyAssignedToPrincipalGroupException extends RuntimeException
+{
+}

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
@@ -6,6 +6,7 @@ namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGr
 
 use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
 use Source\Account\Principal\Application\Exception\CannotRemoveLastPrincipalGroupManagerException;
+use Source\Account\Principal\Application\Exception\PrincipalAlreadyAssignedToPrincipalGroupException;
 use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
 use Source\Account\Principal\Application\Exception\PrincipalNotFoundException;
 use Source\Account\Principal\Domain\Entity\Principal;
@@ -67,6 +68,8 @@ readonly class UpdatePrincipalGroupMembers implements UpdatePrincipalGroupMember
             $principalGroupsById[$principalGroupId]->replaceMembers($principalIdentifiers);
         }
 
+        $this->assertPrincipalsAssignedToSingleGroup($principalGroups);
+
         $principalsById = $this->principalRepository->findByIds(array_values($this->collectPrincipalIdentifiers($principalGroups)));
         $this->assertPrincipalsBelongToAccount(array_values($allRequestedPrincipalIdentifiers), $principalsById, $accountIdentifier);
 
@@ -79,6 +82,25 @@ readonly class UpdatePrincipalGroupMembers implements UpdatePrincipalGroupMember
         }
 
         $output->setPrincipalGroups(array_values(array_intersect_key($principalGroupsById, $requestedPrincipalIdentifiersByGroupId)));
+    }
+
+    /**
+     * @param array<int, PrincipalGroup> $principalGroups
+     */
+    private function assertPrincipalsAssignedToSingleGroup(array $principalGroups): void
+    {
+        $groupIdsByPrincipalId = [];
+        foreach ($principalGroups as $principalGroup) {
+            $principalGroupId = (string) $principalGroup->principalGroupIdentifier();
+            foreach ($principalGroup->members() as $principalIdentifier) {
+                $principalId = (string) $principalIdentifier;
+                if (isset($groupIdsByPrincipalId[$principalId]) && $groupIdsByPrincipalId[$principalId] !== $principalGroupId) {
+                    throw new PrincipalAlreadyAssignedToPrincipalGroupException();
+                }
+
+                $groupIdsByPrincipalId[$principalId] = $principalGroupId;
+            }
+        }
     }
 
     /**

--- a/src/Account/Principal/Domain/Entity/Role.php
+++ b/src/Account/Principal/Domain/Entity/Role.php
@@ -11,6 +11,7 @@ class Role
 {
     public const string OWNER = 'Owner';
     public const string ADMIN = 'Admin';
+
     /**
      * @param PolicyIdentifier[] $policies
      */

--- a/src/Account/Principal/Domain/Entity/Role.php
+++ b/src/Account/Principal/Domain/Entity/Role.php
@@ -11,8 +11,6 @@ class Role
 {
     public const string OWNER = 'Owner';
     public const string ADMIN = 'Admin';
-    public const string BASIC = 'Basic';
-
     /**
      * @param PolicyIdentifier[] $policies
      */

--- a/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/CreateAccount/CreateAccountTest.php
@@ -107,8 +107,12 @@ class CreateAccountTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldReceive('create')
             ->once()
-            ->with($testData->identifier, 'Owners', true)
-            ->andReturn($testData->principalGroup);
+            ->with($testData->identifier, 'Default', true)
+            ->andReturn($testData->defaultPrincipalGroup);
+        $principalGroupFactory->shouldReceive('create')
+            ->once()
+            ->with($testData->identifier, 'Owners', false)
+            ->andReturn($testData->ownerPrincipalGroup);
 
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldReceive('findByName')
@@ -119,7 +123,11 @@ class CreateAccountTest extends TestCase
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('save')
             ->once()
-            ->with($testData->principalGroup)
+            ->with($testData->defaultPrincipalGroup)
+            ->andReturnNull();
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with($testData->ownerPrincipalGroup)
             ->andReturnNull();
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
@@ -152,8 +160,9 @@ class CreateAccountTest extends TestCase
         $this->assertSame((string) $testData->email, $result['email']);
         $this->assertSame($testData->accountType->value, $result['type']);
         $this->assertSame((string) $testData->accountName, $result['name']);
-        $this->assertTrue($testData->principalGroup->hasMember($testData->principalIdentifier));
-        $this->assertTrue($testData->principalGroup->hasRole($testData->ownerRole->roleIdentifier()));
+        $this->assertSame(0, $testData->defaultPrincipalGroup->memberCount());
+        $this->assertTrue($testData->ownerPrincipalGroup->hasMember($testData->principalIdentifier));
+        $this->assertTrue($testData->ownerPrincipalGroup->hasRole($testData->ownerRole->roleIdentifier()));
     }
 
     /**
@@ -190,8 +199,12 @@ class CreateAccountTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldReceive('create')
             ->once()
-            ->with($testData->identifier, 'Owners', true)
-            ->andReturn($testData->principalGroup);
+            ->with($testData->identifier, 'Default', true)
+            ->andReturn($testData->defaultPrincipalGroup);
+        $principalGroupFactory->shouldReceive('create')
+            ->once()
+            ->with($testData->identifier, 'Owners', false)
+            ->andReturn($testData->ownerPrincipalGroup);
 
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldReceive('findByName')
@@ -202,7 +215,11 @@ class CreateAccountTest extends TestCase
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository->shouldReceive('save')
             ->once()
-            ->with($testData->principalGroup)
+            ->with($testData->defaultPrincipalGroup)
+            ->andReturnNull();
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with($testData->ownerPrincipalGroup)
             ->andReturnNull();
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
@@ -232,7 +249,8 @@ class CreateAccountTest extends TestCase
 
         $result = $output->toArray();
         $this->assertSame((string) $testData->identifier, $result['accountIdentifier']);
-        $this->assertSame(0, $testData->principalGroup->memberCount());
+        $this->assertSame(0, $testData->defaultPrincipalGroup->memberCount());
+        $this->assertSame(0, $testData->ownerPrincipalGroup->memberCount());
     }
 
     /**
@@ -327,11 +345,19 @@ class CreateAccountTest extends TestCase
             true,
         );
 
-        $principalGroup = new PrincipalGroup(
+        $defaultPrincipalGroup = new PrincipalGroup(
+            new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
+            $identifier,
+            'Default',
+            true,
+            new \DateTimeImmutable(),
+        );
+
+        $ownerPrincipalGroup = new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
             $identifier,
             'Owners',
-            true,
+            false,
             new \DateTimeImmutable(),
         );
 
@@ -354,7 +380,8 @@ class CreateAccountTest extends TestCase
             $identityIdentifier,
             $principalIdentifier,
             $principal,
-            $principalGroup,
+            $defaultPrincipalGroup,
+            $ownerPrincipalGroup,
             $ownerRole,
             $language,
         );
@@ -374,7 +401,8 @@ readonly class CreateAccountTestData
         public IdentityIdentifier $identityIdentifier,
         public PrincipalIdentifier $principalIdentifier,
         public Principal $principal,
-        public PrincipalGroup $principalGroup,
+        public PrincipalGroup $defaultPrincipalGroup,
+        public PrincipalGroup $ownerPrincipalGroup,
         public Role $ownerRole,
         public Language $language,
     ) {

--- a/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
+++ b/tests/Account/Invitation/Application/EventHandler/IdentityCreatedViaInvitationHandlerTest.php
@@ -18,13 +18,10 @@ use Source\Account\Invitation\Domain\ValueObject\InvitationIdentifier;
 use Source\Account\Invitation\Domain\ValueObject\InvitationStatus;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
-use Source\Account\Principal\Domain\Entity\Role;
 use Source\Account\Principal\Domain\Factory\PrincipalFactoryInterface;
 use Source\Account\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
-use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
-use Source\Account\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Identity\Domain\Entity\Identity;
@@ -55,7 +52,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
@@ -64,7 +60,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
 
@@ -74,11 +69,11 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
     }
 
     /**
-     * 正常系: 既存のMemberグループがある場合、そのグループにメンバーを追加すること
+     * 正常系: 既存のDefaultグループがある場合、そのグループにメンバーを追加すること
      *
      * @throws BindingResolutionException
      */
-    public function testHandleWhenMemberGroupExists(): void
+    public function testHandleWhenDefaultGroupExists(): void
     {
         $data = $this->createTestData();
 
@@ -102,13 +97,13 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->with($data->invitation);
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository->shouldReceive('findByAccountIdAndRole')
+        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
             ->once()
-            ->with($data->accountIdentifier, $data->basicRole->roleIdentifier())
-            ->andReturn($data->memberGroup);
+            ->with($data->accountIdentifier)
+            ->andReturn($data->defaultGroup);
         $principalGroupRepository->shouldReceive('save')
             ->once()
-            ->with($data->memberGroup);
+            ->with($data->defaultGroup);
 
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldNotReceive('create');
@@ -124,12 +119,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->once()
             ->with($data->principal);
 
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldReceive('findByName')
-            ->once()
-            ->with(Role::BASIC)
-            ->andReturn($data->basicRole);
-
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
         $identityRepository->shouldReceive('findById')
             ->once()
@@ -142,21 +131,20 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
 
-        $this->assertTrue($data->memberGroup->hasMember($data->principalIdentifier));
+        $this->assertTrue($data->defaultGroup->hasMember($data->principalIdentifier));
     }
 
     /**
-     * 正常系: Memberグループが存在しない場合、新規作成してメンバーを追加すること
+     * 正常系: Defaultグループが存在しない場合、新規作成してメンバーを追加すること
      *
      * @throws BindingResolutionException
      */
-    public function testHandleWhenMemberGroupNotExists(): void
+    public function testHandleWhenDefaultGroupNotExists(): void
     {
         $data = $this->createTestData();
 
@@ -177,19 +165,19 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->with($data->invitation);
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository->shouldReceive('findByAccountIdAndRole')
+        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
             ->once()
-            ->with($data->accountIdentifier, $data->basicRole->roleIdentifier())
+            ->with($data->accountIdentifier)
             ->andReturnNull();
         $principalGroupRepository->shouldReceive('save')
             ->once()
-            ->with($data->memberGroup);
+            ->with($data->defaultGroup);
 
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory->shouldReceive('create')
             ->once()
-            ->with($data->accountIdentifier, 'Members', false)
-            ->andReturn($data->memberGroup);
+            ->with($data->accountIdentifier, 'Default', true)
+            ->andReturn($data->defaultGroup);
 
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalFactory->shouldReceive('create')
@@ -201,12 +189,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalRepository->shouldReceive('save')
             ->once()
             ->with($data->principal);
-
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldReceive('findByName')
-            ->once()
-            ->with(Role::BASIC)
-            ->andReturn($data->basicRole);
 
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
         $identityRepository->shouldReceive('findById')
@@ -220,13 +202,12 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
         $handler->handle($data->event);
 
-        $this->assertTrue($data->memberGroup->hasMember($data->principalIdentifier));
+        $this->assertTrue($data->defaultGroup->hasMember($data->principalIdentifier));
     }
 
     /**
@@ -251,7 +232,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
@@ -262,7 +242,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
@@ -295,7 +274,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
@@ -306,7 +284,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
@@ -340,7 +317,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
@@ -351,7 +327,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
@@ -385,7 +360,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             ->andReturn($differentEmailIdentity);
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository->shouldNotReceive('findByAccountIdAndRole');
+        $principalGroupRepository->shouldNotReceive('findDefaultByAccountId');
         $principalGroupRepository->shouldNotReceive('save');
 
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
@@ -397,9 +372,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $principalRepository->shouldNotReceive('save');
 
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository->shouldNotReceive('findByName');
-
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
         $eventDispatcher->shouldNotReceive('dispatch');
 
@@ -409,7 +381,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
@@ -444,15 +415,13 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalFactory = Mockery::mock(PrincipalFactoryInterface::class);
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
-        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
 
-        $principalGroupRepository->shouldNotReceive('findByAccountIdAndRole');
+        $principalGroupRepository->shouldNotReceive('findDefaultByAccountId');
         $principalGroupRepository->shouldNotReceive('save');
         $principalGroupFactory->shouldNotReceive('create');
         $principalFactory->shouldNotReceive('create');
         $principalRepository->shouldNotReceive('save');
-        $roleRepository->shouldNotReceive('findByName');
         $eventDispatcher->shouldNotReceive('dispatch');
 
         $this->app->instance(EventDispatcherInterface::class, $eventDispatcher);
@@ -461,7 +430,6 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $this->app->instance(PrincipalGroupFactoryInterface::class, $principalGroupFactory);
         $this->app->instance(PrincipalFactoryInterface::class, $principalFactory);
         $this->app->instance(PrincipalRepositoryInterface::class, $principalRepository);
-        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(IdentityRepositoryInterface::class, $identityRepository);
 
         $handler = $this->app->make(IdentityCreatedViaInvitationHandler::class);
@@ -496,18 +464,11 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
         $identity = $this->createIdentity($identityIdentifier, $invitation->email());
         $principal = new Principal($principalIdentifier, $identityIdentifier, $accountIdentifier);
 
-        $basicRole = new Role(
-            new RoleIdentifier(StrTestHelper::generateUuid()),
-            Role::BASIC,
-            [],
-            true,
-        );
-
-        $memberGroup = new PrincipalGroup(
+        $defaultGroup = new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
             $accountIdentifier,
-            'Members',
-            false,
+            'Default',
+            true,
             new DateTimeImmutable(),
         );
 
@@ -520,8 +481,7 @@ class IdentityCreatedViaInvitationHandlerTest extends TestCase
             $invitation,
             $identity,
             $principal,
-            $memberGroup,
-            $basicRole,
+            $defaultGroup,
         );
     }
 
@@ -550,8 +510,7 @@ readonly class IdentityCreatedViaInvitationHandlerTestData
         public Invitation $invitation,
         public Identity $identity,
         public Principal $principal,
-        public PrincipalGroup $memberGroup,
-        public Role $basicRole,
+        public PrincipalGroup $defaultGroup,
     ) {
     }
 }

--- a/tests/Account/Principal/Infrastructure/Repository/RoleRepositoryTest.php
+++ b/tests/Account/Principal/Infrastructure/Repository/RoleRepositoryTest.php
@@ -78,15 +78,16 @@ class RoleRepositoryTest extends TestCase
     public function testFindByName(): void
     {
         $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        $roleName = 'Role ' . (string) $roleIdentifier;
         $repository = $this->app->make(RoleRepositoryInterface::class);
 
-        $repository->save(new Role($roleIdentifier, Role::BASIC, [], true));
+        $repository->save(new Role($roleIdentifier, $roleName, [], true));
 
-        $result = $repository->findByName(Role::BASIC);
+        $result = $repository->findByName($roleName);
 
         $this->assertNotNull($result);
         $this->assertSame((string) $roleIdentifier, (string) $result->roleIdentifier());
-        $this->assertSame(Role::BASIC, $result->name());
+        $this->assertSame($roleName, $result->name());
     }
 
     private function createPolicy(PolicyIdentifier $policyIdentifier): void

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
@@ -102,6 +102,7 @@ class UpdatePrincipalGroupMembersTest extends TestCase
         $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA, $groupB]);
         $principalGroupRepository->shouldNotReceive('save');
 
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
         $principalRepository = $this->emptyPrincipalRepository();
         $principalRepository->shouldNotReceive('findByIds');
 
@@ -130,6 +131,7 @@ class UpdatePrincipalGroupMembersTest extends TestCase
         $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA, $untargetedGroup]);
         $principalGroupRepository->shouldNotReceive('save');
 
+        /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
         $principalRepository = $this->emptyPrincipalRepository();
         $principalRepository->shouldNotReceive('findByIds');
 

--- a/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
+++ b/tests/Account/PrincipalGroup/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Mockery;
 use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
 use Source\Account\Principal\Application\Exception\CannotRemoveLastPrincipalGroupManagerException;
+use Source\Account\Principal\Application\Exception\PrincipalAlreadyAssignedToPrincipalGroupException;
 use Source\Account\Principal\Application\Exception\PrincipalGroupNotFoundException;
 use Source\Account\Principal\Application\Exception\PrincipalNotFoundException;
 use Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\PrincipalGroupMembers;
@@ -63,6 +64,7 @@ class UpdatePrincipalGroupMembersTest extends TestCase
         /** @var PrincipalRepositoryInterface&\Mockery\MockInterface $principalRepository */
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $principalRepository->shouldReceive('findByIds')->once()->andReturn([
+            (string) $executor->principalIdentifier() => $executor,
             (string) $manager->principalIdentifier() => $manager,
             (string) $memberA->principalIdentifier() => $memberA,
             (string) $memberB->principalIdentifier() => $memberB,
@@ -87,8 +89,63 @@ class UpdatePrincipalGroupMembersTest extends TestCase
         $this->assertTrue($groupA->hasMember($memberA->principalIdentifier()));
         $this->assertFalse($groupA->hasMember($memberB->principalIdentifier()));
         $this->assertTrue($groupB->hasMember($memberB->principalIdentifier()));
-        $this->assertTrue($untargetedGroup->hasMember($manager->principalIdentifier()));
+        $this->assertTrue($untargetedGroup->hasMember($executor->principalIdentifier()));
         $this->assertCount(2, $output->toArray()['principalGroups']);
+    }
+
+    public function testThrowsWhenRequestedPrincipalAppearsInMultipleGroups(): void
+    {
+        [$accountId, $executor, $manager, , , $groupA, $groupB] = $this->fixture();
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA, $groupB]);
+        $principalGroupRepository->shouldNotReceive('save');
+
+        $principalRepository = $this->emptyPrincipalRepository();
+        $principalRepository->shouldNotReceive('findByIds');
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $principalRepository,
+            $this->emptyRoleRepository(),
+            $this->emptyPolicyRepository(),
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $this->expectException(PrincipalAlreadyAssignedToPrincipalGroupException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [
+            new PrincipalGroupMembers($groupA->principalGroupIdentifier(), [$manager->principalIdentifier()]),
+            new PrincipalGroupMembers($groupB->principalGroupIdentifier(), [$manager->principalIdentifier()]),
+        ]), new UpdatePrincipalGroupMembersOutput());
+    }
+
+    public function testThrowsWhenRequestedPrincipalAlreadyBelongsToUntargetedGroup(): void
+    {
+        [$accountId, $executor, $manager, , , $groupA, , $untargetedGroup] = $this->fixture();
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountId')->once()->andReturn([$groupA, $untargetedGroup]);
+        $principalGroupRepository->shouldNotReceive('save');
+
+        $principalRepository = $this->emptyPrincipalRepository();
+        $principalRepository->shouldNotReceive('findByIds');
+
+        $useCase = new UpdatePrincipalGroupMembers(
+            $principalGroupRepository,
+            $principalRepository,
+            $this->emptyRoleRepository(),
+            $this->emptyPolicyRepository(),
+            $this->allowedPolicyEvaluator(),
+        );
+
+        $this->expectException(PrincipalAlreadyAssignedToPrincipalGroupException::class);
+
+        $useCase->process(new UpdatePrincipalGroupMembersInput($accountId, $executor, [
+            new PrincipalGroupMembers($groupA->principalGroupIdentifier(), [$manager->principalIdentifier(), $executor->principalIdentifier()]),
+        ]), new UpdatePrincipalGroupMembersOutput());
     }
 
     public function testThrowsWhenPrincipalGroupIsOutsideAccount(): void
@@ -305,7 +362,7 @@ class UpdatePrincipalGroupMembersTest extends TestCase
         $groupB = $this->principalGroup($accountId);
         $groupB->addMember($memberA->principalIdentifier());
         $untargetedGroup = $this->principalGroup($accountId, $roleId);
-        $untargetedGroup->addMember($manager->principalIdentifier());
+        $untargetedGroup->addMember($executor->principalIdentifier());
 
         return [$accountId, $executor, $manager, $memberA, $memberB, $groupA, $groupB, $untargetedGroup, $roleId, $policyId];
     }

--- a/tests/Database/Seeders/AccountAuthorizationSeederTest.php
+++ b/tests/Database/Seeders/AccountAuthorizationSeederTest.php
@@ -30,22 +30,18 @@ class AccountAuthorizationSeederTest extends TestCase
         $roleRepository = $this->app->make(RoleRepositoryInterface::class);
         $ownerRole = $roleRepository->findByName(Role::OWNER);
         $adminRole = $roleRepository->findByName(Role::ADMIN);
-        $basicRole = $roleRepository->findByName(Role::BASIC);
 
         $this->assertNotNull($ownerRole);
         $this->assertNotNull($adminRole);
-        $this->assertNotNull($basicRole);
+        $this->assertDatabaseMissing('account_roles', ['name' => 'Basic']);
 
         $ownerPolicies = $policyRepository->findByIds($ownerRole->policies());
         $adminPolicies = $policyRepository->findByIds($adminRole->policies());
-        $basicPolicies = $policyRepository->findByIds($basicRole->policies());
 
         $this->assertTrue($this->hasAction($ownerPolicies, Action::INVITE_MEMBER));
         $this->assertTrue($this->hasAction($ownerPolicies, Action::UPDATE));
         $this->assertTrue($this->hasAction($adminPolicies, Action::INVITE_MEMBER));
         $this->assertTrue($this->hasAction($adminPolicies, Action::UPDATE));
-        $this->assertSame([], $basicRole->policies());
-        $this->assertSame([], $basicPolicies);
     }
 
     /**


### PR DESCRIPTION
## 変更内容

- Account の招待ユーザー初期所属先を `Default` グループに変更
- Account 作成時に `Default` と `Owners` を分離
  - `Default`: 招待ユーザー初期所属用、権限なし
  - `Owners`: 作成者用、`Owner` ロール付き
- Account の `Basic` ロールを削除
- `corp@example.com` / `test@example.com` を Account 側 `Owners` に所属させるよう Seeder を修正
- Seeder 実行後に対象ユーザーの Account/Wiki 認可キャッシュを破棄
- PrincipalGroup メンバー一括更新時に、同一ユーザーが複数グループへ所属しないよう検証を追加
- `principalIdentifiers: []` を受け付けるよう Request validation を `present|array` に変更
- ローカル Redis 確認用に `6379` を公開

## 変更の種類

- [x] バグ修正
- [x] リファクタリング
- [x] テスト
- [x] ビルド/CI

## 変更理由・背景

ユーザーは複数 PrincipalGroup に所属しない設計のため、Seeder・招待時初期所属・グループ更新処理でその前提を揃える必要がありました。

また、`migrate-fresh` 後も Redis の `auth-context` が残ると古い `accountPolicies` が返るため、Seeder 側で対象テストアカウントの認可キャッシュを明示的に破棄します。

## テスト

- [x] `task test -- ...` を実行し、全体 PHPUnit がパスすることを確認
  - `OK (2953 tests, 9468 assertions)`

## レビューのポイント

- Account 側の `Default` / `Owners` の責務分離が意図と合っているか
- 招待ユーザーが `Default` に入り、作成者とテストアカウントが `Owners` に入る挙動で問題ないか
- PrincipalGroup 更新時の単一所属チェックが既存ユースケースを壊していないか
- Seeder のキャッシュ破棄対象が十分か

## 関連情報

関連Issueなし

## 注意事項

- TypeSpec / OpenAPI の更新は不要です。API のフィールド構造・型は変更していません。
- `task migrate-fresh` は Redis を初期化しないため、Seeder 側で対象テストアカウントのキャッシュを破棄しています。

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した