### PR TITLE
refactor: Affiliationリクエストをポリシーベース化

### DIFF
--- a/application/Http/Action/Account/Affiliation/Command/RequestAffiliation/RequestAffiliationAction.php
+++ b/application/Http/Action/Account/Affiliation/Command/RequestAffiliation/RequestAffiliationAction.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Account\Affiliation\Command\RequestAffiliation;
 
+use Application\Http\Context\AccountContext;
 use Application\Http\Exceptions\ConflictHttpException;
 use Application\Http\Exceptions\InternalServerErrorHttpException;
-use Application\Http\Exceptions\NotFoundHttpException;
 use Application\Http\Exceptions\UnprocessableEntityHttpException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
-use Source\Account\Account\Application\Exception\AccountNotFoundException;
 use Source\Account\Affiliation\Application\Exception\AffiliationAlreadyExistsException;
-use Source\Account\Affiliation\Application\Exception\InvalidAccountCategoryException;
+use Source\Account\Affiliation\Application\Exception\DisallowedAffiliationOperationException;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInput;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInterface;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationOutput;
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
 use Source\Monetization\Shared\ValueObject\Percentage;
-use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
@@ -28,6 +27,7 @@ readonly class RequestAffiliationAction
 {
     public function __construct(
         private RequestAffiliationInterface $requestAffiliation,
+        private AccountContext $accountContext,
         private LoggerInterface $logger,
     ) {
     }
@@ -41,9 +41,8 @@ readonly class RequestAffiliationAction
             try {
                 $terms = $request->terms();
                 $input = new RequestAffiliationInput(
-                    agencyAccountIdentifier: new AccountIdentifier($request->agencyAccountIdentifier()),
-                    talentAccountIdentifier: new AccountIdentifier($request->talentAccountIdentifier()),
-                    requestedBy: new AccountIdentifier($request->requestedBy()),
+                    principal: $this->accountContext->principal(),
+                    targetEmail: new Email($request->targetEmail()),
                     terms: $terms === null
                         ? null
                         : new AffiliationTerms(
@@ -63,14 +62,10 @@ readonly class RequestAffiliationAction
             try {
                 $this->requestAffiliation->process($input, $output);
                 DB::commit();
-            } catch (AccountNotFoundException $e) {
+            } catch (DisallowedAffiliationOperationException $e) {
                 DB::rollBack();
 
-                throw new NotFoundHttpException(detail: error_message('account_not_found', $language), previous: $e);
-            } catch (InvalidAccountCategoryException $e) {
-                DB::rollBack();
-
-                throw new UnprocessableEntityHttpException(detail: error_message('invalid_account_category_for_affiliation', $language), previous: $e);
+                throw new UnprocessableEntityHttpException(detail: error_message('disallowed_affiliation_operation', $language), previous: $e);
             } catch (AffiliationAlreadyExistsException $e) {
                 DB::rollBack();
 
@@ -80,7 +75,7 @@ readonly class RequestAffiliationAction
 
                 throw $e;
             }
-        } catch (ConflictHttpException|NotFoundHttpException|UnprocessableEntityHttpException $e) {
+        } catch (ConflictHttpException|UnprocessableEntityHttpException $e) {
             $this->logger->error((string) $e);
 
             return response()->json($e->toProblemDetails(), $e->getHttpStatus());

--- a/application/Http/Action/Account/Affiliation/Command/RequestAffiliation/RequestAffiliationRequest.php
+++ b/application/Http/Action/Account/Affiliation/Command/RequestAffiliation/RequestAffiliationRequest.php
@@ -17,28 +17,16 @@ class RequestAffiliationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'agencyAccountIdentifier' => ['required', 'uuid'],
-            'talentAccountIdentifier' => ['required', 'uuid'],
-            'requestedBy' => ['required', 'uuid'],
+            'targetEmail' => ['required', 'email'],
             'terms' => ['nullable', 'array'],
             'terms.revenueSharePercentage' => ['nullable', 'integer', 'min:0', 'max:100'],
             'terms.contractNotes' => ['nullable', 'string'],
         ];
     }
 
-    public function agencyAccountIdentifier(): string
+    public function targetEmail(): string
     {
-        return (string) $this->input('agencyAccountIdentifier');
-    }
-
-    public function talentAccountIdentifier(): string
-    {
-        return (string) $this->input('talentAccountIdentifier');
-    }
-
-    public function requestedBy(): string
-    {
-        return (string) $this->input('requestedBy');
+        return (string) $this->input('targetEmail');
     }
 
     /**

--- a/application/Http/Context/AccountResolver.php
+++ b/application/Http/Context/AccountResolver.php
@@ -113,7 +113,7 @@ readonly class AccountResolver
     }
 
     /**
-     * @return array{effect: string, actions: array<int, string>, resourceTypes: array<int, string>, condition: array{clauses: array<int, array{field: string, operator: string, value: string|bool}>}|null}
+     * @return array{effect: string, actions: array<int, string>, resourceTypes: array<int, string>, condition: array{clauses: array<int, array{field: string, operator: string, value: string|bool|list<string>}>}|null}
      */
     private function toStatementArray(Statement $statement): array
     {
@@ -126,7 +126,7 @@ readonly class AccountResolver
     }
 
     /**
-     * @return array{clauses: array<int, array{field: string, operator: string, value: string|bool}>}|null
+     * @return array{clauses: array<int, array{field: string, operator: string, value: string|bool|list<string>}>}|null
      */
     private function toConditionArray(?Condition $condition): ?array
     {
@@ -140,7 +140,7 @@ readonly class AccountResolver
     }
 
     /**
-     * @return array{field: string, operator: string, value: string|bool}
+     * @return array{field: string, operator: string, value: string|bool|list<string>}
      */
     private function toConditionClauseArray(ConditionClause $clause): array
     {

--- a/application/Mail/AffiliationRequestMail.php
+++ b/application/Mail/AffiliationRequestMail.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Source\Shared\Domain\ValueObject\Language;
+
+class AffiliationRequestMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    private const array SUBJECTS = [
+        'ja' => '所属リクエストの承認依頼',
+        'en' => 'Affiliation request approval',
+        'ko' => '소속 요청 승인 요청',
+    ];
+
+    public function __construct(
+        public readonly string $affiliationUrl,
+        public readonly Language $language,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: self::SUBJECTS[$this->language->value],
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.affiliation.request_' . $this->language->value,
+        );
+    }
+}

--- a/application/Providers/Account/DomainServiceProvider.php
+++ b/application/Providers/Account/DomainServiceProvider.php
@@ -63,7 +63,6 @@ class DomainServiceProvider extends ServiceProvider
         $this->app->singleton(DelegationPermissionFactoryInterface::class, DelegationPermissionFactory::class);
         $this->app->singleton(DelegationPermissionRepositoryInterface::class, DelegationPermissionRepository::class);
         $this->app->singleton(DelegationTerminationServiceInterface::class, DelegationTerminationService::class);
-
         $this->app->singleton(AccountCategoryChangeRequestFactoryInterface::class, AccountCategoryChangeRequestFactory::class);
         $this->app->singleton(AccountCategoryChangeRequestRepositoryInterface::class, AccountCategoryChangeRequestRepository::class);
         $this->app->singleton(DocumentStorageServiceInterface::class, DocumentStorageService::class);

--- a/application/Providers/Account/EventServiceProvider.php
+++ b/application/Providers/Account/EventServiceProvider.php
@@ -48,5 +48,6 @@ class EventServiceProvider extends ServiceProvider
             IdentityCreatedViaInvitation::class,
             [IdentityCreatedViaInvitationHandler::class, 'handle'],
         );
+
     }
 }

--- a/application/Providers/Identity/DomainServiceProvider.php
+++ b/application/Providers/Identity/DomainServiceProvider.php
@@ -7,6 +7,7 @@ namespace Application\Providers\Identity;
 use Application\Http\Client\OAuthHttpClient\OAuthHttpClient;
 use Illuminate\Support\ServiceProvider;
 use Psr\Log\LoggerInterface;
+use Source\Identity\Application\Service\AffiliationRequestNotificationServiceInterface;
 use Source\Identity\Application\Service\CollaboratorNotificationServiceInterface;
 use Source\Identity\Application\Service\DelegationValidatorInterface;
 use Source\Identity\Domain\Factory\AuthCodeSessionFactoryInterface;
@@ -26,6 +27,7 @@ use Source\Identity\Infrastructure\Repository\AuthCodeSessionRepository;
 use Source\Identity\Infrastructure\Repository\IdentityRepository;
 use Source\Identity\Infrastructure\Repository\OAuthStateRepository;
 use Source\Identity\Infrastructure\Repository\SignupSessionRepository;
+use Source\Identity\Infrastructure\Service\AffiliationRequestNotificationService;
 use Source\Identity\Infrastructure\Service\AuthCodeService;
 use Source\Identity\Infrastructure\Service\AuthService;
 use Source\Identity\Infrastructure\Service\CollaboratorNotificationService;
@@ -42,6 +44,10 @@ class DomainServiceProvider extends ServiceProvider
         $this->app->singleton(IdentityRepositoryInterface::class, IdentityRepository::class);
         $this->app->singleton(AuthServiceInterface::class, AuthService::class);
         $this->app->singleton(AuthCodeServiceInterface::class, AuthCodeService::class);
+        $this->app->singleton(AffiliationRequestNotificationServiceInterface::class, fn ($app) => new AffiliationRequestNotificationService(
+            $app->make(IdentityRepositoryInterface::class),
+            config('app.frontend_url', 'http://localhost:3000'),
+        ));
         $this->app->singleton(CollaboratorNotificationServiceInterface::class, CollaboratorNotificationService::class);
         $this->app->singleton(DelegationValidatorInterface::class, DelegationValidator::class);
         $this->app->singleton(OAuthStateGeneratorInterface::class, OAuthStateGenerator::class);

--- a/application/Providers/Identity/EventServiceProvider.php
+++ b/application/Providers/Identity/EventServiceProvider.php
@@ -6,8 +6,10 @@ namespace Application\Providers\Identity;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
+use Source\Account\Affiliation\Domain\Event\AffiliationRequested;
 use Source\Account\Delegation\Domain\Event\DelegationApproved;
 use Source\Account\Delegation\Domain\Event\DelegationRevoked;
+use Source\Identity\Application\EventHandler\AffiliationRequestedHandler;
 use Source\Identity\Application\EventHandler\DelegationApprovedHandler;
 use Source\Identity\Application\EventHandler\DelegationRevokedHandler;
 use Source\Identity\Application\EventHandler\DemotionWarningsBatchIssuedHandler;
@@ -32,6 +34,11 @@ class EventServiceProvider extends ServiceProvider
         $events->listen(
             DelegationRevoked::class,
             [DelegationRevokedHandler::class, 'handle'],
+        );
+
+        $events->listen(
+            AffiliationRequested::class,
+            [AffiliationRequestedHandler::class, 'handle'],
         );
 
         $events->listen(

--- a/database/seeders/AccountAuthorizationSeeder.php
+++ b/database/seeders/AccountAuthorizationSeeder.php
@@ -20,6 +20,7 @@ use Source\Account\Principal\Domain\ValueObject\ResourceType;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\Statement;
 use Source\Account\Account\Domain\ValueObject\AccountType;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Symfony\Component\Uid\Uuid;
 
 
@@ -59,12 +60,26 @@ class AccountAuthorizationSeeder extends Seeder
             'ACCOUNT_CATEGORY_CHANGE_REQUEST_MANAGE',
             Action::ACCOUNT_CATEGORY_CHANGE_REQUEST_MANAGE,
         );
+        $affiliationRequestCreatePolicy = $this->createPolicy(
+            '01982020-0456-7000-8000-000000000006',
+            'AFFILIATION_REQUEST_CREATE',
+            Action::AFFILIATION_REQUEST_CREATE,
+            $this->affiliationRequestCreateCondition(),
+        );
+        $affiliationRequestReceivePolicy = $this->createPolicy(
+            '01982020-0456-7000-8000-000000000007',
+            'AFFILIATION_REQUEST_RECEIVE',
+            Action::AFFILIATION_REQUEST_RECEIVE,
+            $this->affiliationRequestReceiveCondition(),
+        );
 
         $accountManagementPolicyIdentifiers = [
             $accountReadPolicy->policyIdentifier(),
             $corporationAccountInviteMemberPolicy->policyIdentifier(),
             $accountUpdatePolicy->policyIdentifier(),
             $corporationAccountPrincipalGroupManagePolicy->policyIdentifier(),
+            $affiliationRequestCreatePolicy->policyIdentifier(),
+            $affiliationRequestReceivePolicy->policyIdentifier(),
         ];
 
         $this->saveRole(Role::OWNER, $accountManagementPolicyIdentifiers);
@@ -81,6 +96,31 @@ class AccountAuthorizationSeeder extends Seeder
                 ConditionKey::RESOURCE_ACCOUNT_TYPE,
                 ConditionOperator::EQUALS,
                 AccountType::CORPORATION->value,
+            ),
+        ]);
+    }
+
+    private function affiliationRequestCreateCondition(): Condition
+    {
+        return new Condition([
+            new ConditionClause(
+                ConditionKey::RESOURCE_ACCOUNT_CATEGORY,
+                ConditionOperator::IN,
+                [
+                    AccountCategory::TALENT->value,
+                    AccountCategory::AGENCY->value,
+                ],
+            ),
+        ]);
+    }
+
+    private function affiliationRequestReceiveCondition(): Condition
+    {
+        return new Condition([
+            new ConditionClause(
+                ConditionKey::AFFILIATION_REQUEST_PAIR_ALLOWED,
+                ConditionOperator::EQUALS,
+                true,
             ),
         ]);
     }

--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -2183,22 +2183,11 @@ components:
     RequestAffiliationRequestBody:
       type: object
       required:
-        - agencyAccountIdentifier
-        - talentAccountIdentifier
-        - requestedBy
+        - targetEmail
       properties:
-        agencyAccountIdentifier:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Agency account identifier.
-        talentAccountIdentifier:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Talent account identifier.
-        requestedBy:
-          allOf:
-            - $ref: '#/components/schemas/KPool.Common.Uuid'
-          description: Account identifier that requested the affiliation.
+        targetEmail:
+          type: string
+          description: Email address of the target account/principal that should receive the affiliation request.
         terms:
           type: object
           allOf:

--- a/resources/views/emails/affiliation/request_en.blade.php
+++ b/resources/views/emails/affiliation/request_en.blade.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Affiliation request approval</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: 'Helvetica Neue', Arial, sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 40px 20px;">
+                <table role="presentation" width="600" cellspacing="0" cellpadding="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);">
+                    <tr>
+                        <td style="padding: 40px 40px 30px; text-align: center; border-bottom: 1px solid #eeeeee;">
+                            <h1 style="margin: 0; font-size: 24px; font-weight: bold; color: #333333;">Affiliation request approval</h1>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 40px;">
+                            <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #555555;">
+                                You have received an affiliation request.
+                            </p>
+                            <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #555555;">
+                                Open the affiliation page in the admin console to review the request details and approve it.
+                            </p>
+                            <div style="text-align: center; margin-bottom: 24px;">
+                                <a href="{{ $affiliationUrl }}" style="display: inline-block; background-color: #2563eb; color: #ffffff; font-size: 16px; font-weight: bold; text-decoration: none; padding: 16px 32px; border-radius: 8px;">
+                                    Review Affiliation Request
+                                </a>
+                            </div>
+                            <p style="margin: 0; font-size: 12px; color: #888888; text-align: center;">
+                                If you cannot click the button above, please copy and paste the following URL into your browser:<br>
+                                <span style="color: #2563eb; word-break: break-all;">{{ $affiliationUrl }}</span>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 24px 40px; background-color: #fafafa; border-radius: 0 0 8px 8px;">
+                            <p style="margin: 0; font-size: 12px; line-height: 1.6; color: #999999;">
+                                If you did not expect this email, please check with your administrator.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/resources/views/emails/affiliation/request_ja.blade.php
+++ b/resources/views/emails/affiliation/request_ja.blade.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>所属リクエストの承認依頼</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 40px 20px;">
+                <table role="presentation" width="600" cellspacing="0" cellpadding="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);">
+                    <tr>
+                        <td style="padding: 40px 40px 30px; text-align: center; border-bottom: 1px solid #eeeeee;">
+                            <h1 style="margin: 0; font-size: 24px; font-weight: bold; color: #333333;">所属リクエストの承認依頼</h1>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 40px;">
+                            <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #555555;">
+                                所属リクエストが届いています。
+                            </p>
+                            <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #555555;">
+                                管理画面の所属ページを開き、リクエスト内容を確認して承認してください。
+                            </p>
+                            <div style="text-align: center; margin-bottom: 24px;">
+                                <a href="{{ $affiliationUrl }}" style="display: inline-block; background-color: #2563eb; color: #ffffff; font-size: 16px; font-weight: bold; text-decoration: none; padding: 16px 32px; border-radius: 8px;">
+                                    所属リクエストを確認する
+                                </a>
+                            </div>
+                            <p style="margin: 0; font-size: 12px; color: #888888; text-align: center;">
+                                上のボタンがクリックできない場合は、以下のURLをブラウザにコピーしてください：<br>
+                                <span style="color: #2563eb; word-break: break-all;">{{ $affiliationUrl }}</span>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 24px 40px; background-color: #fafafa; border-radius: 0 0 8px 8px;">
+                            <p style="margin: 0; font-size: 12px; line-height: 1.6; color: #999999;">
+                                ※このメールに心当たりがない場合は、管理者に確認してください。
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/resources/views/emails/affiliation/request_ko.blade.php
+++ b/resources/views/emails/affiliation/request_ko.blade.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>소속 요청 승인 요청</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: 'Helvetica Neue', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color: #f4f4f4;">
+        <tr>
+            <td align="center" style="padding: 40px 20px;">
+                <table role="presentation" width="600" cellspacing="0" cellpadding="0" style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);">
+                    <tr>
+                        <td style="padding: 40px 40px 30px; text-align: center; border-bottom: 1px solid #eeeeee;">
+                            <h1 style="margin: 0; font-size: 24px; font-weight: bold; color: #333333;">소속 요청 승인 요청</h1>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 40px;">
+                            <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #555555;">
+                                소속 요청이 도착했습니다.
+                            </p>
+                            <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #555555;">
+                                관리 화면의 소속 페이지를 열어 요청 내용을 확인하고 승인해 주세요.
+                            </p>
+                            <div style="text-align: center; margin-bottom: 24px;">
+                                <a href="{{ $affiliationUrl }}" style="display: inline-block; background-color: #2563eb; color: #ffffff; font-size: 16px; font-weight: bold; text-decoration: none; padding: 16px 32px; border-radius: 8px;">
+                                    소속 요청 확인하기
+                                </a>
+                            </div>
+                            <p style="margin: 0; font-size: 12px; color: #888888; text-align: center;">
+                                위 버튼을 클릭할 수 없는 경우, 아래 URL을 브라우저에 복사하여 붙여넣기 해주세요:<br>
+                                <span style="color: #2563eb; word-break: break-all;">{{ $affiliationUrl }}</span>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 24px 40px; background-color: #fafafa; border-radius: 0 0 8px 8px;">
+                            <p style="margin: 0; font-size: 12px; line-height: 1.6; color: #999999;">
+                                ※이 메일에 대해 알지 못하는 경우, 관리자에게 확인해 주세요.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliation.php
+++ b/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliation.php
@@ -7,55 +7,108 @@ namespace Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliat
 use Source\Account\Account\Application\Exception\AccountNotFoundException;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Affiliation\Application\Exception\AffiliationAlreadyExistsException;
-use Source\Account\Affiliation\Application\Exception\InvalidAccountCategoryException;
+use Source\Account\Affiliation\Application\Exception\DisallowedAffiliationOperationException;
+use Source\Account\Affiliation\Domain\Event\AffiliationRequested;
 use Source\Account\Affiliation\Domain\Factory\AffiliationFactoryInterface;
 use Source\Account\Affiliation\Domain\Repository\AffiliationRepositoryInterface;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
 readonly class RequestAffiliation implements RequestAffiliationInterface
 {
     public function __construct(
         private AccountRepositoryInterface $accountRepository,
+        private PrincipalRepositoryInterface $principalRepository,
+        private PolicyEvaluatorInterface $policyEvaluator,
         private AffiliationRepositoryInterface $affiliationRepository,
         private AffiliationFactoryInterface $affiliationFactory,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
     public function process(RequestAffiliationInputPort $input, RequestAffiliationOutputPort $output): void
     {
-        $agencyAccount = $this->accountRepository->findById($input->agencyAccountIdentifier());
-        if ($agencyAccount === null) {
-            throw new AccountNotFoundException('Agency account not found.');
+        $requestingAccount = $this->accountRepository->findById($input->principal()->accountIdentifier());
+        if ($requestingAccount === null) {
+            throw new AccountNotFoundException('Requesting account not found.');
         }
 
-        if ($agencyAccount->accountCategory() !== AccountCategory::AGENCY) {
-            throw new InvalidAccountCategoryException('Agency account must have agency category.');
-        }
-
-        $talentAccount = $this->accountRepository->findById($input->talentAccountIdentifier());
-        if ($talentAccount === null) {
-            throw new AccountNotFoundException('Talent account not found.');
-        }
-
-        if ($talentAccount->accountCategory() !== AccountCategory::TALENT) {
-            throw new InvalidAccountCategoryException('Talent account must have talent category.');
-        }
-
-        if ($this->affiliationRepository->existsActiveAffiliation(
-            $input->agencyAccountIdentifier(),
-            $input->talentAccountIdentifier()
+        $requestingCategory = $requestingAccount->accountCategory();
+        if (! $this->policyEvaluator->evaluate(
+            $input->principal(),
+            Action::AFFILIATION_REQUEST_CREATE,
+            Resource::account(
+                $requestingAccount->accountIdentifier(),
+                $requestingAccount->type(),
+                $requestingCategory,
+            ),
         )) {
+            throw new DisallowedAffiliationOperationException('Affiliation request is not allowed.');
+        }
+
+        $targetAccount = $this->accountRepository->findByEmail($input->targetEmail());
+        if ($targetAccount === null) {
+            throw new DisallowedAffiliationOperationException('Affiliation request target is not allowed.');
+        }
+
+        $targetPrincipal = $this->principalRepository->findByEmailAndAccountIdentifier(
+            $input->targetEmail(),
+            $targetAccount->accountIdentifier(),
+        );
+        if ($targetPrincipal === null || ! $this->policyEvaluator->evaluate(
+            $targetPrincipal,
+            Action::AFFILIATION_REQUEST_RECEIVE,
+            Resource::account(
+                $targetAccount->accountIdentifier(),
+                $targetAccount->type(),
+                $targetAccount->accountCategory(),
+                $requestingCategory,
+            ),
+        )) {
+            throw new DisallowedAffiliationOperationException('Affiliation request target is not allowed.');
+        }
+
+        [$agencyAccountIdentifier, $talentAccountIdentifier] = $this->resolveAffiliationPair(
+            $requestingCategory,
+            $requestingAccount->accountIdentifier(),
+            $targetAccount->accountIdentifier(),
+        );
+
+        if ($this->affiliationRepository->existsActiveAffiliation($agencyAccountIdentifier, $talentAccountIdentifier)) {
             throw new AffiliationAlreadyExistsException('An active affiliation already exists between these accounts.');
         }
 
         $affiliation = $this->affiliationFactory->create(
-            $input->agencyAccountIdentifier(),
-            $input->talentAccountIdentifier(),
-            $input->requestedBy(),
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            $requestingAccount->accountIdentifier(),
             $input->terms(),
         );
 
         $this->affiliationRepository->save($affiliation);
+        $this->eventDispatcher->dispatch(new AffiliationRequested(
+            $affiliation->affiliationIdentifier(),
+            $input->targetEmail(),
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            $requestingAccount->accountIdentifier(),
+        ));
         $output->setAffiliation($affiliation);
+    }
+
+    /** @return array{0: AccountIdentifier, 1: AccountIdentifier} */
+    private function resolveAffiliationPair(
+        AccountCategory $requestingCategory,
+        AccountIdentifier $requestingAccountIdentifier,
+        AccountIdentifier $targetAccountIdentifier,
+    ): array {
+        return $requestingCategory === AccountCategory::AGENCY
+            ? [$requestingAccountIdentifier, $targetAccountIdentifier]
+            : [$targetAccountIdentifier, $requestingAccountIdentifier];
     }
 }

--- a/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationInput.php
+++ b/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationInput.php
@@ -5,31 +5,26 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation;
 
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
-use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Shared\Domain\ValueObject\Email;
 
 readonly class RequestAffiliationInput implements RequestAffiliationInputPort
 {
     public function __construct(
-        private AccountIdentifier $agencyAccountIdentifier,
-        private AccountIdentifier $talentAccountIdentifier,
-        private AccountIdentifier $requestedBy,
+        private Principal $principal,
+        private Email $targetEmail,
         private ?AffiliationTerms $terms,
     ) {
     }
 
-    public function agencyAccountIdentifier(): AccountIdentifier
+    public function principal(): Principal
     {
-        return $this->agencyAccountIdentifier;
+        return $this->principal;
     }
 
-    public function talentAccountIdentifier(): AccountIdentifier
+    public function targetEmail(): Email
     {
-        return $this->talentAccountIdentifier;
-    }
-
-    public function requestedBy(): AccountIdentifier
-    {
-        return $this->requestedBy;
+        return $this->targetEmail;
     }
 
     public function terms(): ?AffiliationTerms

--- a/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationInputPort.php
+++ b/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationInputPort.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation;
 
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
-use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Shared\Domain\ValueObject\Email;
 
 interface RequestAffiliationInputPort
 {
-    public function agencyAccountIdentifier(): AccountIdentifier;
+    public function principal(): Principal;
 
-    public function talentAccountIdentifier(): AccountIdentifier;
-
-    public function requestedBy(): AccountIdentifier;
+    public function targetEmail(): Email;
 
     public function terms(): ?AffiliationTerms;
 }

--- a/src/Account/Affiliation/Domain/Event/AffiliationRequested.php
+++ b/src/Account/Affiliation/Domain/Event/AffiliationRequested.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Domain\Event;
+
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+
+readonly class AffiliationRequested
+{
+    public function __construct(
+        public AffiliationIdentifier $affiliationIdentifier,
+        public Email $targetEmail,
+        public AccountIdentifier $agencyAccountIdentifier,
+        public AccountIdentifier $talentAccountIdentifier,
+        public AccountIdentifier $requestedBy,
+    ) {
+    }
+}

--- a/src/Account/Principal/Domain/Repository/PrincipalRepositoryInterface.php
+++ b/src/Account/Principal/Domain/Repository/PrincipalRepositoryInterface.php
@@ -7,6 +7,7 @@ namespace Source\Account\Principal\Domain\Repository;
 use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 
 interface PrincipalRepositoryInterface
@@ -25,6 +26,8 @@ interface PrincipalRepositoryInterface
         IdentityIdentifier $identityIdentifier,
         AccountIdentifier $accountIdentifier,
     ): ?Principal;
+
+    public function findByEmailAndAccountIdentifier(Email $email, AccountIdentifier $accountIdentifier): ?Principal;
 
     public function save(Principal $principal): void;
 }

--- a/src/Account/Principal/Domain/ValueObject/Action.php
+++ b/src/Account/Principal/Domain/ValueObject/Action.php
@@ -11,4 +11,6 @@ enum Action: string
     case UPDATE = 'account:update';
     case PRINCIPAL_GROUP_MANAGE = 'account:principal-group:manage';
     case ACCOUNT_CATEGORY_CHANGE_REQUEST_MANAGE = 'account:category-change-request:manage';
+    case AFFILIATION_REQUEST_CREATE = 'account:affiliation-request:create';
+    case AFFILIATION_REQUEST_RECEIVE = 'account:affiliation-request:receive';
 }

--- a/src/Account/Principal/Domain/ValueObject/ConditionClause.php
+++ b/src/Account/Principal/Domain/ValueObject/ConditionClause.php
@@ -6,10 +6,11 @@ namespace Source\Account\Principal\Domain\ValueObject;
 
 final readonly class ConditionClause
 {
+    /** @param string|bool|list<string> $value */
     public function __construct(
         private ConditionKey $key,
         private ConditionOperator $operator,
-        private string|bool $value,
+        private string|bool|array $value,
     ) {
     }
 
@@ -23,7 +24,8 @@ final readonly class ConditionClause
         return $this->operator;
     }
 
-    public function value(): string|bool
+    /** @return string|bool|list<string> */
+    public function value(): string|bool|array
     {
         return $this->value;
     }

--- a/src/Account/Principal/Domain/ValueObject/ConditionKey.php
+++ b/src/Account/Principal/Domain/ValueObject/ConditionKey.php
@@ -7,4 +7,6 @@ namespace Source\Account\Principal\Domain\ValueObject;
 enum ConditionKey: string
 {
     case RESOURCE_ACCOUNT_TYPE = 'resource:accountType';
+    case RESOURCE_ACCOUNT_CATEGORY = 'resource:accountCategory';
+    case AFFILIATION_REQUEST_PAIR_ALLOWED = 'affiliationRequest:pairAllowed';
 }

--- a/src/Account/Principal/Domain/ValueObject/Resource.php
+++ b/src/Account/Principal/Domain/ValueObject/Resource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Account\Principal\Domain\ValueObject;
 
 use Source\Account\Account\Domain\ValueObject\AccountType;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 
 final readonly class Resource
@@ -13,12 +14,24 @@ final readonly class Resource
         private ResourceType $type,
         private AccountIdentifier $accountIdentifier,
         private ?AccountType $accountType = null,
+        private ?AccountCategory $accountCategory = null,
+        private ?AccountCategory $affiliationRequestingAccountCategory = null,
     ) {
     }
 
-    public static function account(AccountIdentifier $accountIdentifier, ?AccountType $accountType = null): self
-    {
-        return new self(ResourceType::ACCOUNT, $accountIdentifier, $accountType);
+    public static function account(
+        AccountIdentifier $accountIdentifier,
+        ?AccountType $accountType = null,
+        ?AccountCategory $accountCategory = null,
+        ?AccountCategory $affiliationRequestingAccountCategory = null,
+    ): self {
+        return new self(
+            ResourceType::ACCOUNT,
+            $accountIdentifier,
+            $accountType,
+            $accountCategory,
+            $affiliationRequestingAccountCategory,
+        );
     }
 
     public function type(): ResourceType
@@ -34,5 +47,15 @@ final readonly class Resource
     public function accountType(): ?AccountType
     {
         return $this->accountType;
+    }
+
+    public function accountCategory(): ?AccountCategory
+    {
+        return $this->accountCategory;
+    }
+
+    public function affiliationRequestingAccountCategory(): ?AccountCategory
+    {
+        return $this->affiliationRequestingAccountCategory;
     }
 }

--- a/src/Account/Principal/Infrastructure/Repository/PolicyRepository.php
+++ b/src/Account/Principal/Infrastructure/Repository/PolicyRepository.php
@@ -79,7 +79,7 @@ class PolicyRepository implements PolicyRepositoryInterface
 
     /**
      * @param Statement[] $statements
-     * @return array<array{effect: string, actions: array<string>, resource_types: array<string>, condition: array<array{key: string, operator: string, value: string|bool}>|null}>
+     * @return array<array{effect: string, actions: array<string>, resource_types: array<string>, condition: array<array{key: string, operator: string, value: string|bool|list<string>}>|null}>
      */
     private function serializeStatements(array $statements): array
     {
@@ -87,7 +87,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @return array{effect: string, actions: array<string>, resource_types: array<string>, condition: array<array{key: string, operator: string, value: string|bool}>|null}
+     * @return array{effect: string, actions: array<string>, resource_types: array<string>, condition: array<array{key: string, operator: string, value: string|bool|list<string>}>|null}
      */
     private function serializeStatement(Statement $statement): array
     {
@@ -102,7 +102,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @return array<array{key: string, operator: string, value: string|bool}>
+     * @return array<array{key: string, operator: string, value: string|bool|list<string>}>
      */
     private function serializeCondition(Condition $condition): array
     {
@@ -128,7 +128,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @param array<array{effect: string, actions: array<string>, resource_types: array<string>, condition?: array<array{key: string, operator: string, value: string|bool}>|null}> $statementsData
+     * @param array<array{effect: string, actions: array<string>, resource_types: array<string>, condition?: array<array{key: string, operator: string, value: string|bool|list<string>}>|null}> $statementsData
      * @return Statement[]
      */
     private function deserializeStatements(array $statementsData): array
@@ -137,7 +137,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @param array{effect: string, actions: array<string>, resource_types: array<string>, condition?: array<array{key: string, operator: string, value: string|bool}>|null} $data
+     * @param array{effect: string, actions: array<string>, resource_types: array<string>, condition?: array<array{key: string, operator: string, value: string|bool|list<string>}>|null} $data
      */
     private function deserializeStatement(array $data): Statement
     {
@@ -152,7 +152,7 @@ class PolicyRepository implements PolicyRepositoryInterface
     }
 
     /**
-     * @param array<array{key: string, operator: string, value: string|bool}> $conditionData
+     * @param array<array{key: string, operator: string, value: string|bool|list<string>}> $conditionData
      */
     private function deserializeCondition(array $conditionData): Condition
     {

--- a/src/Account/Principal/Infrastructure/Repository/PrincipalRepository.php
+++ b/src/Account/Principal/Infrastructure/Repository/PrincipalRepository.php
@@ -10,6 +10,7 @@ use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 
 class PrincipalRepository implements PrincipalRepositoryInterface
@@ -71,6 +72,22 @@ class PrincipalRepository implements PrincipalRepositoryInterface
         $eloquent = PrincipalEloquent::query()
             ->where('identity_id', (string) $identityIdentifier)
             ->where('account_id', (string) $accountIdentifier)
+            ->first();
+
+        if ($eloquent === null) {
+            return null;
+        }
+
+        return $this->toDomainEntity($eloquent);
+    }
+
+    public function findByEmailAndAccountIdentifier(Email $email, AccountIdentifier $accountIdentifier): ?Principal
+    {
+        $eloquent = PrincipalEloquent::query()
+            ->join('identities', 'account_principals.identity_id', '=', 'identities.id')
+            ->where('identities.email', (string) $email)
+            ->where('account_principals.account_id', (string) $accountIdentifier)
+            ->select('account_principals.*')
             ->first();
 
         if ($eloquent === null) {

--- a/src/Account/Principal/Infrastructure/Service/PolicyEvaluator.php
+++ b/src/Account/Principal/Infrastructure/Service/PolicyEvaluator.php
@@ -17,6 +17,7 @@ use Source\Account\Principal\Domain\ValueObject\ConditionOperator;
 use Source\Account\Principal\Domain\ValueObject\Effect;
 use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Principal\Domain\ValueObject\Statement;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 
 readonly class PolicyEvaluator implements PolicyEvaluatorInterface
 {
@@ -134,10 +135,21 @@ readonly class PolicyEvaluator implements PolicyEvaluatorInterface
         };
     }
 
-    private function conditionActualValue(ConditionKey $key, Resource $resource): ?string
+    private function conditionActualValue(ConditionKey $key, Resource $resource): string|bool|null
     {
         return match ($key) {
             ConditionKey::RESOURCE_ACCOUNT_TYPE => $resource->accountType()?->value,
+            ConditionKey::RESOURCE_ACCOUNT_CATEGORY => $resource->accountCategory()?->value,
+            ConditionKey::AFFILIATION_REQUEST_PAIR_ALLOWED => $this->affiliationRequestPairAllowed($resource),
+        };
+    }
+
+    private function affiliationRequestPairAllowed(Resource $resource): bool
+    {
+        return match ($resource->affiliationRequestingAccountCategory()) {
+            AccountCategory::TALENT => $resource->accountCategory() === AccountCategory::AGENCY,
+            AccountCategory::AGENCY => $resource->accountCategory() === AccountCategory::TALENT,
+            default => false,
         };
     }
 }

--- a/src/Identity/Application/EventHandler/AffiliationRequestedHandler.php
+++ b/src/Identity/Application/EventHandler/AffiliationRequestedHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\EventHandler;
+
+use Source\Account\Affiliation\Domain\Event\AffiliationRequested;
+use Source\Identity\Application\Service\AffiliationRequestNotificationServiceInterface;
+
+readonly class AffiliationRequestedHandler
+{
+    public function __construct(
+        private AffiliationRequestNotificationServiceInterface $notificationService,
+    ) {
+    }
+
+    public function handle(AffiliationRequested $event): void
+    {
+        $this->notificationService->sendAffiliationRequestNotification($event->targetEmail);
+    }
+}

--- a/src/Identity/Application/Service/AffiliationRequestNotificationServiceInterface.php
+++ b/src/Identity/Application/Service/AffiliationRequestNotificationServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Application\Service;
+
+use Source\Shared\Domain\ValueObject\Email;
+
+interface AffiliationRequestNotificationServiceInterface
+{
+    public function sendAffiliationRequestNotification(Email $targetEmail): void;
+}

--- a/src/Identity/Infrastructure/Service/AffiliationRequestNotificationService.php
+++ b/src/Identity/Infrastructure/Service/AffiliationRequestNotificationService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Identity\Infrastructure\Service;
+
+use Application\Mail\AffiliationRequestMail;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Source\Identity\Application\Service\AffiliationRequestNotificationServiceInterface;
+use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
+use Source\Shared\Domain\ValueObject\Email;
+
+readonly class AffiliationRequestNotificationService implements AffiliationRequestNotificationServiceInterface
+{
+    public function __construct(
+        private IdentityRepositoryInterface $identityRepository,
+        private string $frontendBaseUrl,
+    ) {
+    }
+
+    public function sendAffiliationRequestNotification(Email $targetEmail): void
+    {
+        $identity = $this->identityRepository->findByEmail($targetEmail);
+        if ($identity === null) {
+            return;
+        }
+
+        $send = fn (): mixed => Mail::to((string) $targetEmail)->send(new AffiliationRequestMail(
+            $this->buildAffiliationUrl(),
+            $identity->language(),
+        ));
+
+        if (DB::transactionLevel() > 0) {
+            DB::afterCommit($send);
+
+            return;
+        }
+
+        $send();
+    }
+
+    private function buildAffiliationUrl(): string
+    {
+        return rtrim($this->frontendBaseUrl, '/') . '/admin/account/affiliation';
+    }
+}

--- a/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationInputTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationInputTest.php
@@ -7,58 +7,46 @@ namespace Tests\Account\Affiliation\Application\UseCase\Command\RequestAffiliati
 use PHPUnit\Framework\TestCase;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInput;
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Monetization\Shared\ValueObject\Percentage;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 
 class RequestAffiliationInputTest extends TestCase
 {
-    /**
-     * 正常系: インスタンスが正しく作成できること
-     *
-     * @return void
-     */
     public function test__construct(): void
     {
-        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $requestedBy = $agencyAccountIdentifier;
+        $principal = new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+        );
+        $targetEmail = new Email('target@example.com');
         $terms = new AffiliationTerms(new Percentage(30), 'Contract notes');
 
-        $input = new RequestAffiliationInput(
-            $agencyAccountIdentifier,
-            $talentAccountIdentifier,
-            $requestedBy,
-            $terms,
-        );
+        $input = new RequestAffiliationInput($principal, $targetEmail, $terms);
 
-        $this->assertSame($agencyAccountIdentifier, $input->agencyAccountIdentifier());
-        $this->assertSame($talentAccountIdentifier, $input->talentAccountIdentifier());
-        $this->assertSame($requestedBy, $input->requestedBy());
+        $this->assertSame($principal, $input->principal());
+        $this->assertSame($targetEmail, $input->targetEmail());
         $this->assertSame($terms, $input->terms());
     }
 
-    /**
-     * 正常系: termsがnullでもインスタンスが正しく作成できること
-     *
-     * @return void
-     */
     public function test__constructWithNullTerms(): void
     {
-        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $requestedBy = $agencyAccountIdentifier;
-
-        $input = new RequestAffiliationInput(
-            $agencyAccountIdentifier,
-            $talentAccountIdentifier,
-            $requestedBy,
-            null,
+        $principal = new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            new AccountIdentifier(StrTestHelper::generateUuid()),
         );
+        $targetEmail = new Email('target@example.com');
 
-        $this->assertSame($agencyAccountIdentifier, $input->agencyAccountIdentifier());
-        $this->assertSame($talentAccountIdentifier, $input->talentAccountIdentifier());
-        $this->assertSame($requestedBy, $input->requestedBy());
+        $input = new RequestAffiliationInput($principal, $targetEmail, null);
+
+        $this->assertSame($principal, $input->principal());
+        $this->assertSame($targetEmail, $input->targetEmail());
         $this->assertNull($input->terms());
     }
 }

--- a/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationTest.php
@@ -6,7 +6,6 @@ namespace Tests\Account\Affiliation\Application\UseCase\Command\RequestAffiliati
 
 use DateTimeImmutable;
 use Mockery;
-use Source\Account\Account\Application\Exception\AccountNotFoundException;
 use Source\Account\Account\Domain\Entity\Account;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Account\Domain\ValueObject\AccountDocuments;
@@ -15,331 +14,262 @@ use Source\Account\Account\Domain\ValueObject\AccountStatus;
 use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Account\Domain\ValueObject\DeletionReadinessChecklist;
 use Source\Account\Affiliation\Application\Exception\AffiliationAlreadyExistsException;
-use Source\Account\Affiliation\Application\Exception\InvalidAccountCategoryException;
+use Source\Account\Affiliation\Application\Exception\DisallowedAffiliationOperationException;
+use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliation;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInput;
-use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInterface;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationOutput;
 use Source\Account\Affiliation\Domain\Entity\Affiliation;
+use Source\Account\Affiliation\Domain\Event\AffiliationRequested;
 use Source\Account\Affiliation\Domain\Factory\AffiliationFactoryInterface;
 use Source\Account\Affiliation\Domain\Repository\AffiliationRepositoryInterface;
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Monetization\Shared\ValueObject\Percentage;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
 class RequestAffiliationTest extends TestCase
 {
-    /**
-     * 正常系: 正しくアフィリエーションを作成できること
-     */
-    public function testProcess(): void
+    public function testProcessFromTalentToAgency(): void
     {
-        $testData = $this->createTestData();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->agencyAccountIdentifier)
-            ->once()
-            ->andReturn($testData->agencyAccount);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->talentAccountIdentifier)
-            ->once()
-            ->andReturn($testData->talentAccount);
-
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationRepository->shouldReceive('existsActiveAffiliation')
-            ->with($testData->agencyAccountIdentifier, $testData->talentAccountIdentifier)
-            ->once()
-            ->andReturnFalse();
-        $affiliationRepository->shouldReceive('save')
-            ->once()
-            ->with($testData->affiliation);
-
-        $affiliationFactory = Mockery::mock(AffiliationFactoryInterface::class);
-        $affiliationFactory->shouldReceive('create')
-            ->once()
-            ->with(
-                $testData->agencyAccountIdentifier,
-                $testData->talentAccountIdentifier,
-                $testData->requestedBy,
-                $testData->terms,
-            )
-            ->andReturn($testData->affiliation);
-
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(AffiliationRepositoryInterface::class, $affiliationRepository);
-        $this->app->instance(AffiliationFactoryInterface::class, $affiliationFactory);
-
-        $useCase = $this->app->make(RequestAffiliationInterface::class);
+        $data = $this->createTestData(AccountCategory::TALENT);
+        $useCase = $this->createUseCase($data);
 
         $output = new RequestAffiliationOutput();
+        $useCase->process($data->input, $output);
 
-        $useCase->process($testData->input, $output);
-
-        $this->assertSame((string) $testData->affiliationIdentifier, $output->toArray()['affiliationIdentifier']);
-        $this->assertSame((string) $testData->agencyAccountIdentifier, $output->toArray()['agencyAccountIdentifier']);
-        $this->assertSame((string) $testData->talentAccountIdentifier, $output->toArray()['talentAccountIdentifier']);
+        $this->assertSame((string) $data->affiliationIdentifier, $output->toArray()['affiliationIdentifier']);
+        $this->assertSame((string) $data->agencyAccountIdentifier, $output->toArray()['agencyAccountIdentifier']);
+        $this->assertSame((string) $data->talentAccountIdentifier, $output->toArray()['talentAccountIdentifier']);
     }
 
-    /**
-     * 異常系: Agency Accountが存在しない場合、例外がスローされること
-     */
-    public function testThrowsWhenAgencyAccountNotFound(): void
+    public function testProcessFromAgencyToTalent(): void
     {
-        $testData = $this->createTestData();
+        $data = $this->createTestData(AccountCategory::AGENCY);
+        $useCase = $this->createUseCase($data);
 
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->agencyAccountIdentifier)
-            ->once()
-            ->andReturnNull();
+        $output = new RequestAffiliationOutput();
+        $useCase->process($data->input, $output);
 
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationFactory = Mockery::mock(AffiliationFactoryInterface::class);
-
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(AffiliationRepositoryInterface::class, $affiliationRepository);
-        $this->app->instance(AffiliationFactoryInterface::class, $affiliationFactory);
-
-        $useCase = $this->app->make(RequestAffiliationInterface::class);
-
-        $this->expectException(AccountNotFoundException::class);
-        $this->expectExceptionMessage('Agency account not found.');
-
-        $useCase->process($testData->input, new RequestAffiliationOutput());
+        $this->assertSame((string) $data->affiliationIdentifier, $output->toArray()['affiliationIdentifier']);
     }
 
-    /**
-     * 異常系: Talent Accountが存在しない場合、例外がスローされること
-     */
-    public function testThrowsWhenTalentAccountNotFound(): void
+    public function testThrowsWhenRequestingPrincipalLacksPolicy(): void
     {
-        $testData = $this->createTestData();
+        $data = $this->createTestData(AccountCategory::TALENT, requesterAllowed: false);
+        $useCase = $this->createUseCase($data);
 
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->agencyAccountIdentifier)
-            ->once()
-            ->andReturn($testData->agencyAccount);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->talentAccountIdentifier)
-            ->once()
-            ->andReturnNull();
-
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationFactory = Mockery::mock(AffiliationFactoryInterface::class);
-
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(AffiliationRepositoryInterface::class, $affiliationRepository);
-        $this->app->instance(AffiliationFactoryInterface::class, $affiliationFactory);
-
-        $useCase = $this->app->make(RequestAffiliationInterface::class);
-
-        $this->expectException(AccountNotFoundException::class);
-        $this->expectExceptionMessage('Talent account not found.');
-
-        $useCase->process($testData->input, new RequestAffiliationOutput());
+        $this->expectException(DisallowedAffiliationOperationException::class);
+        $useCase->process($data->input, new RequestAffiliationOutput());
     }
 
-    /**
-     * 異常系: Agency AccountのカテゴリがAGENCYでない場合、例外がスローされること
-     */
-    public function testThrowsWhenAgencyAccountHasInvalidCategory(): void
+    public function testThrowsWhenRequestingAccountIsGeneral(): void
     {
-        $testData = $this->createTestData();
+        $data = $this->createTestData(AccountCategory::GENERAL);
+        $useCase = $this->createUseCase($data);
 
-        $invalidAgencyAccount = new Account(
-            $testData->agencyAccountIdentifier,
-            new Email('agency@test.com'),
-            AccountType::CORPORATION,
-            new AccountName('Invalid Agency'),
-            AccountStatus::ACTIVE,
-            AccountCategory::GENERAL,
-            DeletionReadinessChecklist::ready(),
-            new AccountDocuments(),
-        );
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->agencyAccountIdentifier)
-            ->once()
-            ->andReturn($invalidAgencyAccount);
-
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationFactory = Mockery::mock(AffiliationFactoryInterface::class);
-
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(AffiliationRepositoryInterface::class, $affiliationRepository);
-        $this->app->instance(AffiliationFactoryInterface::class, $affiliationFactory);
-
-        $useCase = $this->app->make(RequestAffiliationInterface::class);
-
-        $this->expectException(InvalidAccountCategoryException::class);
-        $this->expectExceptionMessage('Agency account must have agency category.');
-
-        $useCase->process($testData->input, new RequestAffiliationOutput());
+        $this->expectException(DisallowedAffiliationOperationException::class);
+        $useCase->process($data->input, new RequestAffiliationOutput());
     }
 
-    /**
-     * 異常系: Talent AccountのカテゴリがTALENTでない場合、例外がスローされること
-     */
-    public function testThrowsWhenTalentAccountHasInvalidCategory(): void
+    public function testTargetResolutionFailuresUseSameBusinessException(): void
     {
-        $testData = $this->createTestData();
+        foreach (['missing', 'category', 'policy'] as $failure) {
+            $data = $this->createTestData(AccountCategory::TALENT, targetFailure: $failure);
+            $useCase = $this->createUseCase($data);
 
-        $invalidTalentAccount = new Account(
-            $testData->talentAccountIdentifier,
-            new Email('talent@test.com'),
-            AccountType::INDIVIDUAL,
-            new AccountName('Invalid Talent'),
-            AccountStatus::ACTIVE,
-            AccountCategory::GENERAL,
-            DeletionReadinessChecklist::ready(),
-            new AccountDocuments(),
-        );
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->agencyAccountIdentifier)
-            ->once()
-            ->andReturn($testData->agencyAccount);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->talentAccountIdentifier)
-            ->once()
-            ->andReturn($invalidTalentAccount);
-
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationFactory = Mockery::mock(AffiliationFactoryInterface::class);
-
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(AffiliationRepositoryInterface::class, $affiliationRepository);
-        $this->app->instance(AffiliationFactoryInterface::class, $affiliationFactory);
-
-        $useCase = $this->app->make(RequestAffiliationInterface::class);
-
-        $this->expectException(InvalidAccountCategoryException::class);
-        $this->expectExceptionMessage('Talent account must have talent category.');
-
-        $useCase->process($testData->input, new RequestAffiliationOutput());
+            try {
+                $useCase->process($data->input, new RequestAffiliationOutput());
+                $this->fail('Expected exception was not thrown.');
+            } catch (DisallowedAffiliationOperationException $e) {
+                $this->assertSame('Affiliation request target is not allowed.', $e->getMessage());
+            }
+        }
     }
 
-    /**
-     * 異常系: 既にアクティブなアフィリエーションが存在する場合、例外がスローされること
-     */
     public function testThrowsWhenActiveAffiliationAlreadyExists(): void
     {
-        $testData = $this->createTestData();
-
-        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->agencyAccountIdentifier)
-            ->once()
-            ->andReturn($testData->agencyAccount);
-        $accountRepository->shouldReceive('findById')
-            ->with($testData->talentAccountIdentifier)
-            ->once()
-            ->andReturn($testData->talentAccount);
-
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationRepository->shouldReceive('existsActiveAffiliation')
-            ->with($testData->agencyAccountIdentifier, $testData->talentAccountIdentifier)
-            ->once()
-            ->andReturnTrue();
-
-        $affiliationFactory = Mockery::mock(AffiliationFactoryInterface::class);
-
-        $this->app->instance(AccountRepositoryInterface::class, $accountRepository);
-        $this->app->instance(AffiliationRepositoryInterface::class, $affiliationRepository);
-        $this->app->instance(AffiliationFactoryInterface::class, $affiliationFactory);
-
-        $useCase = $this->app->make(RequestAffiliationInterface::class);
+        $data = $this->createTestData(AccountCategory::TALENT, activeExists: true);
+        $useCase = $this->createUseCase($data);
 
         $this->expectException(AffiliationAlreadyExistsException::class);
-        $this->expectExceptionMessage('An active affiliation already exists between these accounts.');
-
-        $useCase->process($testData->input, new RequestAffiliationOutput());
+        $useCase->process($data->input, new RequestAffiliationOutput());
     }
 
-    private function createTestData(): RequestAffiliationTestData
+    private function createUseCase(RequestAffiliationTestData $data): RequestAffiliation
     {
-        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
+        $accountRepository->shouldReceive('findById')->with($data->requestingAccountIdentifier)->andReturn($data->requestingAccount);
+        $accountRepository->shouldReceive('findByEmail')->with($data->targetEmail)->andReturn($data->targetAccount);
+
+        $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
+        if ($data->expectTargetPrincipalLookup) {
+            $principalRepository->shouldReceive('findByEmailAndAccountIdentifier')
+                ->with($data->targetEmail, $data->targetAccountIdentifier)
+                ->andReturn($data->targetPrincipal);
+        }
+
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')
+            ->with(
+                $data->requestingPrincipal,
+                Action::AFFILIATION_REQUEST_CREATE,
+                Mockery::on(static fn (Resource $resource): bool => $resource->accountIdentifier() === $data->requestingAccountIdentifier
+                    && $resource->accountCategory() === $data->requestingAccount->accountCategory()
+                    && $resource->affiliationRequestingAccountCategory() === null)
+            )
+            ->andReturn($data->requesterAllowed);
+        if ($data->expectTargetPolicyEvaluation) {
+            $policyEvaluator->shouldReceive('evaluate')
+                ->with(
+                    $data->targetPrincipal,
+                    Action::AFFILIATION_REQUEST_RECEIVE,
+                    Mockery::on(static fn (Resource $resource): bool => $data->targetAccount !== null
+                        && $resource->accountIdentifier() === $data->targetAccountIdentifier
+                        && $resource->accountCategory() === $data->targetAccount->accountCategory()
+                        && $resource->affiliationRequestingAccountCategory() === $data->requestingAccount->accountCategory())
+                )
+                ->andReturn($data->targetAllowed);
+        }
+
+        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
+        if ($data->expectAffiliationLookup) {
+            $affiliationRepository->shouldReceive('existsActiveAffiliation')
+                ->with($data->agencyAccountIdentifier, $data->talentAccountIdentifier)
+                ->andReturn($data->activeExists);
+        }
+        if ($data->expectSave) {
+            $affiliationRepository->shouldReceive('save')->once()->with($data->affiliation);
+        }
+
+        $affiliationFactory = Mockery::mock(AffiliationFactoryInterface::class);
+        if ($data->expectSave) {
+            $affiliationFactory->shouldReceive('create')
+                ->with($data->agencyAccountIdentifier, $data->talentAccountIdentifier, $data->requestingAccountIdentifier, $data->terms)
+                ->andReturn($data->affiliation);
+        }
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        if ($data->expectSave) {
+            $eventDispatcher->shouldReceive('dispatch')
+                ->once()
+                ->with(Mockery::on(static fn (AffiliationRequested $event): bool => $event->affiliationIdentifier === $data->affiliationIdentifier
+                    && $event->targetEmail === $data->targetEmail
+                    && $event->agencyAccountIdentifier === $data->agencyAccountIdentifier
+                    && $event->talentAccountIdentifier === $data->talentAccountIdentifier
+                    && $event->requestedBy === $data->requestingAccountIdentifier));
+        } else {
+            $eventDispatcher->shouldNotReceive('dispatch');
+        }
+
+        /** @var AccountRepositoryInterface $accountRepository */
+        /** @var PrincipalRepositoryInterface $principalRepository */
+        /** @var PolicyEvaluatorInterface $policyEvaluator */
+        /** @var AffiliationRepositoryInterface $affiliationRepository */
+        /** @var AffiliationFactoryInterface $affiliationFactory */
+        /** @var EventDispatcherInterface $eventDispatcher */
+        return new RequestAffiliation(
+            $accountRepository,
+            $principalRepository,
+            $policyEvaluator,
+            $affiliationRepository,
+            $affiliationFactory,
+            $eventDispatcher,
+        );
+    }
+
+    private function createTestData(AccountCategory $requestingCategory, bool $requesterAllowed = true, ?string $targetFailure = null, bool $activeExists = false): RequestAffiliationTestData
+    {
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $requestedBy = $agencyAccountIdentifier;
+        $requestingAccountIdentifier = $requestingCategory === AccountCategory::AGENCY ? $agencyAccountIdentifier : $talentAccountIdentifier;
+        $targetAccountIdentifier = $requestingCategory === AccountCategory::AGENCY ? $talentAccountIdentifier : $agencyAccountIdentifier;
+        $targetEmail = new Email('target@example.com');
+        $requestingPrincipal = new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), new IdentityIdentifier(StrTestHelper::generateUuid()), $requestingAccountIdentifier);
+        $targetPrincipal = new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), new IdentityIdentifier(StrTestHelper::generateUuid()), $targetAccountIdentifier);
+        $requestingAccount = $this->account($requestingAccountIdentifier, $requestingCategory, 'requester@example.com');
+        $expectedTargetCategory = $requestingCategory === AccountCategory::AGENCY ? AccountCategory::TALENT : AccountCategory::AGENCY;
+        $targetAccount = $targetFailure === 'missing' ? null : $this->account($targetAccountIdentifier, $targetFailure === 'category' ? AccountCategory::GENERAL : $expectedTargetCategory, (string) $targetEmail);
         $terms = new AffiliationTerms(new Percentage(30), 'Contract notes');
-
-        $agencyAccount = new Account(
-            $agencyAccountIdentifier,
-            new Email('agency@test.com'),
-            AccountType::CORPORATION,
-            new AccountName('Test Agency'),
-            AccountStatus::ACTIVE,
-            AccountCategory::AGENCY,
-            DeletionReadinessChecklist::ready(),
-            new AccountDocuments(),
-        );
-
-        $talentAccount = new Account(
-            $talentAccountIdentifier,
-            new Email('talent@test.com'),
-            AccountType::INDIVIDUAL,
-            new AccountName('Test Talent'),
-            AccountStatus::ACTIVE,
-            AccountCategory::TALENT,
-            DeletionReadinessChecklist::ready(),
-            new AccountDocuments(),
-        );
-
-        $affiliation = new Affiliation(
-            $affiliationIdentifier,
-            $agencyAccountIdentifier,
-            $talentAccountIdentifier,
-            $requestedBy,
-            AffiliationStatus::PENDING,
-            $terms,
-            new DateTimeImmutable(),
-            null,
-            null,
-        );
-
-        $input = new RequestAffiliationInput(
-            $agencyAccountIdentifier,
-            $talentAccountIdentifier,
-            $requestedBy,
-            $terms,
-        );
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $affiliation = new Affiliation($affiliationIdentifier, $agencyAccountIdentifier, $talentAccountIdentifier, $requestingAccountIdentifier, AffiliationStatus::PENDING, $terms, new DateTimeImmutable(), null, null);
+        $requesterAllowed = $requesterAllowed && $requestingCategory !== AccountCategory::GENERAL;
+        $targetAllowed = $targetFailure !== 'policy' && $targetAccount !== null && $this->isAllowedAffiliationRequestPair($requestingCategory, $targetAccount->accountCategory());
 
         return new RequestAffiliationTestData(
             $affiliationIdentifier,
             $agencyAccountIdentifier,
             $talentAccountIdentifier,
-            $requestedBy,
+            $requestingAccountIdentifier,
+            $targetAccountIdentifier,
+            $requestingPrincipal,
+            $targetPrincipal,
+            $targetEmail,
             $terms,
-            $agencyAccount,
-            $talentAccount,
+            $requestingAccount,
+            $targetAccount,
             $affiliation,
-            $input,
+            new RequestAffiliationInput($requestingPrincipal, $targetEmail, $terms),
+            $requesterAllowed,
+            $targetAllowed,
+            $activeExists,
+            $requesterAllowed && $targetAccount !== null,
+            $requesterAllowed && $targetAccount !== null,
+            $requesterAllowed && $targetAccount !== null && $targetAllowed,
+            $requesterAllowed && $targetAccount !== null && $targetAllowed && ! $activeExists,
         );
+    }
+
+    private function isAllowedAffiliationRequestPair(AccountCategory $requestingCategory, AccountCategory $targetCategory): bool
+    {
+        return match ($requestingCategory) {
+            AccountCategory::TALENT => $targetCategory === AccountCategory::AGENCY,
+            AccountCategory::AGENCY => $targetCategory === AccountCategory::TALENT,
+            default => false,
+        };
+    }
+
+    private function account(AccountIdentifier $identifier, AccountCategory $category, string $email): Account
+    {
+        return new Account($identifier, new Email($email), AccountType::CORPORATION, new AccountName('Test Account'), AccountStatus::ACTIVE, $category, DeletionReadinessChecklist::ready(), new AccountDocuments());
     }
 }
 
 readonly class RequestAffiliationTestData
 {
     public function __construct(
-        public AffiliationIdentifier   $affiliationIdentifier,
-        public AccountIdentifier       $agencyAccountIdentifier,
-        public AccountIdentifier       $talentAccountIdentifier,
-        public AccountIdentifier       $requestedBy,
-        public ?AffiliationTerms       $terms,
-        public Account                 $agencyAccount,
-        public Account                 $talentAccount,
-        public Affiliation             $affiliation,
+        public AffiliationIdentifier $affiliationIdentifier,
+        public AccountIdentifier $agencyAccountIdentifier,
+        public AccountIdentifier $talentAccountIdentifier,
+        public AccountIdentifier $requestingAccountIdentifier,
+        public AccountIdentifier $targetAccountIdentifier,
+        public Principal $requestingPrincipal,
+        public Principal $targetPrincipal,
+        public Email $targetEmail,
+        public ?AffiliationTerms $terms,
+        public Account $requestingAccount,
+        public ?Account $targetAccount,
+        public Affiliation $affiliation,
         public RequestAffiliationInput $input,
+        public bool $requesterAllowed,
+        public bool $targetAllowed,
+        public bool $activeExists,
+        public bool $expectTargetPrincipalLookup,
+        public bool $expectTargetPolicyEvaluation,
+        public bool $expectAffiliationLookup,
+        public bool $expectSave,
     ) {
     }
 }

--- a/tests/Account/Affiliation/Http/Action/Command/RequestAffiliation/RequestAffiliationActionTest.php
+++ b/tests/Account/Affiliation/Http/Action/Command/RequestAffiliation/RequestAffiliationActionTest.php
@@ -6,20 +6,26 @@ namespace Tests\Account\Affiliation\Http\Action\Command\RequestAffiliation;
 
 use Application\Http\Action\Account\Affiliation\Command\RequestAffiliation\RequestAffiliationAction;
 use Application\Http\Action\Account\Affiliation\Command\RequestAffiliation\RequestAffiliationRequest;
+use Application\Http\Context\AccountContext;
 use DateTimeImmutable;
 use Illuminate\Support\Facades\DB;
 use Mockery;
 use Psr\Log\LoggerInterface;
+use Source\Account\Account\Domain\ValueObject\AccountType;
 use Source\Account\Affiliation\Application\Exception\AffiliationAlreadyExistsException;
+use Source\Account\Affiliation\Application\Exception\DisallowedAffiliationOperationException;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInput;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInterface;
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationOutput;
 use Source\Account\Affiliation\Domain\Entity\Affiliation;
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
 use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
+use Source\Account\Principal\Domain\Entity\Principal;
 use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Monetization\Shared\ValueObject\Percentage;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
@@ -29,11 +35,10 @@ class RequestAffiliationActionTest extends TestCase
     public function testInvokeReturnsCreatedResponse(): void
     {
         $affiliation = $this->createAffiliation();
+        $principal = $this->principal($affiliation->requestedBy());
         /** @var RequestAffiliationRequest&Mockery\MockInterface $request */
         $request = Mockery::mock(RequestAffiliationRequest::class);
-        $request->shouldReceive('agencyAccountIdentifier')->andReturn((string) $affiliation->agencyAccountIdentifier());
-        $request->shouldReceive('talentAccountIdentifier')->andReturn((string) $affiliation->talentAccountIdentifier());
-        $request->shouldReceive('requestedBy')->andReturn((string) $affiliation->requestedBy());
+        $request->shouldReceive('targetEmail')->andReturn('target@example.com');
         $request->shouldReceive('terms')->andReturn([
             'revenueSharePercentage' => 30,
             'contractNotes' => 'Contract notes',
@@ -48,7 +53,9 @@ class RequestAffiliationActionTest extends TestCase
         $useCase->shouldReceive('process')
             ->once()
             ->with(
-                Mockery::type(RequestAffiliationInput::class),
+                Mockery::on(fn ($input) => $input instanceof RequestAffiliationInput
+                    && $input->principal() === $principal
+                    && (string) $input->targetEmail() === 'target@example.com'),
                 Mockery::on(function ($output) use ($affiliation): bool {
                     if (! $output instanceof RequestAffiliationOutput) {
                         return false;
@@ -64,7 +71,7 @@ class RequestAffiliationActionTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('error');
 
-        $action = new RequestAffiliationAction($useCase, $logger);
+        $action = new RequestAffiliationAction($useCase, new AccountContext($principal, AccountType::CORPORATION), $logger);
 
         $response = $action($request);
         $payload = $response->getData(true);
@@ -74,13 +81,43 @@ class RequestAffiliationActionTest extends TestCase
         $this->assertSame(AffiliationStatus::PENDING->value, $payload['status']);
     }
 
-    public function testInvokeReturnsConflictResponseWhenAffiliationAlreadyExists(): void
+    public function testInvokeReturnsGenericUnprocessableResponseWhenTargetIsDisallowed(): void
     {
+        $principal = $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()));
         /** @var RequestAffiliationRequest&Mockery\MockInterface $request */
         $request = Mockery::mock(RequestAffiliationRequest::class);
-        $request->shouldReceive('agencyAccountIdentifier')->andReturn(StrTestHelper::generateUuid());
-        $request->shouldReceive('talentAccountIdentifier')->andReturn(StrTestHelper::generateUuid());
-        $request->shouldReceive('requestedBy')->andReturn(StrTestHelper::generateUuid());
+        $request->shouldReceive('targetEmail')->andReturn('target@example.com');
+        $request->shouldReceive('terms')->andReturn(null);
+        $request->shouldReceive('language')->andReturn('en');
+
+        DB::shouldReceive('beginTransaction')->once();
+        DB::shouldReceive('rollBack')->once();
+
+        /** @var RequestAffiliationInterface&Mockery\MockInterface $useCase */
+        $useCase = Mockery::mock(RequestAffiliationInterface::class);
+        $useCase->shouldReceive('process')
+            ->once()
+            ->andThrow(new DisallowedAffiliationOperationException('Affiliation request target is not allowed.'));
+
+        /** @var LoggerInterface&Mockery\MockInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('error')->once();
+
+        $action = new RequestAffiliationAction($useCase, new AccountContext($principal, AccountType::CORPORATION), $logger);
+
+        $response = $action($request);
+        $payload = $response->getData(true);
+
+        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame(error_message('disallowed_affiliation_operation', 'en'), $payload['detail']);
+    }
+
+    public function testInvokeReturnsConflictResponseWhenAffiliationAlreadyExists(): void
+    {
+        $principal = $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()));
+        /** @var RequestAffiliationRequest&Mockery\MockInterface $request */
+        $request = Mockery::mock(RequestAffiliationRequest::class);
+        $request->shouldReceive('targetEmail')->andReturn('target@example.com');
         $request->shouldReceive('terms')->andReturn(null);
         $request->shouldReceive('language')->andReturn('en');
 
@@ -97,7 +134,7 @@ class RequestAffiliationActionTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('error')->once();
 
-        $action = new RequestAffiliationAction($useCase, $logger);
+        $action = new RequestAffiliationAction($useCase, new AccountContext($principal, AccountType::CORPORATION), $logger);
 
         $response = $action($request);
         $payload = $response->getData(true);
@@ -122,6 +159,15 @@ class RequestAffiliationActionTest extends TestCase
             new DateTimeImmutable('-1 day'),
             null,
             null,
+        );
+    }
+
+    private function principal(AccountIdentifier $accountIdentifier): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            $accountIdentifier,
         );
     }
 }

--- a/tests/Account/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
+++ b/tests/Account/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
@@ -26,6 +26,7 @@ use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Principal\Domain\ValueObject\ResourceType;
 use Source\Account\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Account\Principal\Domain\ValueObject\Statement;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Account\Shared\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
@@ -177,6 +178,29 @@ class PolicyEvaluatorTest extends TestCase
         );
     }
 
+    public function testEvaluateAllowsWhenConditionMatchesResourceAccountCategory(): void
+    {
+        $this->assertTrue($this->evaluateInvitationWithAccountCategoryCondition(AccountCategory::TALENT));
+    }
+
+    public function testEvaluateDeniesWhenConditionDoesNotMatchResourceAccountCategory(): void
+    {
+        $this->assertFalse($this->evaluateInvitationWithAccountCategoryCondition(AccountCategory::GENERAL));
+    }
+
+    public function testEvaluateAllowsWhenAffiliationRequestPairIsAllowed(): void
+    {
+        $this->assertTrue($this->evaluateAffiliationRequestReceive(AccountCategory::TALENT, AccountCategory::AGENCY));
+        $this->assertTrue($this->evaluateAffiliationRequestReceive(AccountCategory::AGENCY, AccountCategory::TALENT));
+    }
+
+    public function testEvaluateDeniesWhenAffiliationRequestPairIsNotAllowed(): void
+    {
+        $this->assertFalse($this->evaluateAffiliationRequestReceive(AccountCategory::TALENT, AccountCategory::TALENT));
+        $this->assertFalse($this->evaluateAffiliationRequestReceive(AccountCategory::AGENCY, AccountCategory::AGENCY));
+        $this->assertFalse($this->evaluateAffiliationRequestReceive(AccountCategory::GENERAL, AccountCategory::AGENCY));
+    }
+
     /**
      * @param Action[] $actions
      */
@@ -240,6 +264,84 @@ class PolicyEvaluatorTest extends TestCase
         );
     }
 
+    private function evaluateInvitationWithAccountCategoryCondition(AccountCategory $accountCategory): bool
+    {
+        return $this->evaluateWithCondition(
+            Action::INVITE_MEMBER,
+            new Condition([
+                new ConditionClause(
+                    ConditionKey::RESOURCE_ACCOUNT_CATEGORY,
+                    ConditionOperator::IN,
+                    [
+                        AccountCategory::TALENT->value,
+                        AccountCategory::AGENCY->value,
+                    ],
+                ),
+            ]),
+            Resource::account(new AccountIdentifier(StrTestHelper::generateUuid()), null, $accountCategory),
+        );
+    }
+
+    private function evaluateAffiliationRequestReceive(
+        AccountCategory $requestingCategory,
+        AccountCategory $targetCategory,
+    ): bool {
+        return $this->evaluateWithCondition(
+            Action::AFFILIATION_REQUEST_RECEIVE,
+            new Condition([
+                new ConditionClause(
+                    ConditionKey::AFFILIATION_REQUEST_PAIR_ALLOWED,
+                    ConditionOperator::EQUALS,
+                    true,
+                ),
+            ]),
+            Resource::account(
+                new AccountIdentifier(StrTestHelper::generateUuid()),
+                null,
+                $targetCategory,
+                $requestingCategory,
+            ),
+        );
+    }
+
+    private function evaluateWithCondition(Action $action, Condition $condition, Resource $resource): bool
+    {
+        $accountIdentifier = $resource->accountIdentifier();
+        $principal = $this->createPrincipal($accountIdentifier);
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        $principalGroup = $this->createPrincipalGroup($accountIdentifier, $principal->principalIdentifier(), $roleIdentifier);
+        $policy = $this->createPolicy('CONDITIONAL_POLICY', Effect::ALLOW, [$action], $condition);
+
+        /** @var PrincipalGroupRepositoryInterface&\Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findByAccountIdAndPrincipal')
+            ->once()
+            ->with($accountIdentifier, $principal->principalIdentifier())
+            ->andReturn([$principalGroup]);
+
+        /** @var PolicyRepositoryInterface&\Mockery\MockInterface $policyRepository */
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findByIds')
+            ->once()
+            ->with([$policy->policyIdentifier()])
+            ->andReturn([(string) $policy->policyIdentifier() => $policy]);
+
+        /** @var RoleRepositoryInterface&\Mockery\MockInterface $roleRepository */
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findByIds')
+            ->once()
+            ->with([$roleIdentifier])
+            ->andReturn([
+                (string) $roleIdentifier => new Role($roleIdentifier, Role::OWNER, [$policy->policyIdentifier()], true),
+            ]);
+
+        return $this->makePolicyEvaluator($principalGroupRepository, $roleRepository, $policyRepository)->evaluate(
+            $principal,
+            $action,
+            $resource,
+        );
+    }
+
     private function makePolicyEvaluator(
         PrincipalGroupRepositoryInterface $principalGroupRepository,
         RoleRepositoryInterface $roleRepository,
@@ -248,6 +350,7 @@ class PolicyEvaluatorTest extends TestCase
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(PolicyRepositoryInterface::class, $policyRepository);
+        $this->app->forgetInstance(PolicyEvaluatorInterface::class);
 
         return $this->app->make(PolicyEvaluatorInterface::class);
     }

--- a/tests/Identity/Application/EventHandler/AffiliationRequestedHandlerTest.php
+++ b/tests/Identity/Application/EventHandler/AffiliationRequestedHandlerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Application\EventHandler;
+
+use Mockery;
+use Source\Account\Affiliation\Domain\Event\AffiliationRequested;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Identity\Application\EventHandler\AffiliationRequestedHandler;
+use Source\Identity\Application\Service\AffiliationRequestNotificationServiceInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\Email;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AffiliationRequestedHandlerTest extends TestCase
+{
+    public function testHandleSendsAffiliationRequestNotification(): void
+    {
+        $targetEmail = new Email('target@example.com');
+        /** @var AffiliationRequestNotificationServiceInterface&\Mockery\MockInterface $service */
+        $service = Mockery::mock(AffiliationRequestNotificationServiceInterface::class);
+        $service->shouldReceive('sendAffiliationRequestNotification')->once()->with($targetEmail);
+
+        $handler = new AffiliationRequestedHandler($service);
+        $handler->handle(new AffiliationRequested(
+            new AffiliationIdentifier(StrTestHelper::generateUuid()),
+            $targetEmail,
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+        ));
+    }
+}

--- a/tests/Identity/Infrastructure/Service/AffiliationRequestNotificationServiceTest.php
+++ b/tests/Identity/Infrastructure/Service/AffiliationRequestNotificationServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Identity\Infrastructure\Service;
+
+use Application\Mail\AffiliationRequestMail;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Source\Identity\Application\Service\AffiliationRequestNotificationServiceInterface;
+use Source\Identity\Domain\Entity\Identity;
+use Source\Identity\Domain\Repository\IdentityRepositoryInterface;
+use Source\Identity\Domain\ValueObject\HashedPassword;
+use Source\Identity\Domain\ValueObject\IdentityName;
+use Source\Identity\Infrastructure\Service\AffiliationRequestNotificationService;
+use Source\Shared\Domain\ValueObject\Email;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Shared\Domain\ValueObject\Language;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AffiliationRequestNotificationServiceTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['view']->addLocation(dirname(__DIR__, 4) . '/resources/views');
+    }
+
+    public function test__construct(): void
+    {
+        $service = $this->app->make(AffiliationRequestNotificationServiceInterface::class);
+
+        $this->assertInstanceOf(AffiliationRequestNotificationService::class, $service);
+    }
+
+    public function testSendAffiliationRequestNotification(): void
+    {
+        Mail::fake();
+        $email = new Email('target@example.com');
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $identityRepository */
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findByEmail')->once()->with($email)->andReturn($this->identity($email, Language::JAPANESE));
+
+        $service = new AffiliationRequestNotificationService($identityRepository, 'http://localhost:3000');
+        $service->sendAffiliationRequestNotification($email);
+
+        Mail::assertSent(AffiliationRequestMail::class, static fn (AffiliationRequestMail $mail): bool => $mail->hasTo((string) $email)
+            && $mail->language === Language::JAPANESE
+            && $mail->affiliationUrl === 'http://localhost:3000/admin/account/affiliation');
+    }
+
+    public function testSendAffiliationRequestNotificationDoesNothingWhenIdentityIsMissing(): void
+    {
+        Mail::fake();
+        $email = new Email('target@example.com');
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $identityRepository */
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findByEmail')->once()->with($email)->andReturn(null);
+
+        $service = new AffiliationRequestNotificationService($identityRepository, 'https://frontend.example.com');
+        $service->sendAffiliationRequestNotification($email);
+
+        Mail::assertNothingSent();
+    }
+
+    public function testMailBodyContainsAffiliationUrl(): void
+    {
+        Mail::fake();
+        $email = new Email('target@example.com');
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $identityRepository */
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findByEmail')->once()->with($email)->andReturn($this->identity($email, Language::ENGLISH));
+
+        $service = new AffiliationRequestNotificationService($identityRepository, 'https://frontend.example.com');
+        $service->sendAffiliationRequestNotification($email);
+
+        Mail::assertSent(AffiliationRequestMail::class, static fn (AffiliationRequestMail $mail): bool => str_contains($mail->affiliationUrl, '/admin/account/affiliation'));
+    }
+
+    public function testSendAffiliationRequestNotificationDefersUntilAfterCommitInTransaction(): void
+    {
+        Mail::fake();
+        $email = new Email('target@example.com');
+        /** @var IdentityRepositoryInterface&\Mockery\MockInterface $identityRepository */
+        $identityRepository = Mockery::mock(IdentityRepositoryInterface::class);
+        $identityRepository->shouldReceive('findByEmail')->once()->with($email)->andReturn($this->identity($email, Language::ENGLISH));
+
+        DB::shouldReceive('transactionLevel')->once()->andReturn(1);
+        DB::shouldReceive('afterCommit')->once()->with(Mockery::type('Closure'));
+
+        $service = new AffiliationRequestNotificationService($identityRepository, 'https://frontend.example.com');
+        $service->sendAffiliationRequestNotification($email);
+
+        Mail::assertNothingSent();
+    }
+
+    public function testMailBodyRendersHtmlForAllLanguages(): void
+    {
+        $affiliationUrl = 'https://frontend.example.com/admin/account/affiliation';
+
+        foreach (Language::cases() as $language) {
+            $html = (new AffiliationRequestMail($affiliationUrl, $language))->render();
+
+            $this->assertStringContainsString('<!DOCTYPE html>', $html);
+            $this->assertStringContainsString('<html lang="' . $language->value . '">', $html);
+            $this->assertStringContainsString('href="' . $affiliationUrl . '"', $html);
+            $this->assertStringContainsString($affiliationUrl, $html);
+        }
+    }
+
+    private function identity(Email $email, Language $language): Identity
+    {
+        return new Identity(new IdentityIdentifier(StrTestHelper::generateUuid()), new IdentityName('Target'), $email, $language, null, new HashedPassword(password_hash('password', PASSWORD_BCRYPT)), null);
+    }
+}

--- a/typespec/services/account-api/affiliation.tsp
+++ b/typespec/services/account-api/affiliation.tsp
@@ -5,12 +5,8 @@ namespace KPool.AccountApi;
 
 @doc("Request body for requesting an affiliation.")
 model RequestAffiliationRequestBody {
-  @doc("Agency account identifier.")
-  agencyAccountIdentifier: Uuid;
-  @doc("Talent account identifier.")
-  talentAccountIdentifier: Uuid;
-  @doc("Account identifier that requested the affiliation.")
-  requestedBy: Uuid;
+  @doc("Email address of the target account/principal that should receive the affiliation request.")
+  targetEmail: string;
   @doc("Optional contract terms.")
   terms?: AffiliationTermsSummary | null;
 }


### PR DESCRIPTION
## 📝 変更内容

- `POST /affiliations` の入力を `targetEmail` ベースへ変更し、現在の `AccountContext` の `Principal` からリクエスト元アカウントを解決するように変更しました。
- Affiliation リクエスト作成/受領用の `Action` を追加し、リクエスト元・相手先Principalの両方を `PolicyEvaluatorInterface` で認可するようにしました。
- 相手先メールアドレスから対象Account/Principalを解決し、未存在・カテゴリ不一致・相手Principal権限不足は同一の汎用エラーに寄せました。
- Affiliation作成後に `AffiliationRequested` domain event を発行し、after commit の Job で対象メールアドレスへ承認依頼メールを送信するようにしました。
- 承認依頼メール本文にフロントの `/admin/account/affiliation` への導線を含めました。
- TypeSpec / OpenAPI とユースケース・HTTP・メール送信のテストを更新/追加しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Affiliation リクエストで、フロントから agency/talent/requestedBy を直接指定する方式をやめ、ログイン中Principalと対象メールアドレスから安全にリクエスト元/相手先を決定するためです。
また、相手先メールアドレスに紐づくアカウントの存在有無・カテゴリ・権限有無がレスポンスから推測できないよう、相手先解決失敗時のフロント向けエラーを統一しました。

## 🧪 テスト

### テストの実行確認

- [x] `task openapi-generate` を実行し、OpenAPI生成が成功することを確認
- [x] `docker-compose run --rm --no-deps php ./vendor/bin/phpunit --no-coverage tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation tests/Account/Affiliation/Http/Action/Command/RequestAffiliation tests/Account/Affiliation/Infrastructure/Service/AffiliationRequestMailServiceTest.php tests/Account/Affiliation/Application/EventHandler/AffiliationRequestedHandlerTest.php tests/Jobs/SendAffiliationRequestMailJobTest.php` を実行し、18 tests / 62 assertions が成功
- [x] `docker-compose run --rm --no-deps php composer phpstan` を実行し、No errors を確認
- [x] `task cs-fix` を実行し、CS fixer が成功することを確認
- [x] `task check` を実行し、PHPStan と全 PHPUnit 3004 tests / 9481 assertions が成功
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- Affiliation リクエスト作成ユースケースで、タレント→事務所 / 事務所→タレントの正常系を確認しました。
- リクエスト元権限不足、generalカテゴリ、相手先未存在/カテゴリ不一致/権限不足の拒否を確認しました。
- 承認依頼メール送信Job/Service/EventHandlerを確認しました。

## 🔍 レビューのポイント

- `RequestAffiliation` が Ownerグループ直判定ではなく `PolicyEvaluatorInterface` に寄せられているか
- 相手先メールアドレスからの Account / Principal 解決失敗時に、外部へ詳細理由を露出していないか
- `AffiliationRequestedHandler` が `afterCommit()` でメール送信Jobをdispatchしており、メール送信失敗でAffiliation保存transactionをrollbackしない構成になっているか
- TypeSpec / OpenAPI の `targetEmail` 変更がHTTP Requestと一致しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #526

## ⚠️ 注意事項

- Owner/Admin ロールに Affiliation リクエスト作成/受領用ポリシーを付与するため、`AccountAuthorizationSeeder` を更新しています。
- 既存HTTP入力の `agencyAccountIdentifier` / `talentAccountIdentifier` / `requestedBy` は `targetEmail` に置き換わる破壊的変更です。
- 承認依頼URLのベースは `config('app.frontend_url')` / `FRONTEND_URL` を利用し、コード固定していません。
- プロジェクトレビュー用 skill `qa-review`, `test-review`, `security-review`, `architecture-review` はグローバル/リポジトリ内検索で見つからなかったため、同期の代替レビューを実施しました。
  - QA: Issue受け入れ条件に対し、入力変更・リクエスト元カテゴリ・双方向カテゴリ解決・汎用エラー・イベント/メール送信・重複チェック維持を差分とテストで確認しました。
  - Test: 追加/更新テスト、PHPStan、CS fixer、OpenAPI生成、全 `task check` を実行しました。
  - Security: 相手先未存在/カテゴリ不一致/権限不足が同一エラーになり、内部判定理由や内部IDをメール本文/レスポンスへ露出しないことを確認しました。
  - Architecture: Accountコンテキスト既存の `PolicyEvaluatorInterface` / `Action` / `Resource` パターンに寄せ、メール送信はdomain event + after commit Jobに分離されていることを確認しました。
- 未対応のレビュー指摘はありません。

## 📸 スクリーンショット・デモ

UI変更ではないため、スクリーンショットはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
