### PR TITLE
Affiliation成立時の動的Condition policyを検証

### DIFF
--- a/tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php
+++ b/tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php
@@ -28,10 +28,17 @@ use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Principal\Domain\Repository\RoleRepositoryInterface;
 use Source\Wiki\Principal\Domain\ValueObject\AffiliationGrantIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\AffiliationGrantType;
+use Source\Wiki\Principal\Domain\ValueObject\ConditionClause;
+use Source\Wiki\Principal\Domain\ValueObject\ConditionKey;
+use Source\Wiki\Principal\Domain\ValueObject\ConditionOperator;
+use Source\Wiki\Principal\Domain\ValueObject\ConditionValue;
 use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\Statement;
+use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -139,8 +146,30 @@ class AffiliationActivatedHandlerTest extends TestCase
         $policyFactory = Mockery::mock(PolicyFactoryInterface::class);
         $policyFactory
             ->shouldReceive('create')
-            ->twice()
-            ->andReturn($talentSidePolicy, $agencySidePolicy);
+            ->once()
+            ->with(
+                "Affiliation Policy - Agency {$agencyAccountIdentifier}",
+                Mockery::on(function (array $statements) use ($agencyAccountIdentifier): bool {
+                    $this->assertTalentSideStatements((string) $agencyAccountIdentifier, $statements);
+
+                    return true;
+                }),
+                false,
+            )
+            ->andReturn($talentSidePolicy);
+        $policyFactory
+            ->shouldReceive('create')
+            ->once()
+            ->with(
+                "Affiliation Policy - Talent {$talentAccountIdentifier}",
+                Mockery::on(function (array $statements): bool {
+                    $this->assertAgencySideStatements($statements);
+
+                    return true;
+                }),
+                false,
+            )
+            ->andReturn($agencySidePolicy);
 
         $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
         $policyRepository
@@ -452,8 +481,30 @@ class AffiliationActivatedHandlerTest extends TestCase
         $policyFactory = Mockery::mock(PolicyFactoryInterface::class);
         $policyFactory
             ->shouldReceive('create')
-            ->twice()
-            ->andReturn($talentSidePolicy, $agencySidePolicy);
+            ->once()
+            ->with(
+                "Affiliation Policy - Agency {$agencyAccountIdentifier}",
+                Mockery::on(function (array $statements) use ($agencyAccountIdentifier): bool {
+                    $this->assertTalentSideStatements((string) $agencyAccountIdentifier, $statements);
+
+                    return true;
+                }),
+                false,
+            )
+            ->andReturn($talentSidePolicy);
+        $policyFactory
+            ->shouldReceive('create')
+            ->once()
+            ->with(
+                "Affiliation Policy - Talent {$talentAccountIdentifier}",
+                Mockery::on(function (array $statements): bool {
+                    $this->assertAgencySideStatements($statements);
+
+                    return true;
+                }),
+                false,
+            )
+            ->andReturn($agencySidePolicy);
 
         $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
         $policyRepository
@@ -490,6 +541,75 @@ class AffiliationActivatedHandlerTest extends TestCase
         $handler = $this->app->make(AffiliationActivatedHandler::class);
 
         $handler->handle($event);
+    }
+
+    /**
+     * @param Statement[] $statements
+     */
+    private function assertAgencySideStatements(array $statements): void
+    {
+        $this->assertCount(1, $statements);
+        $this->assertStatement(
+            $statements[0],
+            ResourceType::TALENT,
+            [
+                new ConditionClause(
+                    ConditionKey::RESOURCE_TALENT_ID,
+                    ConditionOperator::IN,
+                    ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @param Statement[] $statements
+     */
+    private function assertTalentSideStatements(string $agencyId, array $statements): void
+    {
+        $this->assertCount(3, $statements);
+        $this->assertStatement(
+            $statements[0],
+            ResourceType::GROUP,
+            [
+                new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
+                new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_IDS),
+            ],
+        );
+        $this->assertStatement(
+            $statements[1],
+            ResourceType::SONG,
+            [
+                new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
+                new ConditionClause(ConditionKey::RESOURCE_GROUP_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_WIKI_GROUP_IDS),
+            ],
+        );
+        $this->assertStatement(
+            $statements[2],
+            ResourceType::SONG,
+            [
+                new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
+                new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_IDS),
+            ],
+        );
+    }
+
+    /**
+     * @param ConditionClause[] $expectedClauses
+     */
+    private function assertStatement(Statement $statement, ResourceType $resourceType, array $expectedClauses): void
+    {
+        $this->assertSame([Action::READ, Action::CREATE, Action::EDIT, Action::SUBMIT], $statement->actions());
+        $this->assertSame([$resourceType], $statement->resourceTypes());
+        $this->assertNotNull($statement->condition());
+        $actualClauses = $statement->condition()->clauses();
+        $this->assertCount(count($expectedClauses), $actualClauses);
+
+        foreach ($expectedClauses as $index => $expectedClause) {
+            $this->assertSame($expectedClause->key(), $actualClauses[$index]->key());
+            $this->assertSame($expectedClause->operator(), $actualClauses[$index]->operator());
+            $this->assertSame($expectedClause->value(), $actualClauses[$index]->value());
+        }
     }
 
     private function createPrincipal(AccountIdentifier $accountIdentifier): Principal


### PR DESCRIPTION
## 📝 変更内容

- `AffiliationActivatedHandlerTest` で、Affiliation 成立時に作成される policy statement の中身を検証するようにしました。
- Agency 側 policy が `ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS` を使い、成立時点の Talent Wiki ID に依存しないことをテストで固定しました。
- Talent 側 policy が Agency 条件と Talent / Group の交差条件を持つことをテストで固定しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Issue #529 の受け入れ条件である「Affiliation 成立時の Wiki 権限付与を静的な Talent Wiki ID 埋め込みではなく、動的 Condition policy に寄せる」仕様をテストで明示するためです。

現在の `AffiliationActivatedHandler` は、Affiliation ごとの専用 PrincipalGroup / Policy / Role / AffiliationGrant を維持しつつ、Agency 側の対象 Talent Wiki を `PRINCIPAL_AFFILIATED_TALENT_IDS` の動的 resolver で評価時に解決する実装になっています。本PRではその仕様が後退しないよう、policy factory に渡される statement の構造まで検証します。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
  - `task cs-fix`: OK（Fixed 0 of 2534 files）
  - `task phpstan`: OK（No errors）
  - `task test`: OK（3014 tests, 9615 assertions）
- [x] 新しく追加した機能に対するテストを作成
  - `tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php` に動的 Condition policy の statement 検証を追加
- [x] 既存のテストが壊れていないことを確認
  - `task test-no-db`: OK（2416 tests, 7628 assertions）
  - `docker-compose run --rm --no-deps php ./vendor/bin/phpunit --no-coverage tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php tests/Wiki/Principal/Infrastructure/Service/AffiliationConditionValueResolverTest.php`: OK（8 tests, 132 assertions）
  - `docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php ./vendor/bin/phpunit --no-coverage tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php tests/Wiki/Principal/Infrastructure/Service/AffiliationConditionValueResolverTest.php`: OK（8 tests, 132 assertions）

### 動作確認

- 自動テストで確認しました。

## 🔍 レビューのポイント

- Agency 側 statement が `resource:talentId in ${principal.affiliatedTalentIds}` になっており、成立時点の Talent Wiki ID を静的に埋め込まないこと。
- Talent 側 statement が Agency ID と Principal の Talent / Wiki Group 条件の交差で GROUP / SONG を許可すること。
- AffiliationGrant の `affiliationId + type` による冪等性テストを維持したまま、statement 構造の検証が追加されていること。

## 📖 関連情報

### 関連Issue・タスク

Closes #529

## ⚠️ 注意事項

- リリース前仕様のため、既存 static grant との互換処理は追加していません。
- 本PRの差分はテスト強化のみです。Issue #529 が前提にしている動的 Condition resolver / handler 側の実装は、既に base branch に入っている状態を確認しています。
- 指定されたプロジェクトスキル `qa-review`, `test-review`, `security-review`, `architecture-review` は、Hermes グローバルスキル、Codex スキル、repo-local ファイル検索のいずれでも見つかりませんでした。そのため、同一セッション内で同期的に以下の代替レビューを実施しました。
  - QA: Issue #529 の受け入れ条件に対して、Agency 側/Talent 側/冪等性/Wiki 未作成時の各仕様がテストまたは既存 resolver テストで確認されていることを確認。
  - Test: targeted PHPUnit、`task test-no-db`、`task phpstan`、`task check` を実行して通過を確認。
  - Security: 権限範囲が静的な広い allow ではなく動的 Condition により評価時に絞られること、Default group に混ぜない専用 group/role 設計を維持していることを確認。
  - Architecture: Application handler は role/policy/grant 作成に留まり、Affiliation/Wiki の評価時解決は resolver 側に閉じていることを確認。
- 代替レビューで未対応の妥当な指摘はありません。

## 📸 スクリーンショット・デモ

なし（バックエンドのテスト変更のみ）

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
