### PR TITLE
アカウント種別変更リクエスト承認APIを追加

### DIFF
--- a/application/Http/Action/Account/Account/AccountTypeChangeRequest/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestAction.php
+++ b/application/Http/Action/Account/Account/AccountTypeChangeRequest/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Account\AccountTypeChangeRequest\Command\ApproveAccountTypeChangeRequest;
+
+use Application\Http\Context\AccountContext;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\NotFoundHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Application\Exception\AccountTypeChangeRequestForbiddenException;
+use Source\Account\Account\Application\Exception\AccountTypeChangeRequestNotFoundException;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestInput;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestInterface;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestOutput;
+use Source\Account\Account\Domain\Exception\InvalidAccountTypeChangeRequestApprovalException;
+use Source\Account\Account\Domain\ValueObject\AccountTypeChangeRequestIdentifier;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ApproveAccountTypeChangeRequestAction
+{
+    public function __construct(private ApproveAccountTypeChangeRequestInterface $useCase, private AccountContext $accountContext, private LoggerInterface $logger)
+    {
+    }
+
+    public function __invoke(ApproveAccountTypeChangeRequestRequest $request): JsonResponse
+    {
+        try {
+            $language = $request->language();
+
+            try {
+                $input = new ApproveAccountTypeChangeRequestInput(new AccountTypeChangeRequestIdentifier($request->requestId()), $this->accountContext->principal());
+                $output = new ApproveAccountTypeChangeRequestOutput();
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            DB::beginTransaction();
+
+            try {
+                $this->useCase->process($input, $output);
+                DB::commit();
+            } catch (AccountTypeChangeRequestNotFoundException|AccountNotFoundException $e) {
+                DB::rollBack();
+
+                throw new NotFoundHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (AccountTypeChangeRequestForbiddenException $e) {
+                DB::rollBack();
+
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            } catch (InvalidAccountTypeChangeRequestApprovalException $e) {
+                DB::rollBack();
+
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            } catch (Throwable $e) {
+                DB::rollBack();
+
+                throw $e;
+            }
+        } catch (ForbiddenHttpException|UnprocessableEntityHttpException|NotFoundHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/Account/AccountTypeChangeRequest/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestRequest.php
+++ b/application/Http/Action/Account/Account/AccountTypeChangeRequest/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Account\AccountTypeChangeRequest\Command\ApproveAccountTypeChangeRequest;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveAccountTypeChangeRequestRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function requestId(): string
+    {
+        return (string) $this->route('requestId');
+    }
+}

--- a/application/Providers/Account/UseCaseServiceProvider.php
+++ b/application/Providers/Account/UseCaseServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Application\Providers\Account;
 
 use Illuminate\Support\ServiceProvider;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequest;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestInterface;
 use Source\Account\Account\Application\UseCase\Command\ApproveVerification\ApproveVerification;
 use Source\Account\Account\Application\UseCase\Command\ApproveVerification\ApproveVerificationInterface;
 use Source\Account\Account\Application\UseCase\Command\CreateAccount\CreateAccount;
@@ -91,6 +93,7 @@ class UseCaseServiceProvider extends ServiceProvider
         // AccountVerification
         $this->app->singleton(RequestVerificationInterface::class, RequestVerification::class);
         $this->app->singleton(RequestAccountTypeChangeInterface::class, RequestAccountTypeChange::class);
+        $this->app->singleton(ApproveAccountTypeChangeRequestInterface::class, ApproveAccountTypeChangeRequest::class);
         $this->app->singleton(ApproveVerificationInterface::class, ApproveVerification::class);
         $this->app->singleton(RejectVerificationInterface::class, RejectVerification::class);
 

--- a/database/seeders/AccountAuthorizationSeeder.php
+++ b/database/seeders/AccountAuthorizationSeeder.php
@@ -100,8 +100,19 @@ class AccountAuthorizationSeeder extends Seeder
             ),
         ]);
 
+        $operationsPolicy = $this->createPolicy('01982020-0456-7000-8000-000000000003', 'ACCOUNT_TYPE_CHANGE_REQUEST_APPROVAL', [
+            new Statement(
+                effect: Effect::ALLOW,
+                actions: [
+                    Action::ACCOUNT_TYPE_CHANGE_REQUEST_APPROVE,
+                ],
+                resourceTypes: [ResourceType::ACCOUNT],
+            ),
+        ]);
+
         $this->saveRole(Role::OWNER, [$ownerPolicy->policyIdentifier()]);
         $this->saveRole(Role::ADMIN, [$adminPolicy->policyIdentifier()]);
+        $this->saveRole(Role::OPERATIONS, [$operationsPolicy->policyIdentifier()]);
     }
 
     private function corporationAccountCondition(): Condition

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,7 +14,8 @@ class DatabaseSeeder extends Seeder
             SystemPolicySeeder::class,
             SystemRoleSeeder::class,
             AccountAuthorizationSeeder::class,
-            FullAccessTestAccountSeeder::class,
+            TestAccountSeeder::class,
+            OperationsAccountSeeder::class,
             WikiEditorSampleSeeder::class,
         ]);
     }

--- a/database/seeders/OperationsAccountSeeder.php
+++ b/database/seeders/OperationsAccountSeeder.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Application\Http\Context\AuthContextCache;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use RuntimeException;
+use Source\Account\Principal\Domain\Entity\Role;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+
+class OperationsAccountSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (! app()->environment(['local', 'testing'])) {
+            return;
+        }
+
+        $operationsRoleId = DB::table('account_roles')->where('name', Role::OPERATIONS)->value('id');
+        if (! is_string($operationsRoleId)) {
+            throw new RuntimeException('Operations account role not found. Please run AccountAuthorizationSeeder first.');
+        }
+
+        $administratorRoleId = DB::table('roles')->where('name', 'ADMINISTRATOR')->value('id');
+        if (! is_string($administratorRoleId)) {
+            throw new RuntimeException('ADMINISTRATOR role not found. Please run SystemRoleSeeder first.');
+        }
+
+        $now = now();
+        $accountId = '01965bb2-bcc9-7c6f-8b90-89f7f217fb01';
+        $identityId = '01965bb2-bcc9-7c6f-8b90-89f7f217fb02';
+        $principalId = '01965bb2-bcc9-7c6f-8b90-89f7f217fb03';
+        $accountPrincipalGroupId = '01965bb2-bcc9-7c6f-8b90-89f7f217fb04';
+        $accountMembershipId = '01965bb2-bcc9-7c6f-8b90-89f7f217fb05';
+        $wikiDefaultPrincipalGroupId = '01965bb2-bcc9-7c6f-8b90-89f7f217fb06';
+        $wikiPrincipalGroupId = '01965bb2-bcc9-7c6f-8b90-89f7f217fb07';
+
+        DB::table('accounts')->upsert([[
+            'id' => $accountId,
+            'email' => 'operations@example.com',
+            'type' => 'corporation',
+            'name' => 'Operations Account',
+            'status' => 'active',
+            'category' => 'general',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]], ['id']);
+
+        DB::table('identities')->upsert([[
+            'id' => $identityId,
+            'identity_name' => 'operations',
+            'email' => 'operations@example.com',
+            'language' => 'ja',
+            'profile_image' => null,
+            'password' => Hash::make('password'),
+            'email_verified_at' => $now,
+            'delegation_identifier' => null,
+            'original_identity_identifier' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]], ['id']);
+
+        DB::table('account_principals')->upsert([[
+            'id' => $principalId,
+            'identity_id' => $identityId,
+            'account_id' => $accountId,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]], ['id']);
+
+        DB::table('account_principal_groups')->upsert([[
+            'id' => $accountPrincipalGroupId,
+            'account_id' => $accountId,
+            'name' => 'Operations',
+            'is_default' => false,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]], ['id']);
+
+        DB::table('account_principal_group_memberships')->upsert([[
+            'id' => $accountMembershipId,
+            'principal_group_id' => $accountPrincipalGroupId,
+            'principal_id' => $principalId,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]], ['principal_group_id', 'principal_id']);
+
+        DB::table('account_principal_group_role_attachments')->upsert([[
+            'principal_group_id' => $accountPrincipalGroupId,
+            'role_id' => $operationsRoleId,
+        ]], ['principal_group_id', 'role_id']);
+
+        DB::table('wiki_principals')->upsert([[
+            'id' => $principalId,
+            'identity_id' => $identityId,
+            'agency_id' => null,
+            'group_ids' => json_encode([], JSON_THROW_ON_ERROR),
+            'talent_ids' => json_encode([], JSON_THROW_ON_ERROR),
+            'delegation_identifier' => null,
+            'enabled' => true,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]], ['id']);
+
+        DB::table('principal_groups')->upsert([
+            [
+                'id' => $wikiDefaultPrincipalGroupId,
+                'account_id' => $accountId,
+                'name' => 'Default',
+                'is_default' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'id' => $wikiPrincipalGroupId,
+                'account_id' => $accountId,
+                'name' => 'Operations Wiki Administrators',
+                'is_default' => false,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['id']);
+
+        DB::table('principal_group_memberships')->upsert([[
+            'principal_group_id' => $wikiPrincipalGroupId,
+            'principal_id' => $principalId,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]], ['principal_group_id', 'principal_id']);
+
+        DB::table('principal_group_role_attachments')->upsert([[
+            'principal_group_id' => $wikiPrincipalGroupId,
+            'role_id' => $administratorRoleId,
+        ]], ['principal_group_id', 'role_id']);
+
+        $authContextCache = app(AuthContextCache::class);
+        $identityIdentifier = new IdentityIdentifier($identityId);
+        $authContextCache->forgetAccount($identityIdentifier);
+        $authContextCache->forgetWiki($identityIdentifier);
+    }
+}

--- a/database/seeders/TestAccountSeeder.php
+++ b/database/seeders/TestAccountSeeder.php
@@ -13,7 +13,7 @@ use RuntimeException;
 use Source\Account\Principal\Domain\Entity\Role;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 
-class FullAccessTestAccountSeeder extends Seeder
+class TestAccountSeeder extends Seeder
 {
     private const array ACCOUNTS = [
         [
@@ -25,9 +25,9 @@ class FullAccessTestAccountSeeder extends Seeder
             'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0b',
             'accountOwnerPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa05',
             'email' => 'test@example.com',
-            'identityName' => 'full-access-test',
-            'accountName' => 'Full Access Test Account',
-            'wikiPrincipalGroupName' => 'Full Access Test Group',
+            'identityName' => 'test-account',
+            'accountName' => 'Test Account',
+            'wikiPrincipalGroupName' => 'Test Account Group',
             'accountType' => 'individual',
         ],
         [
@@ -39,9 +39,9 @@ class FullAccessTestAccountSeeder extends Seeder
             'wikiDefaultPrincipalGroupId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0c',
             'accountOwnerPrincipalGroupMembershipId' => '01965bb2-bcc9-7c6f-8b90-89f7f217fa0a',
             'email' => 'corp@example.com',
-            'identityName' => 'corp-full-access-test',
-            'accountName' => 'Corporate Full Access Test Account',
-            'wikiPrincipalGroupName' => 'Corporate Full Access Test Group',
+            'identityName' => 'corp-test-account',
+            'accountName' => 'Corporate Test Account',
+            'wikiPrincipalGroupName' => 'Corporate Test Account Group',
             'accountType' => 'corporation',
         ],
     ];
@@ -50,14 +50,6 @@ class FullAccessTestAccountSeeder extends Seeder
     {
         if (! app()->environment(['local', 'testing'])) {
             return;
-        }
-
-        $administratorRoleId = DB::table('roles')
-            ->where('name', 'ADMINISTRATOR')
-            ->value('id');
-
-        if (! is_string($administratorRoleId)) {
-            throw new RuntimeException('ADMINISTRATOR role not found. Please run SystemRoleSeeder first.');
         }
 
         $collaboratorRoleId = DB::table('roles')
@@ -79,7 +71,7 @@ class FullAccessTestAccountSeeder extends Seeder
         $now = now();
 
         foreach (self::ACCOUNTS as $account) {
-            $this->createFullAccessAccount($account, $administratorRoleId, $collaboratorRoleId, $ownerRoleId, $now);
+            $this->createTestAccount($account, $collaboratorRoleId, $ownerRoleId, $now);
         }
     }
 
@@ -99,9 +91,8 @@ class FullAccessTestAccountSeeder extends Seeder
      *     accountType: string
      * } $account
      */
-    private function createFullAccessAccount(
+    private function createTestAccount(
         array $account,
-        string $administratorRoleId,
         string $collaboratorRoleId,
         string $ownerRoleId,
         Carbon $now,
@@ -237,10 +228,6 @@ class FullAccessTestAccountSeeder extends Seeder
             [
                 'principal_group_id' => $account['wikiDefaultPrincipalGroupId'],
                 'role_id' => $collaboratorRoleId,
-            ],
-            [
-                'principal_group_id' => $account['principalGroupId'],
-                'role_id' => $administratorRoleId,
             ],
         ], ['principal_group_id', 'role_id']);
 

--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -52,6 +52,53 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RequestAccountTypeChangeRequestBody'
+  /account-type-change-requests/{requestId}/approve:
+    post:
+      operationId: AccountTypeChangeRequestOperations_approveAccountTypeChangeRequest
+      description: Approve account type change request.
+      parameters:
+        - name: requestId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+      responses:
+        '200':
+          description: Response returned when an account type change request is approved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountTypeChangeRequestSummary'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /account-verifications:
     post:
       operationId: AccountVerificationOperations_requestVerification

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -12,6 +12,7 @@ use Application\Http\Action\Account\Account\Query\ViewMyAccountDocument\ViewMyAc
 use Application\Http\Action\Account\Account\AccountVerification\Command\ApproveVerification\ApproveVerificationAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\RejectVerification\RejectVerificationAction;
 use Application\Http\Action\Account\Account\AccountVerification\Command\RequestVerification\RequestVerificationAction;
+use Application\Http\Action\Account\Account\AccountTypeChangeRequest\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestAction;
 use Application\Http\Action\Account\Account\AccountTypeChangeRequest\Command\RequestAccountTypeChange\RequestAccountTypeChangeAction;
 use Application\Http\Action\Account\Member\Query\ListMembers\ListMembersAction;
 use Application\Http\Action\Account\Affiliation\Command\ApproveAffiliation\ApproveAffiliationAction;
@@ -74,6 +75,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.account'])->group(funct
 
     // AccountTypeChangeRequest
     Route::post('/account-type-change-requests', RequestAccountTypeChangeAction::class);
+    Route::post('/account-type-change-requests/{requestId}/approve', ApproveAccountTypeChangeRequestAction::class);
 
     // Affiliation
     Route::post('/affiliations', RequestAffiliationAction::class);

--- a/src/Account/Account/Application/Exception/AccountTypeChangeRequestNotFoundException.php
+++ b/src/Account/Account/Application/Exception/AccountTypeChangeRequestNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\Exception;
+
+use RuntimeException;
+
+class AccountTypeChangeRequestNotFoundException extends RuntimeException
+{
+    public function __construct(string $message = 'Account type change request not found.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequest.php
+++ b/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest;
+
+use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Application\Exception\AccountTypeChangeRequestForbiddenException;
+use Source\Account\Account\Application\Exception\AccountTypeChangeRequestNotFoundException;
+use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
+use Source\Account\Account\Domain\Repository\AccountTypeChangeRequestRepositoryInterface;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+
+readonly class ApproveAccountTypeChangeRequest implements ApproveAccountTypeChangeRequestInterface
+{
+    public function __construct(
+        private AccountTypeChangeRequestRepositoryInterface $requestRepository,
+        private AccountRepositoryInterface $accountRepository,
+        private PolicyEvaluatorInterface $policyEvaluator,
+    ) {
+    }
+
+    public function process(ApproveAccountTypeChangeRequestInputPort $input, ApproveAccountTypeChangeRequestOutputPort $output): void
+    {
+        $request = $this->requestRepository->findById($input->requestIdentifier());
+        if ($request === null) {
+            throw new AccountTypeChangeRequestNotFoundException();
+        }
+
+        $reviewerAccountIdentifier = $input->principal()->accountIdentifier();
+        if (! $this->policyEvaluator->evaluate(
+            $input->principal(),
+            Action::ACCOUNT_TYPE_CHANGE_REQUEST_APPROVE,
+            Resource::account($reviewerAccountIdentifier),
+        )) {
+            throw new AccountTypeChangeRequestForbiddenException();
+        }
+
+        $account = $this->accountRepository->findById($request->accountIdentifier());
+        if ($account === null) {
+            throw new AccountNotFoundException();
+        }
+
+        $request->approve($reviewerAccountIdentifier);
+        $account->changeType($request->requestedAccountType());
+
+        $this->accountRepository->save($account);
+        $this->requestRepository->save($request);
+
+        $output->setRequest($request);
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestInput.php
+++ b/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestInput.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest;
+
+use Source\Account\Account\Domain\ValueObject\AccountTypeChangeRequestIdentifier;
+use Source\Account\Principal\Domain\Entity\Principal;
+
+readonly class ApproveAccountTypeChangeRequestInput implements ApproveAccountTypeChangeRequestInputPort
+{
+    public function __construct(private AccountTypeChangeRequestIdentifier $requestIdentifier, private Principal $principal)
+    {
+    }
+
+    public function requestIdentifier(): AccountTypeChangeRequestIdentifier
+    {
+        return $this->requestIdentifier;
+    }
+
+    public function principal(): Principal
+    {
+        return $this->principal;
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestInputPort.php
+++ b/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestInputPort.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest;
+
+use Source\Account\Account\Domain\ValueObject\AccountTypeChangeRequestIdentifier;
+use Source\Account\Principal\Domain\Entity\Principal;
+
+interface ApproveAccountTypeChangeRequestInputPort
+{
+    public function requestIdentifier(): AccountTypeChangeRequestIdentifier;
+
+    public function principal(): Principal;
+}

--- a/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestInterface.php
+++ b/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest;
+
+interface ApproveAccountTypeChangeRequestInterface
+{
+    public function process(ApproveAccountTypeChangeRequestInputPort $input, ApproveAccountTypeChangeRequestOutputPort $output): void;
+}

--- a/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestOutput.php
+++ b/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestOutput.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest;
+
+use DateTimeInterface;
+use Source\Account\Account\Domain\Entity\AccountTypeChangeRequest;
+
+class ApproveAccountTypeChangeRequestOutput implements ApproveAccountTypeChangeRequestOutputPort
+{
+    private ?AccountTypeChangeRequest $request = null;
+
+    public function setRequest(AccountTypeChangeRequest $request): void
+    {
+        $this->request = $request;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        if ($this->request === null) {
+            return [];
+        }
+        $request = $this->request;
+
+        return [
+            'requestIdentifier' => (string) $request->requestIdentifier(),
+            'accountIdentifier' => (string) $request->accountIdentifier(),
+            'currentAccountType' => $request->currentAccountType()->value,
+            'requestedAccountType' => $request->requestedAccountType()->value,
+            'status' => $request->status()->value,
+            'requestedAt' => $request->requestedAt()->format(DateTimeInterface::ATOM),
+            'reviewedBy' => $request->reviewedBy() !== null ? (string) $request->reviewedBy() : null,
+            'reviewedAt' => $request->reviewedAt()?->format(DateTimeInterface::ATOM),
+            'rejectionReason' => $request->rejectionReason() !== null ? [
+                'code' => $request->rejectionReason()->code()->value,
+                'detail' => $request->rejectionReason()->detail(),
+            ] : null,
+        ];
+    }
+}

--- a/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestOutputPort.php
+++ b/src/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestOutputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest;
+
+use Source\Account\Account\Domain\Entity\AccountTypeChangeRequest;
+
+interface ApproveAccountTypeChangeRequestOutputPort
+{
+    public function setRequest(AccountTypeChangeRequest $request): void;
+}

--- a/src/Account/Account/Domain/Entity/Account.php
+++ b/src/Account/Account/Domain/Entity/Account.php
@@ -20,7 +20,7 @@ class Account
     public function __construct(
         private readonly AccountIdentifier $accountIdentifier,
         private readonly Email $email,
-        private readonly AccountType $type,
+        private AccountType $type,
         private AccountName $name,
         private readonly AccountStatus $status,
         private AccountCategory $accountCategory,
@@ -42,6 +42,11 @@ class Account
     public function type(): AccountType
     {
         return $this->type;
+    }
+
+    public function changeType(AccountType $type): void
+    {
+        $this->type = $type;
     }
 
     public function name(): AccountName

--- a/src/Account/Principal/Domain/Entity/Role.php
+++ b/src/Account/Principal/Domain/Entity/Role.php
@@ -11,6 +11,7 @@ class Role
 {
     public const string OWNER = 'Owner';
     public const string ADMIN = 'Admin';
+    public const string OPERATIONS = 'Operations';
 
     /**
      * @param PolicyIdentifier[] $policies

--- a/src/Account/Principal/Domain/ValueObject/Action.php
+++ b/src/Account/Principal/Domain/ValueObject/Action.php
@@ -10,4 +10,5 @@ enum Action: string
     case INVITE_MEMBER = 'account:member:invite';
     case UPDATE = 'account:update';
     case PRINCIPAL_GROUP_MANAGE = 'account:principal-group:manage';
+    case ACCOUNT_TYPE_CHANGE_REQUEST_APPROVE = 'account:type-change-request:approve';
 }

--- a/tests/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/ApproveAccountTypeChangeRequest/ApproveAccountTypeChangeRequestTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest;
+
+use DateTimeImmutable;
+use Mockery;
+use Source\Account\Account\Application\Exception\AccountTypeChangeRequestForbiddenException;
+use Source\Account\Account\Application\Exception\AccountTypeChangeRequestNotFoundException;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequest;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestInput;
+use Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestOutput;
+use Source\Account\Account\Domain\Entity\Account;
+use Source\Account\Account\Domain\Entity\AccountTypeChangeRequest;
+use Source\Account\Account\Domain\Exception\InvalidAccountTypeChangeRequestApprovalException;
+use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
+use Source\Account\Account\Domain\Repository\AccountTypeChangeRequestRepositoryInterface;
+use Source\Account\Account\Domain\ValueObject\AccountDocuments;
+use Source\Account\Account\Domain\ValueObject\AccountName;
+use Source\Account\Account\Domain\ValueObject\AccountStatus;
+use Source\Account\Account\Domain\ValueObject\AccountType;
+use Source\Account\Account\Domain\ValueObject\AccountTypeChangeRequestIdentifier;
+use Source\Account\Account\Domain\ValueObject\AccountTypeChangeRequestStatus;
+use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ApproveAccountTypeChangeRequestTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $this->app->instance(AccountTypeChangeRequestRepositoryInterface::class, Mockery::mock(AccountTypeChangeRequestRepositoryInterface::class));
+        $this->app->instance(AccountRepositoryInterface::class, Mockery::mock(AccountRepositoryInterface::class));
+        $this->app->instance(PolicyEvaluatorInterface::class, Mockery::mock(PolicyEvaluatorInterface::class));
+
+        $this->assertInstanceOf(ApproveAccountTypeChangeRequest::class, $this->app->make(\Source\Account\Account\Application\UseCase\Command\ApproveAccountTypeChangeRequest\ApproveAccountTypeChangeRequestInterface::class));
+    }
+
+    public function testApproveUpdatesRequestAndAccountTypeWhenOperationsPolicyAllows(): void
+    {
+        $requestId = new AccountTypeChangeRequestIdentifier(StrTestHelper::generateUuid());
+        $targetAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
+        $reviewerAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principal = $this->principal($reviewerAccountId);
+        $request = $this->request($requestId, $targetAccountId, AccountTypeChangeRequestStatus::PENDING);
+        $account = $this->account($targetAccountId, AccountType::INDIVIDUAL);
+
+        /** @var AccountTypeChangeRequestRepositoryInterface&Mockery\MockInterface $requestRepository */
+        $requestRepository = Mockery::mock(AccountTypeChangeRequestRepositoryInterface::class);
+        $requestRepository->shouldReceive('findById')->once()->with($requestId)->andReturn($request);
+        $requestRepository->shouldReceive('save')->once()->with($request);
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldReceive('findById')->once()->with($targetAccountId)->andReturn($account);
+        $accountRepository->shouldReceive('save')->once()->with(Mockery::on(static fn (Account $saved): bool => $saved->type() === AccountType::CORPORATION));
+
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')
+            ->once()
+            ->with($principal, Action::ACCOUNT_TYPE_CHANGE_REQUEST_APPROVE, Mockery::on(static fn (Resource $resource): bool => (string) $resource->accountIdentifier() === (string) $reviewerAccountId))
+            ->andReturnTrue();
+
+        $output = new ApproveAccountTypeChangeRequestOutput();
+        (new ApproveAccountTypeChangeRequest($requestRepository, $accountRepository, $policyEvaluator))
+            ->process(new ApproveAccountTypeChangeRequestInput($requestId, $principal), $output);
+
+        $this->assertSame(AccountTypeChangeRequestStatus::APPROVED, $request->status());
+        $this->assertSame((string) $reviewerAccountId, (string) $request->reviewedBy());
+        $this->assertSame(AccountType::CORPORATION, $account->type());
+    }
+
+    public function testForbiddenWhenReviewerDoesNotHaveOperationsPolicy(): void
+    {
+        $requestId = new AccountTypeChangeRequestIdentifier(StrTestHelper::generateUuid());
+        $principal = $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()));
+        $request = $this->request($requestId, new AccountIdentifier(StrTestHelper::generateUuid()), AccountTypeChangeRequestStatus::PENDING);
+
+        /** @var AccountTypeChangeRequestRepositoryInterface&Mockery\MockInterface $requestRepository */
+        $requestRepository = Mockery::mock(AccountTypeChangeRequestRepositoryInterface::class);
+        $requestRepository->shouldReceive('findById')->once()->andReturn($request);
+        $requestRepository->shouldNotReceive('save');
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldNotReceive('findById');
+        $accountRepository->shouldNotReceive('save');
+
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->once()->andReturnFalse();
+
+        $this->expectException(AccountTypeChangeRequestForbiddenException::class);
+        (new ApproveAccountTypeChangeRequest($requestRepository, $accountRepository, $policyEvaluator))
+            ->process(new ApproveAccountTypeChangeRequestInput($requestId, $principal), new ApproveAccountTypeChangeRequestOutput());
+    }
+
+    public function testNotFoundWhenRequestDoesNotExist(): void
+    {
+        $requestId = new AccountTypeChangeRequestIdentifier(StrTestHelper::generateUuid());
+        /** @var AccountTypeChangeRequestRepositoryInterface&Mockery\MockInterface $requestRepository */
+        $requestRepository = Mockery::mock(AccountTypeChangeRequestRepositoryInterface::class);
+        $requestRepository->shouldReceive('findById')->once()->with($requestId)->andReturnNull();
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+
+        $this->expectException(AccountTypeChangeRequestNotFoundException::class);
+        (new ApproveAccountTypeChangeRequest(
+            $requestRepository,
+            $accountRepository,
+            $policyEvaluator,
+        ))->process(new ApproveAccountTypeChangeRequestInput($requestId, $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()))), new ApproveAccountTypeChangeRequestOutput());
+    }
+
+    public function testCannotApproveNonPendingRequest(): void
+    {
+        $requestId = new AccountTypeChangeRequestIdentifier(StrTestHelper::generateUuid());
+        $targetAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
+        $request = $this->request($requestId, $targetAccountId, AccountTypeChangeRequestStatus::APPROVED);
+
+        /** @var AccountTypeChangeRequestRepositoryInterface&Mockery\MockInterface $requestRepository */
+        $requestRepository = Mockery::mock(AccountTypeChangeRequestRepositoryInterface::class);
+        $requestRepository->shouldReceive('findById')->once()->andReturn($request);
+        $requestRepository->shouldNotReceive('save');
+
+        /** @var AccountRepositoryInterface&Mockery\MockInterface $accountRepository */
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldReceive('findById')->once()->with($targetAccountId)->andReturn($this->account($targetAccountId, AccountType::INDIVIDUAL));
+        $accountRepository->shouldNotReceive('save');
+
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->once()->andReturnTrue();
+
+        $this->expectException(InvalidAccountTypeChangeRequestApprovalException::class);
+        (new ApproveAccountTypeChangeRequest($requestRepository, $accountRepository, $policyEvaluator))
+            ->process(new ApproveAccountTypeChangeRequestInput($requestId, $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()))), new ApproveAccountTypeChangeRequestOutput());
+    }
+
+    private function request(AccountTypeChangeRequestIdentifier $requestId, AccountIdentifier $accountId, AccountTypeChangeRequestStatus $status): AccountTypeChangeRequest
+    {
+        return new AccountTypeChangeRequest($requestId, $accountId, AccountType::INDIVIDUAL, AccountType::CORPORATION, $status, new DateTimeImmutable(), null, null, null);
+    }
+
+    private function account(AccountIdentifier $accountId, AccountType $type): Account
+    {
+        return new Account($accountId, new Email('account@example.com'), $type, new AccountName('Account'), AccountStatus::ACTIVE, AccountCategory::GENERAL, DeletionReadinessChecklist::ready(), new AccountDocuments([]));
+    }
+
+    private function principal(AccountIdentifier $accountId): Principal
+    {
+        return new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), new IdentityIdentifier(StrTestHelper::generateUuid()), $accountId);
+    }
+}

--- a/typespec/services/account-api/account-type-change-request.tsp
+++ b/typespec/services/account-api/account-type-change-request.tsp
@@ -17,6 +17,12 @@ model CreateAccountTypeChangeRequestResponse {
   @body body: AccountTypeChangeRequestSummary;
 }
 
+@doc("Response returned when an account type change request is approved.")
+model ApproveAccountTypeChangeRequestResponse {
+  @statusCode statusCode: 200;
+  @body body: AccountTypeChangeRequestSummary;
+}
+
 @route("/account-type-change-requests")
 interface AccountTypeChangeRequestOperations {
   @post
@@ -24,4 +30,11 @@ interface AccountTypeChangeRequestOperations {
   requestAccountTypeChange(
     @body body: RequestAccountTypeChangeRequestBody,
   ): CreateAccountTypeChangeRequestResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @post
+  @route("/{requestId}/approve")
+  @doc("Approve account type change request.")
+  approveAccountTypeChangeRequest(
+    @path requestId: Uuid,
+  ): ApproveAccountTypeChangeRequestResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.NotFoundProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 }


### PR DESCRIPTION
## 📝 変更内容

- `POST /account-type-change-requests/{requestId}/approve` のHTTP Action / Request / Route / UseCase / DI bindingを追加しました。
- 承認時にログイン中の `AccountContext` の principal を reviewer として使い、対象 Account の `type` と request の `status` / `reviewedBy` / `reviewedAt` を更新するようにしました。
- Account 権限に `account:type-change-request:approve` を追加し、専用 policy `ACCOUNT_TYPE_CHANGE_REQUEST_APPROVAL` と専用 role `Operations` を追加しました。
- `OperationsAccountSeeder` を追加し、運営用 Account だけに承認専用 role と Wiki `ADMINISTRATOR` を付与するようにしました。
- `FullAccessTestAccountSeeder` を `TestAccountSeeder` に rename し、通常テストアカウントから Wiki `ADMINISTRATOR` 付与を外しました。
- TypeSpec / OpenAPI に承認APIを追加しました。
- 承認UseCaseのテストを追加しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

アカウント種別変更リクエストの承認は、対象 Account の owner/admin 権限ではなく、プラットフォーム運営としての権限で実行する操作です。
通常テストアカウントに Wiki `ADMINISTRATOR` が付いている状態もミスリードになるため、運営用 Account / role / policy を通常 Account から分離しました。

このPRは #508（Issue #505）の変更に依存するため、base branch は `issue-505-account-type-change-request` です。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi-generate` を実行し、TypeSpec / OpenAPI 生成が成功することを確認
- [x] `task cs-fix` を実行し、コードスタイルを適用
- [x] `task phpstan` を実行し、PHPStan が成功することを確認
- [x] `docker-compose run --rm --no-deps php ./vendor/bin/phpunit --filter 'ApproveAccountTypeChangeRequestTest|AccountTypeChangeRequestTest' --exclude-group useDb --coverage-html coverage-html` を実行し、9 tests / 35 assertions が成功することを確認
- [x] `task test` を実行し、3006 tests / 9632 assertions が成功することを確認
- [x] 新しく追加した承認UseCaseに対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- TypeSpec から `doc/openapi/KPool.AccountApi.openapi.yaml` を再生成し、承認APIの path が追加されることを確認しました。
- 承認UseCaseで、運営 policy がある principal のみ承認できること、通常権限では forbidden になること、存在しない request / pending でない request の異常系を確認しました。

## 🔍 レビューのポイント

- 承認権限の判定対象 Resource が審査対象 Account ではなく、ログイン中の運営 Account になっていること
- `Owner` / `Admin` に承認専用 policy が付与されず、`Operations` role にだけ付与されていること
- 通常テストアカウントから Wiki `ADMINISTRATOR` が外れ、運営用 Account に分離されていること
- 承認時に request と Account が同じHTTP Action transaction 内で保存されること
- TypeSpec / OpenAPI の承認API定義が実装と一致していること

## 📖 関連情報

### 関連Issue・タスク

Closes #506
Relates to #505
Relates to #508

## ⚠️ 注意事項

- このPRは #508 / `issue-505-account-type-change-request` を base にした stacked PR です。
- `FullAccessTestAccountSeeder` は `TestAccountSeeder` に rename されています。
- 通常テストアカウント（`test@example.com` / `corp@example.com`）には Wiki `ADMINISTRATOR` を付与しない構成に変更しています。
- SSH push は `git@github.com: Permission denied (publickey).` で失敗したため、`gh` の認証済み token を使った一時的な HTTPS push を実行しました。`origin` は SSH remote のまま維持し、branch upstream は `origin/issue-506-approve-account-type-change-request` に復元済みです。

## 📸 スクリーンショット・デモ

API / backend 変更のため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した

## Review skills used / unavailable skills and alternative review

- `qa-review`: Hermes/Codex/リポジトリ内でスキル定義を見つけられなかったため、同期の代替QAレビューを実施しました。承認APIの正常系、403/404/422相当の異常系、reviewer が request body ではなく `AccountContext` 由来である点を確認しました。
- `test-review`: スキル定義を見つけられなかったため、同期の代替テストレビューを実施しました。追加UseCaseテスト、既存 domain test、全 PHPUnit、PHPStan、OpenAPI生成を確認しました。
- `security-review`: スキル定義を見つけられなかったため、同期の代替セキュリティレビューを実施しました。承認専用 action/policy/role を通常 owner/admin と分離し、認可判定の Resource がログイン中運営 Account であることを確認しました。
- `architecture-review`: スキル定義を見つけられなかったため、同期の代替アーキテクチャレビューを実施しました。#505 の AccountTypeChangeRequest 構造を拡張し、新規トップレベルコンテキストを追加せず、既存 Command UseCase / HTTP Action / TypeSpec のパターンに沿っていることを確認しました。

## 未対応のレビュー指摘

なし。代替レビューで妥当な未対応指摘は残っていません。
