### PR TITLE
fix: Account書類アップロードの認可と形式対応

### DIFF
--- a/application/Http/Action/Account/Account/Query/GetAccount/GetAccountAction.php
+++ b/application/Http/Action/Account/Account/Query/GetAccount/GetAccountAction.php
@@ -43,6 +43,7 @@ readonly class GetAccountAction
                 $input = new GetAccountInput(
                     accountIdentifier: new AccountIdentifier($request->accountId()),
                     principal: $this->accountContext->principal(),
+                    accountType: $this->accountContext->accountType(),
                 );
             } catch (InvalidArgumentException $e) {
                 throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);

--- a/application/Http/Action/Account/Account/Query/ViewMyAccountDocument/ViewMyAccountDocumentAction.php
+++ b/application/Http/Action/Account/Account/Query/ViewMyAccountDocument/ViewMyAccountDocumentAction.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Account\Query\ViewMyAccountDocument;
+
+use Application\Http\Context\AccountContext;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Models\Account\AccountDocument;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Storage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
+
+readonly class ViewMyAccountDocumentAction
+{
+    private const string DISK = 'verification-documents';
+
+    public function __construct(
+        private AccountContext $accountContext,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(ViewMyAccountDocumentRequest $request): JsonResponse|StreamedResponse
+    {
+        try {
+            /** @var AccountDocument|null $document */
+            $document = AccountDocument::query()
+                ->where('account_id', (string) $this->accountContext->principal()->accountIdentifier())
+                ->where('document_type', $request->documentType())
+                ->first();
+
+            if ($document === null) {
+                throw new NotFoundHttpException(detail: 'Account document not found.');
+            }
+
+            $disk = Storage::disk(self::DISK);
+
+            if (! $disk->exists($document->document_path)) {
+                throw new NotFoundHttpException(detail: 'Account document file not found.');
+            }
+
+            return $disk->response(
+                $document->document_path,
+                basename($document->document_path),
+                ['Cache-Control' => 'private, no-store'],
+            );
+        } catch (NotFoundHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+    }
+}

--- a/application/Http/Action/Account/Account/Query/ViewMyAccountDocument/ViewMyAccountDocumentRequest.php
+++ b/application/Http/Action/Account/Account/Query/ViewMyAccountDocument/ViewMyAccountDocumentRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Account\Query\ViewMyAccountDocument;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ViewMyAccountDocumentRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function documentType(): string
+    {
+        return (string) $this->route('documentType');
+    }
+}

--- a/application/Http/Action/Account/Member/Query/ListMembers/ListMembersAction.php
+++ b/application/Http/Action/Account/Member/Query/ListMembers/ListMembersAction.php
@@ -31,7 +31,11 @@ readonly class ListMembersAction
     public function __invoke(ListMembersRequest $request): JsonResponse
     {
         try {
-            $members = $this->listMembers->process(new ListMembersInput($this->accountContext->principal()->accountIdentifier(), $this->accountContext->principal()));
+            $members = $this->listMembers->process(new ListMembersInput(
+                $this->accountContext->principal()->accountIdentifier(),
+                $this->accountContext->principal(),
+                $this->accountContext->accountType(),
+            ));
         } catch (AccountUpdateForbiddenException $e) {
             $exception = new ForbiddenHttpException(detail: error_message('account_update_forbidden', $request->language()), previous: $e);
 

--- a/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersAction.php
+++ b/application/Http/Action/Account/PrincipalGroup/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersAction.php
@@ -50,6 +50,7 @@ readonly class UpdatePrincipalGroupMembersAction
                         new PrincipalGroupIdentifier($principalGroup['principalGroupIdentifier']),
                         array_map(static fn (string $principalIdentifier): PrincipalIdentifier => new PrincipalIdentifier($principalIdentifier), $principalGroup['principalIdentifiers']),
                     ), $request->principalGroups()),
+                    accountType: $this->accountContext->accountType(),
                 );
                 $output = new UpdatePrincipalGroupMembersOutput();
             } catch (InvalidArgumentException $e) {

--- a/application/Http/Action/Account/PrincipalGroup/Query/ListPrincipalGroups/ListPrincipalGroupsAction.php
+++ b/application/Http/Action/Account/PrincipalGroup/Query/ListPrincipalGroups/ListPrincipalGroupsAction.php
@@ -31,7 +31,11 @@ readonly class ListPrincipalGroupsAction
     public function __invoke(ListPrincipalGroupsRequest $request): JsonResponse
     {
         try {
-            $principalGroups = $this->listPrincipalGroups->process(new ListPrincipalGroupsInput($this->accountContext->principal()->accountIdentifier(), $this->accountContext->principal()));
+            $principalGroups = $this->listPrincipalGroups->process(new ListPrincipalGroupsInput(
+                $this->accountContext->principal()->accountIdentifier(),
+                $this->accountContext->principal(),
+                $this->accountContext->accountType(),
+            ));
         } catch (AccountUpdateForbiddenException $e) {
             $exception = new ForbiddenHttpException(detail: error_message('account_update_forbidden', $request->language()), previous: $e);
 

--- a/application/Http/Context/AccountResolver.php
+++ b/application/Http/Context/AccountResolver.php
@@ -14,6 +14,8 @@ use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Condition;
+use Source\Account\Principal\Domain\ValueObject\ConditionClause;
 use Source\Account\Principal\Domain\ValueObject\ResourceType;
 use Source\Account\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Account\Principal\Domain\ValueObject\Statement;
@@ -111,7 +113,7 @@ readonly class AccountResolver
     }
 
     /**
-     * @return array{effect: string, actions: array<int, string>, resourceTypes: array<int, string>}
+     * @return array{effect: string, actions: array<int, string>, resourceTypes: array<int, string>, condition: array{clauses: array<int, array{field: string, operator: string, value: string|bool}>}|null}
      */
     private function toStatementArray(Statement $statement): array
     {
@@ -119,6 +121,33 @@ readonly class AccountResolver
             'effect' => $statement->effect()->value,
             'actions' => array_map(static fn (Action $action): string => $action->value, $statement->actions()),
             'resourceTypes' => array_map(static fn (ResourceType $resourceType): string => $resourceType->value, $statement->resourceTypes()),
+            'condition' => $this->toConditionArray($statement->condition()),
+        ];
+    }
+
+    /**
+     * @return array{clauses: array<int, array{field: string, operator: string, value: string|bool}>}|null
+     */
+    private function toConditionArray(?Condition $condition): ?array
+    {
+        if ($condition === null) {
+            return null;
+        }
+
+        return [
+            'clauses' => array_map($this->toConditionClauseArray(...), $condition->clauses()),
+        ];
+    }
+
+    /**
+     * @return array{field: string, operator: string, value: string|bool}
+     */
+    private function toConditionClauseArray(ConditionClause $clause): array
+    {
+        return [
+            'field' => $clause->key()->value,
+            'operator' => $clause->operator()->value,
+            'value' => $clause->value(),
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "scripts": {
         "cs-fix": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "cs-check": "vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes",
-        "phpstan": "./vendor/bin/phpstan analyse --memory-limit=512M",
+        "phpstan": "./vendor/bin/phpstan analyse --memory-limit=1G",
         "test": "vendor/bin/phpunit --coverage-html coverage-html",
         "test-no-report": "vendor/bin/phpunit"
     }

--- a/database/seeders/AccountAuthorizationSeeder.php
+++ b/database/seeders/AccountAuthorizationSeeder.php
@@ -11,10 +11,15 @@ use Source\Account\Principal\Domain\Entity\Policy;
 use Source\Account\Principal\Domain\Entity\Role;
 use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Condition;
+use Source\Account\Principal\Domain\ValueObject\ConditionClause;
+use Source\Account\Principal\Domain\ValueObject\ConditionKey;
+use Source\Account\Principal\Domain\ValueObject\ConditionOperator;
 use Source\Account\Principal\Domain\ValueObject\PolicyIdentifier;
 use Source\Account\Principal\Domain\ValueObject\ResourceType;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\Statement;
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Symfony\Component\Uid\Uuid;
 
 
@@ -31,15 +36,33 @@ class AccountAuthorizationSeeder extends Seeder
             new Statement(
                 effect: Effect::ALLOW,
                 actions: [
+                    Action::READ,
+                ],
+                resourceTypes: [ResourceType::ACCOUNT],
+            ),
+            new Statement(
+                effect: Effect::ALLOW,
+                actions: [
                     Action::INVITE_MEMBER,
+                ],
+                resourceTypes: [ResourceType::ACCOUNT],
+                condition: $this->corporationAccountCondition(),
+            ),
+            new Statement(
+                effect: Effect::ALLOW,
+                actions: [
                     Action::UPDATE,
-                    Action::SETTINGS_UPDATE,
-                    Action::DELETE,
-                    Action::BILLING_MANAGE,
-                    Action::DELEGATION_MANAGE,
+                ],
+                resourceTypes: [ResourceType::ACCOUNT],
+                condition: $this->corporationAccountCondition(),
+            ),
+            new Statement(
+                effect: Effect::ALLOW,
+                actions: [
                     Action::PRINCIPAL_GROUP_MANAGE,
                 ],
                 resourceTypes: [ResourceType::ACCOUNT],
+                condition: $this->corporationAccountCondition(),
             ),
         ]);
 
@@ -47,18 +70,49 @@ class AccountAuthorizationSeeder extends Seeder
             new Statement(
                 effect: Effect::ALLOW,
                 actions: [
+                    Action::READ,
+                ],
+                resourceTypes: [ResourceType::ACCOUNT],
+            ),
+            new Statement(
+                effect: Effect::ALLOW,
+                actions: [
                     Action::INVITE_MEMBER,
+                ],
+                resourceTypes: [ResourceType::ACCOUNT],
+                condition: $this->corporationAccountCondition(),
+            ),
+            new Statement(
+                effect: Effect::ALLOW,
+                actions: [
                     Action::UPDATE,
-                    Action::SETTINGS_UPDATE,
-                    Action::DELEGATION_MANAGE,
+                ],
+                resourceTypes: [ResourceType::ACCOUNT],
+                condition: $this->corporationAccountCondition(),
+            ),
+            new Statement(
+                effect: Effect::ALLOW,
+                actions: [
                     Action::PRINCIPAL_GROUP_MANAGE,
                 ],
                 resourceTypes: [ResourceType::ACCOUNT],
+                condition: $this->corporationAccountCondition(),
             ),
         ]);
 
         $this->saveRole(Role::OWNER, [$ownerPolicy->policyIdentifier()]);
         $this->saveRole(Role::ADMIN, [$adminPolicy->policyIdentifier()]);
+    }
+
+    private function corporationAccountCondition(): Condition
+    {
+        return new Condition([
+            new ConditionClause(
+                ConditionKey::RESOURCE_ACCOUNT_TYPE,
+                ConditionOperator::EQUALS,
+                AccountType::CORPORATION->value,
+            ),
+        ]);
     }
 
     /**

--- a/doc/openapi/KPool.IdentityApi.openapi.yaml
+++ b/doc/openapi/KPool.IdentityApi.openapi.yaml
@@ -454,6 +454,34 @@ components:
             $ref: '#/components/schemas/AccountPolicyStatement'
           description: Statements that define the effective policy.
       description: Effective account policy summary for the authenticated identity.
+    AccountPolicyCondition:
+      type: object
+      properties:
+        clauses:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountPolicyConditionClause'
+          description: List of condition clauses.
+      description: Conditional constraints for an account policy statement.
+    AccountPolicyConditionClause:
+      type: object
+      required:
+        - field
+        - operator
+        - value
+      properties:
+        field:
+          type: string
+          description: Field name to evaluate.
+        operator:
+          type: string
+          description: Operator used for the comparison.
+        value:
+          anyOf:
+            - type: string
+            - type: boolean
+          description: Value to compare against.
+      description: Single condition clause in an account policy.
     AccountPolicyStatement:
       type: object
       required:
@@ -474,11 +502,18 @@ components:
           items:
             type: string
           description: Resource types covered by this statement.
+        condition:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/AccountPolicyCondition'
+          nullable: true
+          description: Optional condition attached to the statement.
       description: Policy statement returned for account effective policies.
     AuthenticatedIdentitySummary:
       type: object
       required:
         - accountIdentifier
+        - accountPrincipalIdentifier
         - accountType
         - accountPolicies
       properties:
@@ -488,6 +523,12 @@ components:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           nullable: true
           description: Account identifier associated with the authenticated identity.
+        accountPrincipalIdentifier:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
+          description: Account principal identifier associated with the authenticated identity in the current account.
         accountType:
           type: string
           nullable: true

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -8,6 +8,7 @@ use Application\Http\Action\Account\Account\Command\Documents\UploadDocumentsAct
 use Application\Http\Action\Account\Account\Command\UpdateAccount\UpdateAccountAction;
 use Application\Http\Action\Account\Account\Query\GetAccount\GetAccountAction;
 use Application\Http\Action\Account\Account\Query\ListMyAccountDocuments\ListMyAccountDocumentsAction;
+use Application\Http\Action\Account\Account\Query\ViewMyAccountDocument\ViewMyAccountDocumentAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\ApproveVerification\ApproveVerificationAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\RejectVerification\RejectVerificationAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\RequestVerification\RequestVerificationAction;
@@ -36,6 +37,7 @@ Route::post('/accounts', CreateAccountAction::class);
 Route::middleware(['auth.api', 'resolve.actor', 'resolve.account'])->group(function () {
     // Account
     Route::get('/my/documents', ListMyAccountDocumentsAction::class);
+    Route::get('/my/documents/{documentType}', ViewMyAccountDocumentAction::class);
     Route::get('/accounts/{accountId}', GetAccountAction::class);
     Route::patch('/accounts/{accountId}', UpdateAccountAction::class);
     Route::delete('/accounts/{accountId}', DeleteAccountAction::class);

--- a/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccount.php
+++ b/src/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccount.php
@@ -44,7 +44,7 @@ readonly class UpdateAccount implements UpdateAccountInterface
             || ! $this->policyEvaluator->evaluate(
                 $input->principal(),
                 Action::UPDATE,
-                Resource::account($account->accountIdentifier()),
+                Resource::account($account->accountIdentifier(), $account->type()),
             )
         ) {
             throw new AccountUpdateForbiddenException();

--- a/src/Account/Account/Application/UseCase/Query/GetAccount/GetAccountInput.php
+++ b/src/Account/Account/Application/UseCase/Query/GetAccount/GetAccountInput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\UseCase\Query\GetAccount;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
@@ -12,6 +13,7 @@ readonly class GetAccountInput implements GetAccountInputPort
     public function __construct(
         private AccountIdentifier $accountIdentifier,
         private Principal $principal,
+        private ?AccountType $accountType = null,
     ) {
     }
 
@@ -23,5 +25,10 @@ readonly class GetAccountInput implements GetAccountInputPort
     public function principal(): Principal
     {
         return $this->principal;
+    }
+
+    public function accountType(): ?AccountType
+    {
+        return $this->accountType;
     }
 }

--- a/src/Account/Account/Application/UseCase/Query/GetAccount/GetAccountInputPort.php
+++ b/src/Account/Account/Application/UseCase/Query/GetAccount/GetAccountInputPort.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\UseCase\Query\GetAccount;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
@@ -12,4 +13,6 @@ interface GetAccountInputPort
     public function accountIdentifier(): AccountIdentifier;
 
     public function principal(): Principal;
+
+    public function accountType(): ?AccountType;
 }

--- a/src/Account/Account/Domain/ValueObject/AccountDocumentFileType.php
+++ b/src/Account/Account/Domain/ValueObject/AccountDocumentFileType.php
@@ -10,6 +10,8 @@ enum AccountDocumentFileType: string
     case JPEG = 'image/jpeg';
     case PNG = 'image/png';
     case WEBP = 'image/webp';
+    case HEIC = 'image/heic';
+    case HEIF = 'image/heif';
 
     public static function tryFromMimeType(string $mimeType): ?self
     {
@@ -23,6 +25,8 @@ enum AccountDocumentFileType: string
             self::JPEG => 'jpg',
             self::PNG => 'png',
             self::WEBP => 'webp',
+            self::HEIC => 'heic',
+            self::HEIF => 'heif',
         };
     }
 }

--- a/src/Account/Account/Infrastructure/Query/GetAccount.php
+++ b/src/Account/Account/Infrastructure/Query/GetAccount.php
@@ -35,8 +35,8 @@ readonly class GetAccount implements GetAccountInterface
 
         if (! $this->policyEvaluator->evaluate(
             $input->principal(),
-            Action::UPDATE,
-            Resource::account($accountIdentifier),
+            Action::READ,
+            Resource::account($accountIdentifier, $input->accountType()),
         )) {
             throw new AccountUpdateForbiddenException();
         }

--- a/src/Account/Account/Infrastructure/Service/AccountDocumentFileTypeDetector.php
+++ b/src/Account/Account/Infrastructure/Service/AccountDocumentFileTypeDetector.php
@@ -17,9 +17,24 @@ readonly class AccountDocumentFileTypeDetector implements AccountDocumentFileTyp
         $fileType = AccountDocumentFileType::tryFromMimeType((string) $mimeType);
 
         if ($fileType === null) {
+            $fileType = $this->detectIsoBaseMediaFileType($contents);
+        }
+
+        if ($fileType === null) {
             throw new InvalidDocumentsForVerificationException('Unsupported account document file type.');
         }
 
         return $fileType;
+    }
+
+    private function detectIsoBaseMediaFileType(string $contents): ?AccountDocumentFileType
+    {
+        $brand = substr($contents, 8, 4);
+
+        return match ($brand) {
+            'heic', 'heix', 'hevc', 'hevx' => AccountDocumentFileType::HEIC,
+            'mif1', 'msf1' => AccountDocumentFileType::HEIF,
+            default => null,
+        };
     }
 }

--- a/src/Account/Invitation/Application/UseCase/Command/InviteMember/InviteMember.php
+++ b/src/Account/Invitation/Application/UseCase/Command/InviteMember/InviteMember.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Account\Invitation\Application\UseCase\Command\InviteMember;
 
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
+use Source\Account\Account\Domain\Entity\Account;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Invitation\Application\Exception\DisallowedInvitationException;
 use Source\Account\Invitation\Domain\Event\InvitationCreated;
@@ -37,9 +38,9 @@ readonly class InviteMember implements InviteMemberInterface
 
     public function process(InviteMemberInputPort $input, InviteMemberOutputPort $output): void
     {
-        $this->assertAccountAllowsInvitation($input);
+        $account = $this->assertAccountAllowsInvitation($input);
         $principal = $this->findInviterPrincipal($input);
-        $this->assertInviterHasPermission($input, $principal);
+        $this->assertInviterHasPermission($input, $principal, $account);
 
         $invitations = [];
         foreach ($input->emails() as $email) {
@@ -114,11 +115,12 @@ readonly class InviteMember implements InviteMemberInterface
     private function assertInviterHasPermission(
         InviteMemberInputPort $input,
         Principal $principal,
+        Account $account,
     ): void {
         $allowed = $this->policyEvaluator->evaluate(
             $principal,
             Action::INVITE_MEMBER,
-            Resource::account($input->accountIdentifier()),
+            Resource::account($input->accountIdentifier(), $account->type()),
         );
 
         if ($allowed) {
@@ -128,12 +130,12 @@ readonly class InviteMember implements InviteMemberInterface
         throw new DisallowedInvitationException('招待を作成する権限がありません。');
     }
 
-    private function assertAccountAllowsInvitation(InviteMemberInputPort $input): void
+    private function assertAccountAllowsInvitation(InviteMemberInputPort $input): Account
     {
         $account = $this->accountRepository->findById($input->accountIdentifier());
 
         if ($account?->type() === AccountType::CORPORATION) {
-            return;
+            return $account;
         }
 
         throw new DisallowedInvitationException('法人アカウントのみメンバーを招待できます。');

--- a/src/Account/Invitation/Application/UseCase/Command/InviteMember/InviteMember.php
+++ b/src/Account/Invitation/Application/UseCase/Command/InviteMember/InviteMember.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Source\Account\Invitation\Application\UseCase\Command\InviteMember;
 
-use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Account\Domain\Entity\Account;
+use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Invitation\Application\Exception\DisallowedInvitationException;
 use Source\Account\Invitation\Domain\Event\InvitationCreated;

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
@@ -39,7 +39,11 @@ readonly class UpdatePrincipalGroupMembers implements UpdatePrincipalGroupMember
     {
         $accountIdentifier = $input->accountIdentifier();
         if ((string) $input->principal()->accountIdentifier() !== (string) $accountIdentifier
-            || ! $this->policyEvaluator->evaluate($input->principal(), Action::PRINCIPAL_GROUP_MANAGE, Resource::account($accountIdentifier))
+            || ! $this->policyEvaluator->evaluate(
+                $input->principal(),
+                Action::PRINCIPAL_GROUP_MANAGE,
+                Resource::account($accountIdentifier, $input->accountType())
+            )
         ) {
             throw new AccountUpdateForbiddenException();
         }

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInput.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
@@ -16,6 +17,7 @@ readonly class UpdatePrincipalGroupMembersInput implements UpdatePrincipalGroupM
         private AccountIdentifier $accountIdentifier,
         private Principal $principal,
         private array $principalGroups,
+        private ?AccountType $accountType = null,
     ) {
     }
 
@@ -27,6 +29,11 @@ readonly class UpdatePrincipalGroupMembersInput implements UpdatePrincipalGroupM
     public function principal(): Principal
     {
         return $this->principal;
+    }
+
+    public function accountType(): ?AccountType
+    {
+        return $this->accountType;
     }
 
     /**

--- a/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInputPort.php
+++ b/src/Account/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersInputPort.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
@@ -12,6 +13,8 @@ interface UpdatePrincipalGroupMembersInputPort
     public function accountIdentifier(): AccountIdentifier;
 
     public function principal(): Principal;
+
+    public function accountType(): ?AccountType;
 
     /**
      * @return array<int, PrincipalGroupMembers>

--- a/src/Account/Principal/Application/UseCase/Query/ListMembers/ListMembersInput.php
+++ b/src/Account/Principal/Application/UseCase/Query/ListMembers/ListMembersInput.php
@@ -14,8 +14,7 @@ readonly class ListMembersInput implements ListMembersInputPort
         private AccountIdentifier $accountIdentifier,
         private Principal $principal,
         private ?AccountType $accountType = null,
-    )
-    {
+    ) {
     }
 
     public function accountIdentifier(): AccountIdentifier

--- a/src/Account/Principal/Application/UseCase/Query/ListMembers/ListMembersInput.php
+++ b/src/Account/Principal/Application/UseCase/Query/ListMembers/ListMembersInput.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Query\ListMembers;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
 readonly class ListMembersInput implements ListMembersInputPort
 {
-    public function __construct(private AccountIdentifier $accountIdentifier, private Principal $principal)
+    public function __construct(
+        private AccountIdentifier $accountIdentifier,
+        private Principal $principal,
+        private ?AccountType $accountType = null,
+    )
     {
     }
 
@@ -21,5 +26,10 @@ readonly class ListMembersInput implements ListMembersInputPort
     public function principal(): Principal
     {
         return $this->principal;
+    }
+
+    public function accountType(): ?AccountType
+    {
+        return $this->accountType;
     }
 }

--- a/src/Account/Principal/Application/UseCase/Query/ListMembers/ListMembersInputPort.php
+++ b/src/Account/Principal/Application/UseCase/Query/ListMembers/ListMembersInputPort.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Query\ListMembers;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
@@ -12,4 +13,6 @@ interface ListMembersInputPort
     public function accountIdentifier(): AccountIdentifier;
 
     public function principal(): Principal;
+
+    public function accountType(): ?AccountType;
 }

--- a/src/Account/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInput.php
+++ b/src/Account/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInput.php
@@ -14,8 +14,7 @@ readonly class ListPrincipalGroupsInput implements ListPrincipalGroupsInputPort
         private AccountIdentifier $accountIdentifier,
         private Principal $principal,
         private ?AccountType $accountType = null,
-    )
-    {
+    ) {
     }
 
     public function accountIdentifier(): AccountIdentifier

--- a/src/Account/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInput.php
+++ b/src/Account/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInput.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Query\ListPrincipalGroups;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
 readonly class ListPrincipalGroupsInput implements ListPrincipalGroupsInputPort
 {
-    public function __construct(private AccountIdentifier $accountIdentifier, private Principal $principal)
+    public function __construct(
+        private AccountIdentifier $accountIdentifier,
+        private Principal $principal,
+        private ?AccountType $accountType = null,
+    )
     {
     }
 
@@ -21,5 +26,10 @@ readonly class ListPrincipalGroupsInput implements ListPrincipalGroupsInputPort
     public function principal(): Principal
     {
         return $this->principal;
+    }
+
+    public function accountType(): ?AccountType
+    {
+        return $this->accountType;
     }
 }

--- a/src/Account/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInputPort.php
+++ b/src/Account/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInputPort.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Application\UseCase\Query\ListPrincipalGroups;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
@@ -12,4 +13,6 @@ interface ListPrincipalGroupsInputPort
     public function accountIdentifier(): AccountIdentifier;
 
     public function principal(): Principal;
+
+    public function accountType(): ?AccountType;
 }

--- a/src/Account/Principal/Domain/ValueObject/Action.php
+++ b/src/Account/Principal/Domain/ValueObject/Action.php
@@ -6,11 +6,8 @@ namespace Source\Account\Principal\Domain\ValueObject;
 
 enum Action: string
 {
+    case READ = 'account:read';
     case INVITE_MEMBER = 'account:member:invite';
     case UPDATE = 'account:update';
-    case SETTINGS_UPDATE = 'account:settings:update';
-    case DELETE = 'account:delete';
-    case BILLING_MANAGE = 'account:billing:manage';
-    case DELEGATION_MANAGE = 'account:delegation:manage';
     case PRINCIPAL_GROUP_MANAGE = 'account:principal-group:manage';
 }

--- a/src/Account/Principal/Domain/ValueObject/Condition.php
+++ b/src/Account/Principal/Domain/ValueObject/Condition.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Domain\ValueObject;
+
+final readonly class Condition
+{
+    /**
+     * @param list<ConditionClause> $clauses AND結合で評価
+     */
+    public function __construct(
+        private array $clauses,
+    ) {
+    }
+
+    /**
+     * @return list<ConditionClause>
+     */
+    public function clauses(): array
+    {
+        return $this->clauses;
+    }
+}

--- a/src/Account/Principal/Domain/ValueObject/ConditionClause.php
+++ b/src/Account/Principal/Domain/ValueObject/ConditionClause.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Domain\ValueObject;
+
+final readonly class ConditionClause
+{
+    public function __construct(
+        private ConditionKey $key,
+        private ConditionOperator $operator,
+        private string|bool $value,
+    ) {
+    }
+
+    public function key(): ConditionKey
+    {
+        return $this->key;
+    }
+
+    public function operator(): ConditionOperator
+    {
+        return $this->operator;
+    }
+
+    public function value(): string|bool
+    {
+        return $this->value;
+    }
+}

--- a/src/Account/Principal/Domain/ValueObject/ConditionKey.php
+++ b/src/Account/Principal/Domain/ValueObject/ConditionKey.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Domain\ValueObject;
+
+enum ConditionKey: string
+{
+    case RESOURCE_ACCOUNT_TYPE = 'resource:accountType';
+}

--- a/src/Account/Principal/Domain/ValueObject/ConditionOperator.php
+++ b/src/Account/Principal/Domain/ValueObject/ConditionOperator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Principal\Domain\ValueObject;
+
+enum ConditionOperator: string
+{
+    case EQUALS = 'eq';
+    case NOT_EQUALS = 'ne';
+    case IN = 'in';
+    case NOT_IN = 'not_in';
+}

--- a/src/Account/Principal/Domain/ValueObject/Resource.php
+++ b/src/Account/Principal/Domain/ValueObject/Resource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Source\Account\Principal\Domain\ValueObject;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
 final readonly class Resource
@@ -11,12 +12,13 @@ final readonly class Resource
     public function __construct(
         private ResourceType $type,
         private AccountIdentifier $accountIdentifier,
+        private ?AccountType $accountType = null,
     ) {
     }
 
-    public static function account(AccountIdentifier $accountIdentifier): self
+    public static function account(AccountIdentifier $accountIdentifier, ?AccountType $accountType = null): self
     {
-        return new self(ResourceType::ACCOUNT, $accountIdentifier);
+        return new self(ResourceType::ACCOUNT, $accountIdentifier, $accountType);
     }
 
     public function type(): ResourceType
@@ -27,5 +29,10 @@ final readonly class Resource
     public function accountIdentifier(): AccountIdentifier
     {
         return $this->accountIdentifier;
+    }
+
+    public function accountType(): ?AccountType
+    {
+        return $this->accountType;
     }
 }

--- a/src/Account/Principal/Domain/ValueObject/Statement.php
+++ b/src/Account/Principal/Domain/ValueObject/Statement.php
@@ -14,6 +14,7 @@ final readonly class Statement
         private Effect $effect,
         private array $actions,
         private array $resourceTypes,
+        private ?Condition $condition = null,
     ) {
     }
 
@@ -36,5 +37,10 @@ final readonly class Statement
     public function resourceTypes(): array
     {
         return $this->resourceTypes;
+    }
+
+    public function condition(): ?Condition
+    {
+        return $this->condition;
     }
 }

--- a/src/Account/Principal/Infrastructure/Query/Authorization/PrincipalGroupManageAuthorization.php
+++ b/src/Account/Principal/Infrastructure/Query/Authorization/PrincipalGroupManageAuthorization.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Infrastructure\Query\Authorization;
 
 use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
@@ -18,13 +19,13 @@ readonly class PrincipalGroupManageAuthorization
     }
 
     /** @throws AccountUpdateForbiddenException */
-    public function assertAllowed(AccountIdentifier $accountIdentifier, Principal $principal): void
+    public function assertAllowed(AccountIdentifier $accountIdentifier, Principal $principal, ?AccountType $accountType = null): void
     {
         if ((string) $principal->accountIdentifier() !== (string) $accountIdentifier) {
             throw new AccountUpdateForbiddenException();
         }
 
-        if (! $this->policyEvaluator->evaluate($principal, Action::PRINCIPAL_GROUP_MANAGE, Resource::account($accountIdentifier))) {
+        if (! $this->policyEvaluator->evaluate($principal, Action::PRINCIPAL_GROUP_MANAGE, Resource::account($accountIdentifier, $accountType))) {
             throw new AccountUpdateForbiddenException();
         }
     }

--- a/src/Account/Principal/Infrastructure/Query/ListMembers.php
+++ b/src/Account/Principal/Infrastructure/Query/ListMembers.php
@@ -22,7 +22,7 @@ readonly class ListMembers implements ListMembersInterface
     public function process(ListMembersInputPort $input): array
     {
         $accountIdentifier = $input->accountIdentifier();
-        $this->authorization->assertAllowed($accountIdentifier, $input->principal());
+        $this->authorization->assertAllowed($accountIdentifier, $input->principal(), $input->accountType());
 
         /** @var Collection<int, PrincipalModel> $principals */
         $principals = PrincipalModel::query()

--- a/src/Account/Principal/Infrastructure/Query/ListPrincipalGroups.php
+++ b/src/Account/Principal/Infrastructure/Query/ListPrincipalGroups.php
@@ -22,7 +22,7 @@ readonly class ListPrincipalGroups implements ListPrincipalGroupsInterface
     public function process(ListPrincipalGroupsInputPort $input): array
     {
         $accountIdentifier = $input->accountIdentifier();
-        $this->authorization->assertAllowed($accountIdentifier, $input->principal());
+        $this->authorization->assertAllowed($accountIdentifier, $input->principal(), $input->accountType());
 
         /** @var Collection<int, PrincipalGroupModel> $groups */
         $groups = PrincipalGroupModel::query()

--- a/src/Account/Principal/Infrastructure/Repository/PolicyRepository.php
+++ b/src/Account/Principal/Infrastructure/Repository/PolicyRepository.php
@@ -14,6 +14,10 @@ use DateTimeImmutable;
 use Source\Account\Principal\Domain\Entity\Policy;
 use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Condition;
+use Source\Account\Principal\Domain\ValueObject\ConditionClause;
+use Source\Account\Principal\Domain\ValueObject\ConditionKey;
+use Source\Account\Principal\Domain\ValueObject\ConditionOperator;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\PolicyIdentifier;
 use Source\Account\Principal\Domain\ValueObject\ResourceType;
@@ -75,7 +79,7 @@ class PolicyRepository implements PolicyRepositoryInterface
 
     /**
      * @param Statement[] $statements
-     * @return array<array{effect: string, actions: array<string>, resource_types: array<string>}>
+     * @return array<array{effect: string, actions: array<string>, resource_types: array<string>, condition: array<array{key: string, operator: string, value: string|bool}>|null}>
      */
     private function serializeStatements(array $statements): array
     {
@@ -83,7 +87,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @return array{effect: string, actions: array<string>, resource_types: array<string>}
+     * @return array{effect: string, actions: array<string>, resource_types: array<string>, condition: array<array{key: string, operator: string, value: string|bool}>|null}
      */
     private function serializeStatement(Statement $statement): array
     {
@@ -91,7 +95,25 @@ class PolicyRepository implements PolicyRepositoryInterface
             'effect' => $statement->effect()->value,
             'actions' => array_map(static fn (Action $action) => $action->value, $statement->actions()),
             'resource_types' => array_map(static fn (ResourceType $resourceType) => $resourceType->value, $statement->resourceTypes()),
+            'condition' => $statement->condition() !== null
+                ? $this->serializeCondition($statement->condition())
+                : null,
         ];
+    }
+
+    /**
+     * @return array<array{key: string, operator: string, value: string|bool}>
+     */
+    private function serializeCondition(Condition $condition): array
+    {
+        return array_map(
+            static fn (ConditionClause $clause): array => [
+                'key' => $clause->key()->value,
+                'operator' => $clause->operator()->value,
+                'value' => $clause->value(),
+            ],
+            $condition->clauses()
+        );
     }
 
     private function toDomainEntity(PolicyEloquent $eloquent): Policy
@@ -106,7 +128,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @param array<array{effect: string, actions: array<string>, resource_types: array<string>}> $statementsData
+     * @param array<array{effect: string, actions: array<string>, resource_types: array<string>, condition?: array<array{key: string, operator: string, value: string|bool}>|null}> $statementsData
      * @return Statement[]
      */
     private function deserializeStatements(array $statementsData): array
@@ -115,7 +137,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @param array{effect: string, actions: array<string>, resource_types: array<string>} $data
+     * @param array{effect: string, actions: array<string>, resource_types: array<string>, condition?: array<array{key: string, operator: string, value: string|bool}>|null} $data
      */
     private function deserializeStatement(array $data): Statement
     {
@@ -123,7 +145,25 @@ class PolicyRepository implements PolicyRepositoryInterface
             Effect::from($data['effect']),
             array_map(Action::from(...), $data['actions']),
             array_map(ResourceType::from(...), $data['resource_types']),
+            array_key_exists('condition', $data) && $data['condition'] !== null
+                ? $this->deserializeCondition($data['condition'])
+                : null,
         );
+    }
+
+    /**
+     * @param array<array{key: string, operator: string, value: string|bool}> $conditionData
+     */
+    private function deserializeCondition(array $conditionData): Condition
+    {
+        return new Condition(array_map(
+            static fn (array $clauseData): ConditionClause => new ConditionClause(
+                ConditionKey::from($clauseData['key']),
+                ConditionOperator::from($clauseData['operator']),
+                $clauseData['value'],
+            ),
+            $conditionData
+        ));
     }
 
     /** @return array<int, string> */

--- a/src/Account/Principal/Infrastructure/Service/PolicyEvaluator.php
+++ b/src/Account/Principal/Infrastructure/Service/PolicyEvaluator.php
@@ -10,9 +10,12 @@ use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface
 use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
 use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Condition;
+use Source\Account\Principal\Domain\ValueObject\ConditionClause;
+use Source\Account\Principal\Domain\ValueObject\ConditionKey;
+use Source\Account\Principal\Domain\ValueObject\ConditionOperator;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\Resource;
-use Source\Account\Principal\Domain\ValueObject\ResourceType;
 use Source\Account\Principal\Domain\ValueObject\Statement;
 
 readonly class PolicyEvaluator implements PolicyEvaluatorInterface
@@ -30,7 +33,7 @@ readonly class PolicyEvaluator implements PolicyEvaluatorInterface
         Resource $resource,
     ): bool {
         $statements = $this->collectStatements($principal, $resource);
-        $applicableStatements = $this->filterApplicable($statements, $action, $resource->type());
+        $applicableStatements = $this->filterApplicable($statements, $action, $resource);
 
         foreach ($applicableStatements as $statement) {
             if ($statement->effect() === Effect::DENY) {
@@ -90,13 +93,51 @@ readonly class PolicyEvaluator implements PolicyEvaluatorInterface
      * @param Statement[] $statements
      * @return Statement[]
      */
-    private function filterApplicable(array $statements, Action $action, ResourceType $resourceType): array
+    private function filterApplicable(array $statements, Action $action, Resource $resource): array
     {
-        return array_filter($statements, static function (Statement $statement) use ($action, $resourceType): bool {
+        return array_filter($statements, function (Statement $statement) use ($action, $resource): bool {
             $actionMatches = in_array($action, $statement->actions(), true);
-            $resourceMatches = in_array($resourceType, $statement->resourceTypes(), true);
+            $resourceMatches = in_array($resource->type(), $statement->resourceTypes(), true);
 
-            return $actionMatches && $resourceMatches;
+            return $actionMatches && $resourceMatches && $this->conditionMatches($statement->condition(), $resource);
         });
+    }
+
+    private function conditionMatches(?Condition $condition, Resource $resource): bool
+    {
+        if ($condition === null) {
+            return true;
+        }
+
+        foreach ($condition->clauses() as $clause) {
+            if (! $this->conditionClauseMatches($clause, $resource)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function conditionClauseMatches(ConditionClause $clause, Resource $resource): bool
+    {
+        $actual = $this->conditionActualValue($clause->key(), $resource);
+
+        if ($actual === null) {
+            return false;
+        }
+
+        return match ($clause->operator()) {
+            ConditionOperator::EQUALS => $actual === $clause->value(),
+            ConditionOperator::NOT_EQUALS => $actual !== $clause->value(),
+            ConditionOperator::IN => in_array($actual, (array) $clause->value(), true),
+            ConditionOperator::NOT_IN => ! in_array($actual, (array) $clause->value(), true),
+        };
+    }
+
+    private function conditionActualValue(ConditionKey $key, Resource $resource): ?string
+    {
+        return match ($key) {
+            ConditionKey::RESOURCE_ACCOUNT_TYPE => $resource->accountType()?->value,
+        };
     }
 }

--- a/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
+++ b/src/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModel.php
@@ -16,6 +16,7 @@ readonly class AuthenticatedIdentityReadModel
         private string $language,
         private ?string $profileImage,
         private ?string $accountIdentifier,
+        private ?string $accountPrincipalIdentifier,
         private ?string $accountType,
         private array $accountPolicies = [],
     ) {
@@ -51,6 +52,11 @@ readonly class AuthenticatedIdentityReadModel
         return $this->accountIdentifier;
     }
 
+    public function accountPrincipalIdentifier(): ?string
+    {
+        return $this->accountPrincipalIdentifier;
+    }
+
     public function accountType(): ?string
     {
         return $this->accountType;
@@ -76,6 +82,7 @@ readonly class AuthenticatedIdentityReadModel
             'language' => $this->language,
             'profileImage' => $this->profileImage,
             'accountIdentifier' => $this->accountIdentifier,
+            'accountPrincipalIdentifier' => $this->accountPrincipalIdentifier,
             'accountType' => $this->accountType,
             'accountPolicies' => $this->accountPolicies,
         ];

--- a/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
+++ b/src/Identity/Infrastructure/Query/GetAuthenticatedIdentity.php
@@ -55,6 +55,7 @@ readonly class GetAuthenticatedIdentity implements GetAuthenticatedIdentityInter
             language: $model->language,
             profileImage: ImageUrl::fromPath($model->profile_image),
             accountIdentifier: $accountContext === null ? null : (string) $accountContext->principal()->accountIdentifier(),
+            accountPrincipalIdentifier: $accountContext === null ? null : (string) $accountContext->principal()->principalIdentifier(),
             accountType: $accountContext?->accountType()->value,
             accountPolicies: $accountContext?->accountPolicies() ?? [],
         );

--- a/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/UpdateAccount/UpdateAccountTest.php
@@ -67,7 +67,9 @@ class UpdateAccountTest extends TestCase
         $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
         $policyEvaluator->shouldReceive('evaluate')
             ->once()
-            ->with($principal, Action::UPDATE, Mockery::type(Resource::class))
+            ->with($principal, Action::UPDATE, Mockery::on(
+                static fn (Resource $resource): bool => $resource->accountType() === AccountType::CORPORATION
+            ))
             ->andReturnTrue();
 
         $useCase = new UpdateAccount($accountRepository, $policyEvaluator);

--- a/tests/Account/Account/Application/UseCase/Query/GetAccount/GetAccountInputTest.php
+++ b/tests/Account/Account/Application/UseCase/Query/GetAccount/GetAccountInputTest.php
@@ -6,6 +6,7 @@ namespace Tests\Account\Account\Application\UseCase\Query\GetAccount;
 
 use PHPUnit\Framework\TestCase;
 use Source\Account\Account\Application\UseCase\Query\GetAccount\GetAccountInput;
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
@@ -23,9 +24,10 @@ class GetAccountInputTest extends TestCase
             $accountIdentifier,
         );
 
-        $input = new GetAccountInput($accountIdentifier, $principal);
+        $input = new GetAccountInput($accountIdentifier, $principal, AccountType::CORPORATION);
 
         $this->assertSame($accountIdentifier, $input->accountIdentifier());
         $this->assertSame($principal, $input->principal());
+        $this->assertSame(AccountType::CORPORATION, $input->accountType());
     }
 }

--- a/tests/Account/Account/Infrastructure/Query/GetAccountTest.php
+++ b/tests/Account/Account/Infrastructure/Query/GetAccountTest.php
@@ -11,6 +11,7 @@ use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException
 use Source\Account\Account\Application\UseCase\Query\AccountReadModel;
 use Source\Account\Account\Application\UseCase\Query\GetAccount\GetAccountInput;
 use Source\Account\Account\Application\UseCase\Query\GetAccount\GetAccountInterface;
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Account\Infrastructure\Query\GetAccount;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
@@ -53,10 +54,12 @@ class GetAccountTest extends TestCase
         $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
         $policyEvaluator->shouldReceive('evaluate')
             ->once()
-            ->with($principal, Action::UPDATE, Mockery::type(Resource::class))
+            ->with($principal, Action::READ, Mockery::on(
+                static fn (Resource $resource): bool => $resource->accountType() === AccountType::CORPORATION
+            ))
             ->andReturnTrue();
 
-        $readModel = (new GetAccount($policyEvaluator))->process(new GetAccountInput($accountIdentifier, $principal));
+        $readModel = (new GetAccount($policyEvaluator))->process(new GetAccountInput($accountIdentifier, $principal, AccountType::CORPORATION));
 
         $this->assertInstanceOf(AccountReadModel::class, $readModel);
         $this->assertSame((string) $accountIdentifier, $readModel->accountIdentifier());
@@ -77,12 +80,14 @@ class GetAccountTest extends TestCase
         $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
         $policyEvaluator->shouldReceive('evaluate')
             ->once()
-            ->with($principal, Action::UPDATE, Mockery::type(Resource::class))
+            ->with($principal, Action::READ, Mockery::on(
+                static fn (Resource $resource): bool => $resource->accountType() === AccountType::CORPORATION
+            ))
             ->andReturnTrue();
 
         $this->expectException(AccountNotFoundException::class);
 
-        (new GetAccount($policyEvaluator))->process(new GetAccountInput($accountIdentifier, $principal));
+        (new GetAccount($policyEvaluator))->process(new GetAccountInput($accountIdentifier, $principal, AccountType::CORPORATION));
     }
 
     #[Group('useDb')]

--- a/tests/Account/Account/Infrastructure/Service/AccountDocumentFileTypeDetectorTest.php
+++ b/tests/Account/Account/Infrastructure/Service/AccountDocumentFileTypeDetectorTest.php
@@ -35,6 +35,8 @@ class AccountDocumentFileTypeDetectorTest extends TestCase
             'jpeg' => ["\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01\x01\x00\x48\x00\x48\x00\x00\xFF\xD9", AccountDocumentFileType::JPEG],
             'png' => ["\x89PNG\r\n\x1A\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xDE", AccountDocumentFileType::PNG],
             'webp' => ["RIFF\x1A\x00\x00\x00WEBPVP8 \x0E\x00\x00\x00\x10\x00\x00\x9D\x01\x2A\x01\x00\x01\x00", AccountDocumentFileType::WEBP],
+            'heic' => ["\x00\x00\x00\x18ftypheic\x00\x00\x00\x00heicmif1", AccountDocumentFileType::HEIC],
+            'heif' => ["\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00mif1heic", AccountDocumentFileType::HEIF],
         ];
     }
 }

--- a/tests/Account/Invitation/Application/UseCase/Command/InviteMember/InviteMemberTest.php
+++ b/tests/Account/Invitation/Application/UseCase/Command/InviteMember/InviteMemberTest.php
@@ -240,7 +240,8 @@ class InviteMemberTest extends TestCase
                     static fn (Principal $actual): bool => $actual === $principal
                 ),
                 Action::INVITE_MEMBER,
-                Mockery::on(static fn (Resource $resource) => (string) $resource->accountIdentifier() === (string) $accountIdentifier)
+                Mockery::on(static fn (Resource $resource): bool => (string) $resource->accountIdentifier() === (string) $accountIdentifier
+                    && $resource->accountType() === AccountType::CORPORATION)
             )
             ->andReturnTrue();
 
@@ -416,7 +417,8 @@ class InviteMemberTest extends TestCase
                     static fn (Principal $principal): bool => $principal === $data->principal
                 ),
                 Action::INVITE_MEMBER,
-                Mockery::on(static fn (Resource $resource) => (string) $resource->accountIdentifier() === (string) $data->accountIdentifier)
+                Mockery::on(static fn (Resource $resource): bool => (string) $resource->accountIdentifier() === (string) $data->accountIdentifier
+                    && $resource->accountType() === AccountType::CORPORATION)
             )
             ->andReturn($allowed);
 

--- a/tests/Account/Principal/Domain/ValueObject/ActionTest.php
+++ b/tests/Account/Principal/Domain/ValueObject/ActionTest.php
@@ -9,6 +9,11 @@ use Tests\TestCase;
 
 class ActionTest extends TestCase
 {
+    public function testReadValue(): void
+    {
+        $this->assertSame('account:read', Action::READ->value);
+    }
+
     public function testInviteMemberValue(): void
     {
         $this->assertSame('account:member:invite', Action::INVITE_MEMBER->value);

--- a/tests/Account/Principal/Domain/ValueObject/StatementTest.php
+++ b/tests/Account/Principal/Domain/ValueObject/StatementTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Account\Principal\Domain\ValueObject;
 
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Condition;
+use Source\Account\Principal\Domain\ValueObject\ConditionClause;
+use Source\Account\Principal\Domain\ValueObject\ConditionKey;
+use Source\Account\Principal\Domain\ValueObject\ConditionOperator;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Principal\Domain\ValueObject\ResourceType;
@@ -17,24 +22,34 @@ class StatementTest extends TestCase
 {
     public function testConstructAndAccessors(): void
     {
+        $condition = new Condition([
+            new ConditionClause(
+                ConditionKey::RESOURCE_ACCOUNT_TYPE,
+                ConditionOperator::EQUALS,
+                AccountType::CORPORATION->value,
+            ),
+        ]);
         $statement = new Statement(
             Effect::DENY,
-            [Action::DELETE],
+            [Action::UPDATE],
             [ResourceType::ACCOUNT],
+            $condition,
         );
 
         $this->assertSame(Effect::DENY, $statement->effect());
-        $this->assertSame([Action::DELETE], $statement->actions());
+        $this->assertSame([Action::UPDATE], $statement->actions());
         $this->assertSame([ResourceType::ACCOUNT], $statement->resourceTypes());
+        $this->assertSame($condition, $statement->condition());
     }
 
     public function testResourceFactoryCreatesResource(): void
     {
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
 
-        $resource = Resource::account($accountIdentifier);
+        $resource = Resource::account($accountIdentifier, AccountType::CORPORATION);
 
         $this->assertSame(ResourceType::ACCOUNT, $resource->type());
         $this->assertSame($accountIdentifier, $resource->accountIdentifier());
+        $this->assertSame(AccountType::CORPORATION, $resource->accountType());
     }
 }

--- a/tests/Account/Principal/Infrastructure/Repository/PolicyRepositoryTest.php
+++ b/tests/Account/Principal/Infrastructure/Repository/PolicyRepositoryTest.php
@@ -6,9 +6,14 @@ namespace Tests\Account\Principal\Infrastructure\Repository;
 
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Group;
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Policy;
 use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Condition;
+use Source\Account\Principal\Domain\ValueObject\ConditionClause;
+use Source\Account\Principal\Domain\ValueObject\ConditionKey;
+use Source\Account\Principal\Domain\ValueObject\ConditionOperator;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\PolicyIdentifier;
 use Source\Account\Principal\Domain\ValueObject\ResourceType;
@@ -36,6 +41,13 @@ class PolicyRepositoryTest extends TestCase
                 Effect::ALLOW,
                 [Action::INVITE_MEMBER],
                 [ResourceType::ACCOUNT],
+                new Condition([
+                    new ConditionClause(
+                        ConditionKey::RESOURCE_ACCOUNT_TYPE,
+                        ConditionOperator::EQUALS,
+                        AccountType::CORPORATION->value,
+                    ),
+                ]),
             )],
             true,
             new DateTimeImmutable(),
@@ -58,5 +70,10 @@ class PolicyRepositoryTest extends TestCase
         $this->assertSame(Effect::ALLOW, $foundPolicy->statements()[0]->effect());
         $this->assertSame(Action::INVITE_MEMBER, $foundPolicy->statements()[0]->actions()[0]);
         $this->assertSame(ResourceType::ACCOUNT, $foundPolicy->statements()[0]->resourceTypes()[0]);
+        $condition = $foundPolicy->statements()[0]->condition();
+        $this->assertNotNull($condition);
+        $this->assertSame(ConditionKey::RESOURCE_ACCOUNT_TYPE, $condition->clauses()[0]->key());
+        $this->assertSame(ConditionOperator::EQUALS, $condition->clauses()[0]->operator());
+        $this->assertSame(AccountType::CORPORATION->value, $condition->clauses()[0]->value());
     }
 }

--- a/tests/Account/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
+++ b/tests/Account/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
@@ -6,6 +6,7 @@ namespace Tests\Account\Principal\Infrastructure\Service;
 
 use DateTimeImmutable;
 use Mockery;
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Principal\Domain\Entity\Policy;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Entity\PrincipalGroup;
@@ -13,14 +14,18 @@ use Source\Account\Principal\Domain\Entity\Role;
 use Source\Account\Principal\Domain\Repository\PolicyRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
 use Source\Account\Principal\Domain\Repository\RoleRepositoryInterface;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Condition;
+use Source\Account\Principal\Domain\ValueObject\ConditionClause;
+use Source\Account\Principal\Domain\ValueObject\ConditionKey;
+use Source\Account\Principal\Domain\ValueObject\ConditionOperator;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\PolicyIdentifier;
 use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Principal\Domain\ValueObject\ResourceType;
 use Source\Account\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Account\Principal\Domain\ValueObject\Statement;
-use Source\Account\Principal\Infrastructure\Service\PolicyEvaluator;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
@@ -61,7 +66,7 @@ class PolicyEvaluatorTest extends TestCase
                 (string) $roleIdentifier => new Role($roleIdentifier, Role::OWNER, [$policy->policyIdentifier()], true),
             ]);
 
-        $evaluator = new PolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository);
+        $evaluator = $this->makePolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository);
 
         $this->assertTrue($evaluator->evaluate(
             $principal,
@@ -90,7 +95,7 @@ class PolicyEvaluatorTest extends TestCase
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
         $roleRepository->shouldNotReceive('findByIds');
 
-        $evaluator = new PolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository);
+        $evaluator = $this->makePolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository);
 
         $this->assertFalse($evaluator->evaluate(
             $principal,
@@ -139,7 +144,7 @@ class PolicyEvaluatorTest extends TestCase
                 ),
             ]);
 
-        $evaluator = new PolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository);
+        $evaluator = $this->makePolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository);
 
         $this->assertFalse($evaluator->evaluate(
             $principal,
@@ -148,18 +153,103 @@ class PolicyEvaluatorTest extends TestCase
         ));
     }
 
+    public function testEvaluateAllowsWhenConditionMatchesResourceAccountType(): void
+    {
+        $this->assertSame(
+            true,
+            $this->evaluateInvitationWithAccountTypeCondition(AccountType::CORPORATION)
+        );
+    }
+
+    public function testEvaluateDeniesWhenConditionDoesNotMatchResourceAccountType(): void
+    {
+        $this->assertSame(
+            false,
+            $this->evaluateInvitationWithAccountTypeCondition(AccountType::INDIVIDUAL)
+        );
+    }
+
+    public function testEvaluateDeniesWhenConditionRequiresAccountTypeButResourceDoesNotHaveIt(): void
+    {
+        $this->assertSame(
+            false,
+            $this->evaluateInvitationWithAccountTypeCondition(null)
+        );
+    }
+
     /**
      * @param Action[] $actions
      */
-    private function createPolicy(string $name, Effect $effect, array $actions): Policy
+    private function createPolicy(string $name, Effect $effect, array $actions, ?Condition $condition = null): Policy
     {
         return new Policy(
             new PolicyIdentifier(StrTestHelper::generateUuid()),
             $name,
-            [new Statement($effect, $actions, [ResourceType::ACCOUNT])],
+            [new Statement($effect, $actions, [ResourceType::ACCOUNT], $condition)],
             true,
             new DateTimeImmutable(),
         );
+    }
+
+    private function evaluateInvitationWithAccountTypeCondition(?AccountType $accountType): bool
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principal = $this->createPrincipal($accountIdentifier);
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        $principalGroup = $this->createPrincipalGroup($accountIdentifier, $principal->principalIdentifier(), $roleIdentifier);
+        $policy = $this->createPolicy(
+            'CORPORATE_INVITATION',
+            Effect::ALLOW,
+            [Action::INVITE_MEMBER],
+            new Condition([
+                new ConditionClause(
+                    ConditionKey::RESOURCE_ACCOUNT_TYPE,
+                    ConditionOperator::EQUALS,
+                    AccountType::CORPORATION->value,
+                ),
+            ]),
+        );
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountIdAndPrincipal')
+            ->once()
+            ->with($accountIdentifier, $principal->principalIdentifier())
+            ->andReturn([$principalGroup]);
+
+        /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findByIds')
+            ->once()
+            ->with([$policy->policyIdentifier()])
+            ->andReturn([(string) $policy->policyIdentifier() => $policy]);
+
+        /** @var RoleRepositoryInterface&\Mockery\MockInterface $roleRepository */
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findByIds')
+            ->once()
+            ->with([$roleIdentifier])
+            ->andReturn([
+                (string) $roleIdentifier => new Role($roleIdentifier, Role::OWNER, [$policy->policyIdentifier()], true),
+            ]);
+
+        return $this->makePolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository)->evaluate(
+            $principal,
+            Action::INVITE_MEMBER,
+            Resource::account($accountIdentifier, $accountType),
+        );
+    }
+
+    private function makePolicyEvaluator(
+        PrincipalGroupRepositoryInterface $principalGroupRepository,
+        RoleRepositoryInterface $roleRepository,
+        PolicyRepositoryInterface $policyRepository,
+    ): PolicyEvaluatorInterface {
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
+        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(PolicyRepositoryInterface::class, $policyRepository);
+
+        return $this->app->make(PolicyEvaluatorInterface::class);
     }
 
     private function createPrincipal(AccountIdentifier $accountIdentifier): Principal

--- a/tests/Database/Seeders/AccountAuthorizationSeederTest.php
+++ b/tests/Database/Seeders/AccountAuthorizationSeederTest.php
@@ -38,10 +38,16 @@ class AccountAuthorizationSeederTest extends TestCase
         $ownerPolicies = $policyRepository->findByIds($ownerRole->policies());
         $adminPolicies = $policyRepository->findByIds($adminRole->policies());
 
+        $this->assertTrue($this->hasAction($ownerPolicies, Action::READ));
         $this->assertTrue($this->hasAction($ownerPolicies, Action::INVITE_MEMBER));
         $this->assertTrue($this->hasAction($ownerPolicies, Action::UPDATE));
+        $this->assertTrue($this->hasAction($adminPolicies, Action::READ));
         $this->assertTrue($this->hasAction($adminPolicies, Action::INVITE_MEMBER));
         $this->assertTrue($this->hasAction($adminPolicies, Action::UPDATE));
+        $this->assertFalse($this->hasCondition($ownerPolicies, Action::READ));
+        $this->assertFalse($this->hasCondition($adminPolicies, Action::READ));
+        $this->assertTrue($this->hasCondition($ownerPolicies, Action::UPDATE));
+        $this->assertTrue($this->hasCondition($adminPolicies, Action::UPDATE));
     }
 
     /**
@@ -56,6 +62,26 @@ class AccountAuthorizationSeederTest extends TestCase
                 }
 
                 if (in_array($action, $statement->actions(), true)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<\Source\Account\Principal\Domain\Entity\Policy> $policies
+     */
+    private function hasCondition(array $policies, Action $action): bool
+    {
+        foreach ($policies as $policy) {
+            foreach ($policy->statements() as $statement) {
+                if (! in_array($action, $statement->actions(), true)) {
+                    continue;
+                }
+
+                if ($statement->condition() !== null) {
                     return true;
                 }
             }

--- a/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
+++ b/tests/Identity/Application/UseCase/Query/AuthenticatedIdentityReadModelTest.php
@@ -18,6 +18,7 @@ class AuthenticatedIdentityReadModelTest extends TestCase
             language: 'ja',
             profileImage: '/storage/profile/test.png',
             accountIdentifier: '019de7f3-78f3-7b55-9ed5-17f63e14d5aa',
+            accountPrincipalIdentifier: '019de7f3-78f3-7b55-9ed5-17f63e14d5cc',
             accountType: 'corporation',
             accountPolicies: [
                 [
@@ -35,6 +36,7 @@ class AuthenticatedIdentityReadModelTest extends TestCase
         $this->assertSame('ja', $readModel->language());
         $this->assertSame('/storage/profile/test.png', $readModel->profileImage());
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5aa', $readModel->accountIdentifier());
+        $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5cc', $readModel->accountPrincipalIdentifier());
         $this->assertSame('corporation', $readModel->accountType());
         $this->assertSame([
             [
@@ -51,6 +53,7 @@ class AuthenticatedIdentityReadModelTest extends TestCase
             'language' => 'ja',
             'profileImage' => '/storage/profile/test.png',
             'accountIdentifier' => '019de7f3-78f3-7b55-9ed5-17f63e14d5aa',
+            'accountPrincipalIdentifier' => '019de7f3-78f3-7b55-9ed5-17f63e14d5cc',
             'accountType' => 'corporation',
             'accountPolicies' => [
                 [

--- a/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
+++ b/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
@@ -70,10 +70,23 @@ class GetAuthenticatedIdentityTest extends TestCase
         $this->assertSame('ja', $readModel->language());
         $this->assertSame('http://127.0.0.1:8080/storage/profile/test.png', $readModel->profileImage());
         $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5aa', $readModel->accountIdentifier());
+        $this->assertSame('019de7f3-78f3-7b55-9ed5-17f63e14d5cc', $readModel->accountPrincipalIdentifier());
         $this->assertSame('corporation', $readModel->accountType());
         $this->assertCount(1, $readModel->accountPolicies());
         $this->assertSame('ACCOUNT_OWNER_BASIC', $readModel->accountPolicies()[0]['name']);
-        $this->assertSame('account:update', $readModel->accountPolicies()[0]['statements'][0]['actions'][1]);
+        $actions = array_merge(...array_column($readModel->accountPolicies()[0]['statements'], 'actions'));
+        $this->assertContains('account:read', $actions);
+        $this->assertContains('account:update', $actions);
+        $inviteStatement = $this->statementForAction($readModel->accountPolicies()[0]['statements'], 'account:member:invite');
+        $this->assertSame([
+            'clauses' => [
+                [
+                    'field' => 'resource:accountType',
+                    'operator' => 'eq',
+                    'value' => 'corporation',
+                ],
+            ],
+        ], $inviteStatement['condition']);
     }
 
     #[Group('useDb')]
@@ -99,6 +112,7 @@ class GetAuthenticatedIdentityTest extends TestCase
         $this->assertSame('ja', $readModel->language());
         $this->assertNull($readModel->profileImage());
         $this->assertNull($readModel->accountIdentifier());
+        $this->assertNull($readModel->accountPrincipalIdentifier());
         $this->assertNull($readModel->accountType());
         $this->assertSame([], $readModel->accountPolicies());
     }
@@ -113,5 +127,20 @@ class GetAuthenticatedIdentityTest extends TestCase
         $useCase->process(new GetAuthenticatedIdentityInput(
             new IdentityIdentifier('019de7f3-78f3-7b55-9ed5-17f63e14d5ff'),
         ));
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $statements
+     * @return array<string, mixed>
+     */
+    private function statementForAction(array $statements, string $action): array
+    {
+        foreach ($statements as $statement) {
+            if (in_array($action, $statement['actions'], true)) {
+                return $statement;
+            }
+        }
+
+        $this->fail("Statement for action {$action} was not found.");
     }
 }

--- a/typespec/services/identity-api.tsp
+++ b/typespec/services/identity-api.tsp
@@ -19,6 +19,22 @@ model IdentitySummary {
   profileImage?: string | null;
 }
 
+@doc("Single condition clause in an account policy.")
+model AccountPolicyConditionClause {
+  @doc("Field name to evaluate.")
+  field: string;
+  @doc("Operator used for the comparison.")
+  operator: string;
+  @doc("Value to compare against.")
+  value: string | boolean;
+}
+
+@doc("Conditional constraints for an account policy statement.")
+model AccountPolicyCondition {
+  @doc("List of condition clauses.")
+  clauses?: AccountPolicyConditionClause[];
+}
+
 @doc("Policy statement returned for account effective policies.")
 model AccountPolicyStatement {
   @doc("Whether the statement allows or denies the action.")
@@ -27,6 +43,8 @@ model AccountPolicyStatement {
   actions: string[];
   @doc("Resource types covered by this statement.")
   resourceTypes: string[];
+  @doc("Optional condition attached to the statement.")
+  condition?: AccountPolicyCondition | null;
 }
 
 @doc("Effective account policy summary for the authenticated identity.")
@@ -45,6 +63,8 @@ model AccountEffectivePolicySummary {
 model AuthenticatedIdentitySummary extends IdentitySummary {
   @doc("Account identifier associated with the authenticated identity.")
   accountIdentifier: Uuid | null;
+  @doc("Account principal identifier associated with the authenticated identity in the current account.")
+  accountPrincipalIdentifier: Uuid | null;
   @doc("Account type associated with the authenticated identity.")
   accountType: string | null;
   @doc("Effective policies for the authenticated identity in the current account.")


### PR DESCRIPTION
## 📝 変更内容

- Account 認可ポリシーに condition を追加し、`resource:accountType` で法人向け権限を判定できるようにしました。
- `/auth/me` に Account principal identifier / account type / account policies を返すようにし、フロント側が Account 文脈で権限判定できるようにしました。
- `account:update`、`account:member:invite`、`account:principal-group:manage` を法人アカウント条件付きにし、個人アカウントではアカウント更新・招待・権限管理ができないようにしました。
- `account:read` を追加し、`GET /accounts/{accountId}` は更新権限ではなく読み取り権限で取得できるようにしました。
- 自分の Account 書類を認証付きで表示する route を追加しました。
- Account 書類アップロードで `image/heic` / `image/heif` を許可し、HEIC/HEIF の file brand を検出できるようにしました。
- TypeSpec / OpenAPI と関連テストを更新しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] ⚡ パフォーマンス (Performance)
- [x] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Account 設定画面で Wiki principal を使った権限判定や、`GET /accounts/{accountId}` が `account:update` に依存していたことで、個人アカウントの書類アップロード導線が不要にブロックされていました。

また、iPhone / Android の撮影画像で使われることがある HEIC/HEIF を書類アップロード全体で受け付ける必要があったため、バックエンド側の最終判定にも対応を追加しました。

## 🧪 テスト

### テストの実行確認

- [x] `task test -- tests/Account/Account/Infrastructure/Service/AccountDocumentFileTypeDetectorTest.php`
  - 実際は Taskfile の挙動により全件実行
  - `OK (2986 tests, 9561 assertions)`
- [ ] `task phpstan`
  - PHPStan parallel worker が PHP memory limit 512M に到達して失敗
  - ファイル単位の診断ではなくメモリ不足エラー

## 🔍 レビューのポイント

- `account:update` は法人プロフィール更新の権限として維持し、読み取りだけ `account:read` に分離しています。
- `account:member:invite` / `account:principal-group:manage` / `account:update` は seed 上も法人条件付きです。
- condition の永続化、復元、評価で `resource:accountType` が意図通り評価されるか確認してください。
- HEIC/HEIF は MIME 判定に加えて `ftyp` brand fallback で検出しています。
- 自分の Account 書類表示 route は、同一 Account principal の認証付きアクセス前提です。

## 📖 関連情報

### 関連Issue・タスク

Relates to kpool09122/kpool-frontend#233

## ⚠️ 注意事項

- `task phpstan` は 512M メモリ上限で失敗しています。差分起因の型エラーではなく、PHPStan worker のメモリ不足です。
- 既存 seed の権限が変わるため、権限確認は migrate-fresh 後の seed 状態で確認してください。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
