### PR TITLE
カテゴリ変更申請一覧のOpenAPIスキーマをフラット化

### DIFF
--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -1395,14 +1395,57 @@ components:
     AccountCategoryChangeRequestListItemSummary:
       type: object
       required:
+        - requestIdentifier
+        - accountIdentifier
+        - currentAccountCategory
+        - requestedAccountCategory
+        - status
+        - requestedAt
         - account
       properties:
+        requestIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Account category change request identifier.
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Target account identifier.
+        currentAccountCategory:
+          type: string
+          description: Current account category.
+        requestedAccountCategory:
+          type: string
+          description: Requested account category.
+        status:
+          type: string
+          description: Request status.
+        requestedAt:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          description: Timestamp when the request was created.
+        reviewedBy:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          nullable: true
+          description: Reviewer account identifier.
+        reviewedAt:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Timestamp'
+          nullable: true
+          description: Timestamp when the request was reviewed.
+        rejectionReason:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/VerificationRejectionReasonSummary'
+          nullable: true
+          description: Optional rejection reason.
         account:
           allOf:
             - $ref: '#/components/schemas/AccountSummary'
           description: Target account.
-      allOf:
-        - $ref: '#/components/schemas/AccountCategoryChangeRequestSummary'
       description: Account category change request state with target account summary.
     AccountCategoryChangeRequestSummary:
       type: object

--- a/typespec/services/account-api/common.tsp
+++ b/typespec/services/account-api/common.tsp
@@ -288,7 +288,8 @@ model AccountCategoryChangeRequestIdentitySummary {
 }
 
 @doc("Account category change request state with target account summary.")
-model AccountCategoryChangeRequestListItemSummary extends AccountCategoryChangeRequestSummary {
+model AccountCategoryChangeRequestListItemSummary {
+  ...AccountCategoryChangeRequestSummary;
   @doc("Target account.")
   account: AccountSummary;
 }


### PR DESCRIPTION
## 📝 変更内容

- `AccountCategoryChangeRequestListItemSummary` の TypeSpec 定義を `extends` から spread に変更
- 生成済み OpenAPI で `AccountCategoryChangeRequestListItemSummary` の properties が直下に展開されるように更新

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 📚 ドキュメント (Documentation)

## 🎯 変更理由・背景

フロント側の OpenAPI/Zod 生成で `allOf` による `AccountCategoryChangeRequestSummary` 継承が `account` 付き一覧 item として正しく生成されないため、一覧専用 schema をフラットな OpenAPI として出力する。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi-generate`

### 動作確認

手動確認なし。

## 🔍 レビューのポイント

- `AccountCategoryChangeRequestListItemSummary` から `allOf: AccountCategoryChangeRequestSummary` が消え、`account` を含む properties が直下に出力されていること
- 一覧レスポンスだけ `requests[].account` を持つ契約が維持されていること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

フロント側の型生成を安定させるための OpenAPI 形状変更で、API の実レスポンス構造は変わらない。

## 📸 スクリーンショット・デモ

なし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
