### PR TITLE
個人アカウントの更新権限を許可

### DIFF
--- a/database/seeders/AccountAuthorizationSeeder.php
+++ b/database/seeders/AccountAuthorizationSeeder.php
@@ -43,11 +43,10 @@ class AccountAuthorizationSeeder extends Seeder
             Action::INVITE_MEMBER,
             $this->corporationAccountCondition(),
         );
-        $corporationAccountUpdatePolicy = $this->createPolicy(
+        $accountUpdatePolicy = $this->createPolicy(
             '01982020-0456-7000-8000-000000000003',
-            'CORPORATION_ACCOUNT_UPDATE',
+            'ACCOUNT_UPDATE',
             Action::UPDATE,
-            $this->corporationAccountCondition(),
         );
         $corporationAccountPrincipalGroupManagePolicy = $this->createPolicy(
             '01982020-0456-7000-8000-000000000004',
@@ -64,7 +63,7 @@ class AccountAuthorizationSeeder extends Seeder
         $accountManagementPolicyIdentifiers = [
             $accountReadPolicy->policyIdentifier(),
             $corporationAccountInviteMemberPolicy->policyIdentifier(),
-            $corporationAccountUpdatePolicy->policyIdentifier(),
+            $accountUpdatePolicy->policyIdentifier(),
             $corporationAccountPrincipalGroupManagePolicy->policyIdentifier(),
         ];
 

--- a/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
+++ b/tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php
@@ -77,6 +77,8 @@ class GetAuthenticatedIdentityTest extends TestCase
         $actions = array_merge(...array_column($statements, 'actions'));
         $this->assertContains('account:read', $actions);
         $this->assertContains('account:update', $actions);
+        $updateStatement = $this->statementForAction($statements, 'account:update');
+        $this->assertNull($updateStatement['condition']);
         $inviteStatement = $this->statementForAction($statements, 'account:member:invite');
         $this->assertSame([
             'clauses' => [


### PR DESCRIPTION
## 📝 変更内容

- `account:update` policy から法人アカウント限定条件を外し、個人アカウントでも更新できるようにしました
- 認証 identity の account policy に含まれる `account:update` が条件なしで返ることをテストに追加しました

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

`test@example.com` は individual account の owner ですが、既存の `account:update` policy が `resource:accountType = corporation` 条件付きだったため、アカウント更新が許可されませんでした。

## 🧪 テスト

### テストの実行確認

- [x] `php -l database/seeders/AccountAuthorizationSeeder.php`
- [x] `php -l tests/Identity/Infrastructure/Query/GetAuthenticatedIdentityTest.php`
- [x] `task test-no-db filter=PolicyEvaluatorTest`
- [ ] `task test filter=GetAuthenticatedIdentityTest keepdb=1` は `0.0.0.0:5433` が使用中で testing DB を起動できず未完了

### 動作確認

- [x] `task seed class=Database\\Seeders\\AccountAuthorizationSeeder` でローカル DB に seeder を反映

## 🔍 レビューのポイント

- `account:update` のみ個人アカウントを許可し、招待・principal group 管理の法人限定条件は維持している点
- fixed ID の policy を維持したまま policy 名と条件だけを更新している点

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

既存ローカル DB / 環境では `AccountAuthorizationSeeder` の再実行が必要です。

## 📸 スクリーンショット・デモ

なし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
