### PR TITLE
アカウントカテゴリ変更時にWiki権限グループを作成する

### DIFF
--- a/application/Providers/Wiki/EventServiceProvider.php
+++ b/application/Providers/Wiki/EventServiceProvider.php
@@ -6,10 +6,12 @@ namespace Application\Providers\Wiki;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
+use Source\Account\Account\Domain\Event\AccountCategoryChanged;
 use Source\Account\Affiliation\Domain\Event\AffiliationActivated;
 use Source\Account\Affiliation\Domain\Event\AffiliationTerminated;
 use Source\Identity\Domain\Event\DelegatedIdentityCreated;
 use Source\Identity\Domain\Event\DelegatedIdentityDeleted;
+use Source\Wiki\Principal\Application\EventHandler\AccountCategoryChangedHandler;
 use Source\Wiki\Principal\Application\EventHandler\AffiliationActivatedHandler;
 use Source\Wiki\Principal\Application\EventHandler\AffiliationTerminatedHandler;
 use Source\Wiki\Principal\Application\EventHandler\DelegatedIdentityCreatedHandler;
@@ -35,6 +37,11 @@ class EventServiceProvider extends ServiceProvider
         $events->listen(
             AffiliationActivated::class,
             [AffiliationActivatedHandler::class, 'handle'],
+        );
+
+        $events->listen(
+            AccountCategoryChanged::class,
+            [AccountCategoryChangedHandler::class, 'handle'],
         );
 
         $events->listen(

--- a/src/Account/Account/Application/UseCase/Command/ApproveAccountCategoryChangeRequest/ApproveAccountCategoryChangeRequest.php
+++ b/src/Account/Account/Application/UseCase/Command/ApproveAccountCategoryChangeRequest/ApproveAccountCategoryChangeRequest.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Source\Account\Account\Application\UseCase\Command\ApproveAccountCategoryChangeRequest;
 
+use DateTimeImmutable;
 use Source\Account\Account\Application\Exception\AccountCategoryChangeRequestForbiddenException;
 use Source\Account\Account\Application\Exception\AccountCategoryChangeRequestNotFoundException;
 use Source\Account\Account\Application\Exception\AccountNotFoundException;
+use Source\Account\Account\Domain\Event\AccountCategoryChanged;
 use Source\Account\Account\Domain\Repository\AccountCategoryChangeRequestRepositoryInterface;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
 use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
 use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class ApproveAccountCategoryChangeRequest implements ApproveAccountCategoryChangeRequestInterface
 {
@@ -19,6 +22,7 @@ readonly class ApproveAccountCategoryChangeRequest implements ApproveAccountCate
         private AccountCategoryChangeRequestRepositoryInterface $requestRepository,
         private AccountRepositoryInterface $accountRepository,
         private PolicyEvaluatorInterface $policyEvaluator,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -43,11 +47,22 @@ readonly class ApproveAccountCategoryChangeRequest implements ApproveAccountCate
             throw new AccountNotFoundException();
         }
 
+        $previousAccountCategory = $account->accountCategory();
+        $newAccountCategory = $request->requestedAccountCategory();
+
         $request->approve($reviewerAccountIdentifier);
-        $account->setAccountCategory($request->requestedAccountCategory());
+        $account->setAccountCategory($newAccountCategory);
 
         $this->accountRepository->save($account);
         $this->requestRepository->save($request);
+
+        $this->eventDispatcher->dispatch(new AccountCategoryChanged(
+            accountIdentifier: $account->accountIdentifier(),
+            previousAccountCategory: $previousAccountCategory,
+            newAccountCategory: $newAccountCategory,
+            reviewerAccountIdentifier: $reviewerAccountIdentifier,
+            changedAt: new DateTimeImmutable(),
+        ));
 
         $output->setRequest($request);
     }

--- a/src/Account/Account/Domain/Event/AccountCategoryChanged.php
+++ b/src/Account/Account/Domain/Event/AccountCategoryChanged.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Account\Domain\Event;
+
+use DateTimeImmutable;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+readonly class AccountCategoryChanged
+{
+    public function __construct(
+        private AccountIdentifier $accountIdentifier,
+        private AccountCategory $previousAccountCategory,
+        private AccountCategory $newAccountCategory,
+        private AccountIdentifier $reviewerAccountIdentifier,
+        private DateTimeImmutable $changedAt,
+    ) {
+    }
+
+    public function accountIdentifier(): AccountIdentifier
+    {
+        return $this->accountIdentifier;
+    }
+
+    public function previousAccountCategory(): AccountCategory
+    {
+        return $this->previousAccountCategory;
+    }
+
+    public function newAccountCategory(): AccountCategory
+    {
+        return $this->newAccountCategory;
+    }
+
+    public function reviewerAccountIdentifier(): AccountIdentifier
+    {
+        return $this->reviewerAccountIdentifier;
+    }
+
+    public function changedAt(): DateTimeImmutable
+    {
+        return $this->changedAt;
+    }
+}

--- a/src/Wiki/Principal/Application/EventHandler/AccountCategoryChangedHandler.php
+++ b/src/Wiki/Principal/Application/EventHandler/AccountCategoryChangedHandler.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\EventHandler;
+
+use RuntimeException;
+use Source\Account\Account\Domain\Event\AccountCategoryChanged;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Wiki\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
+use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Wiki\Principal\Domain\Repository\RoleRepositoryInterface;
+
+readonly class AccountCategoryChangedHandler
+{
+    private const string AGENCY_ACTOR_GROUP_NAME = 'Agency Actor';
+    private const string TALENT_ACTOR_GROUP_NAME = 'Talent Actor';
+    private const string AGENCY_ACTOR_ROLE = 'AGENCY_ACTOR';
+    private const string TALENT_ACTOR_ROLE = 'TALENT_ACTOR';
+
+    public function __construct(
+        private PrincipalGroupFactoryInterface $principalGroupFactory,
+        private PrincipalGroupRepositoryInterface $principalGroupRepository,
+        private PrincipalRepositoryInterface $principalRepository,
+        private RoleRepositoryInterface $roleRepository,
+    ) {
+    }
+
+    public function handle(AccountCategoryChanged $event): void
+    {
+        $groupName = $this->groupNameForCategory($event->newAccountCategory());
+        $roleName = $this->roleNameForCategory($event->newAccountCategory());
+
+        if ($groupName === null || $roleName === null) {
+            return;
+        }
+
+        $role = $this->roleRepository->findByName($roleName);
+        if ($role === null) {
+            throw new RuntimeException("Wiki system role {$roleName} is not found.");
+        }
+
+        $principalGroup = $this->principalGroupRepository->findByAccountIdAndName(
+            $event->accountIdentifier(),
+            $groupName,
+        );
+
+        if ($principalGroup === null) {
+            $principalGroup = $this->principalGroupFactory->create(
+                $event->accountIdentifier(),
+                $groupName,
+                false,
+            );
+        }
+
+        $principalGroup->addRole($role->roleIdentifier());
+
+        $principals = $this->principalRepository->findByAccountId($event->accountIdentifier());
+        $defaultPrincipalGroup = empty($principals)
+            ? null
+            : $this->principalGroupRepository->findDefaultByAccountId($event->accountIdentifier());
+        $defaultPrincipalGroupChanged = false;
+
+        foreach ($principals as $principal) {
+            if (! $principalGroup->hasMember($principal->principalIdentifier())) {
+                $principalGroup->addMember($principal->principalIdentifier());
+            }
+
+            if ($defaultPrincipalGroup !== null && $defaultPrincipalGroup->hasMember($principal->principalIdentifier())) {
+                $defaultPrincipalGroup->removeMember($principal->principalIdentifier());
+                $defaultPrincipalGroupChanged = true;
+            }
+        }
+
+        if ($defaultPrincipalGroupChanged) {
+            $this->principalGroupRepository->save($defaultPrincipalGroup);
+        }
+
+        $this->principalGroupRepository->save($principalGroup);
+    }
+
+    private function groupNameForCategory(AccountCategory $category): ?string
+    {
+        return match ($category) {
+            AccountCategory::AGENCY => self::AGENCY_ACTOR_GROUP_NAME,
+            AccountCategory::TALENT => self::TALENT_ACTOR_GROUP_NAME,
+            AccountCategory::GENERAL => null,
+        };
+    }
+
+    private function roleNameForCategory(AccountCategory $category): ?string
+    {
+        return match ($category) {
+            AccountCategory::AGENCY => self::AGENCY_ACTOR_ROLE,
+            AccountCategory::TALENT => self::TALENT_ACTOR_ROLE,
+            AccountCategory::GENERAL => null,
+        };
+    }
+}

--- a/src/Wiki/Principal/Domain/Repository/PrincipalGroupRepositoryInterface.php
+++ b/src/Wiki/Principal/Domain/Repository/PrincipalGroupRepositoryInterface.php
@@ -33,5 +33,7 @@ interface PrincipalGroupRepositoryInterface
 
     public function findDefaultByAccountId(AccountIdentifier $accountIdentifier): ?PrincipalGroup;
 
+    public function findByAccountIdAndName(AccountIdentifier $accountIdentifier, string $name): ?PrincipalGroup;
+
     public function delete(PrincipalGroup $principalGroup): void;
 }

--- a/src/Wiki/Principal/Infrastructure/Repository/PrincipalGroupRepository.php
+++ b/src/Wiki/Principal/Infrastructure/Repository/PrincipalGroupRepository.php
@@ -115,6 +115,21 @@ class PrincipalGroupRepository implements PrincipalGroupRepositoryInterface
         return $eloquentModels->map(fn (PrincipalGroupEloquent $eloquent) => $this->toDomainEntity($eloquent))->all();
     }
 
+    public function findByAccountIdAndName(AccountIdentifier $accountIdentifier, string $name): ?PrincipalGroup
+    {
+        $eloquent = PrincipalGroupEloquent::query()
+            ->with(['memberships', 'roleAttachments'])
+            ->where('account_id', (string) $accountIdentifier)
+            ->where('name', $name)
+            ->first();
+
+        if ($eloquent === null) {
+            return null;
+        }
+
+        return $this->toDomainEntity($eloquent);
+    }
+
     public function delete(PrincipalGroup $principalGroup): void
     {
         $principalIds = PrincipalGroupMembershipEloquent::query()

--- a/tests/Account/Account/Application/UseCase/Command/ApproveAccountCategoryChangeRequest/ApproveAccountCategoryChangeRequestTest.php
+++ b/tests/Account/Account/Application/UseCase/Command/ApproveAccountCategoryChangeRequest/ApproveAccountCategoryChangeRequestTest.php
@@ -13,6 +13,7 @@ use Source\Account\Account\Application\UseCase\Command\ApproveAccountCategoryCha
 use Source\Account\Account\Application\UseCase\Command\ApproveAccountCategoryChangeRequest\ApproveAccountCategoryChangeRequestOutput;
 use Source\Account\Account\Domain\Entity\Account;
 use Source\Account\Account\Domain\Entity\AccountCategoryChangeRequest;
+use Source\Account\Account\Domain\Event\AccountCategoryChanged;
 use Source\Account\Account\Domain\Exception\InvalidAccountCategoryChangeRequestApprovalException;
 use Source\Account\Account\Domain\Repository\AccountCategoryChangeRequestRepositoryInterface;
 use Source\Account\Account\Domain\Repository\AccountRepositoryInterface;
@@ -29,6 +30,7 @@ use Source\Account\Principal\Domain\ValueObject\Action;
 use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Shared\Domain\ValueObject\AccountCategory;
 use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\Email;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -42,6 +44,7 @@ class ApproveAccountCategoryChangeRequestTest extends TestCase
         $this->app->instance(AccountCategoryChangeRequestRepositoryInterface::class, Mockery::mock(AccountCategoryChangeRequestRepositoryInterface::class));
         $this->app->instance(AccountRepositoryInterface::class, Mockery::mock(AccountRepositoryInterface::class));
         $this->app->instance(PolicyEvaluatorInterface::class, Mockery::mock(PolicyEvaluatorInterface::class));
+        $this->app->instance(EventDispatcherInterface::class, Mockery::mock(EventDispatcherInterface::class));
 
         $this->assertInstanceOf(ApproveAccountCategoryChangeRequest::class, $this->app->make(\Source\Account\Account\Application\UseCase\Command\ApproveAccountCategoryChangeRequest\ApproveAccountCategoryChangeRequestInterface::class));
     }
@@ -72,8 +75,17 @@ class ApproveAccountCategoryChangeRequestTest extends TestCase
             ->with($principal, Action::ACCOUNT_CATEGORY_CHANGE_REQUEST_MANAGE, Mockery::on(static fn (Resource $resource): bool => (string) $resource->accountIdentifier() === (string) $reviewerAccountId))
             ->andReturnTrue();
 
+        /** @var EventDispatcherInterface&Mockery\MockInterface $eventDispatcher */
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->with(Mockery::on(static fn (AccountCategoryChanged $event): bool => (string) $event->accountIdentifier() === (string) $targetAccountId
+                && $event->previousAccountCategory() === AccountCategory::GENERAL
+                && $event->newAccountCategory() === AccountCategory::AGENCY
+                && (string) $event->reviewerAccountIdentifier() === (string) $reviewerAccountId));
+
         $output = new ApproveAccountCategoryChangeRequestOutput();
-        (new ApproveAccountCategoryChangeRequest($requestRepository, $accountRepository, $policyEvaluator))
+        (new ApproveAccountCategoryChangeRequest($requestRepository, $accountRepository, $policyEvaluator, $eventDispatcher))
             ->process(new ApproveAccountCategoryChangeRequestInput($requestId, $principal), $output);
 
         $this->assertSame(AccountCategoryChangeRequestStatus::APPROVED, $request->status());
@@ -102,7 +114,7 @@ class ApproveAccountCategoryChangeRequestTest extends TestCase
         $policyEvaluator->shouldReceive('evaluate')->once()->andReturnFalse();
 
         $this->expectException(AccountCategoryChangeRequestForbiddenException::class);
-        (new ApproveAccountCategoryChangeRequest($requestRepository, $accountRepository, $policyEvaluator))
+        (new ApproveAccountCategoryChangeRequest($requestRepository, $accountRepository, $policyEvaluator, self::eventDispatcherMock()))
             ->process(new ApproveAccountCategoryChangeRequestInput($requestId, $principal), new ApproveAccountCategoryChangeRequestOutput());
     }
 
@@ -123,6 +135,7 @@ class ApproveAccountCategoryChangeRequestTest extends TestCase
             $requestRepository,
             $accountRepository,
             $policyEvaluator,
+            self::eventDispatcherMock(),
         ))->process(new ApproveAccountCategoryChangeRequestInput($requestId, $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()))), new ApproveAccountCategoryChangeRequestOutput());
     }
 
@@ -147,8 +160,19 @@ class ApproveAccountCategoryChangeRequestTest extends TestCase
         $policyEvaluator->shouldReceive('evaluate')->once()->andReturnTrue();
 
         $this->expectException(InvalidAccountCategoryChangeRequestApprovalException::class);
-        (new ApproveAccountCategoryChangeRequest($requestRepository, $accountRepository, $policyEvaluator))
+        (new ApproveAccountCategoryChangeRequest($requestRepository, $accountRepository, $policyEvaluator, self::eventDispatcherMock()))
             ->process(new ApproveAccountCategoryChangeRequestInput($requestId, $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()))), new ApproveAccountCategoryChangeRequestOutput());
+    }
+
+    /**
+     * @return EventDispatcherInterface&Mockery\MockInterface
+     */
+    private static function eventDispatcherMock(): EventDispatcherInterface
+    {
+        /** @var EventDispatcherInterface&Mockery\MockInterface $mock */
+        $mock = Mockery::mock(EventDispatcherInterface::class);
+
+        return $mock;
     }
 
     private function request(AccountCategoryChangeRequestIdentifier $requestId, AccountIdentifier $accountId, AccountCategoryChangeRequestStatus $status): AccountCategoryChangeRequest

--- a/tests/Wiki/Principal/Application/EventHandler/AccountCategoryChangedHandlerTest.php
+++ b/tests/Wiki/Principal/Application/EventHandler/AccountCategoryChangedHandlerTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\EventHandler;
+
+use DateTimeImmutable;
+use Mockery;
+use Source\Account\Account\Domain\Event\AccountCategoryChanged;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\EventHandler\AccountCategoryChangedHandler;
+use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
+use Source\Wiki\Principal\Domain\Entity\Role;
+use Source\Wiki\Principal\Domain\Factory\PrincipalGroupFactoryInterface;
+use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
+use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
+use Source\Wiki\Principal\Domain\Repository\RoleRepositoryInterface;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AccountCategoryChangedHandlerTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $this->app->instance(PrincipalGroupFactoryInterface::class, Mockery::mock(PrincipalGroupFactoryInterface::class));
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, Mockery::mock(PrincipalGroupRepositoryInterface::class));
+        $this->app->instance(PrincipalRepositoryInterface::class, Mockery::mock(PrincipalRepositoryInterface::class));
+        $this->app->instance(RoleRepositoryInterface::class, Mockery::mock(RoleRepositoryInterface::class));
+
+        $this->assertInstanceOf(AccountCategoryChangedHandler::class, $this->app->make(AccountCategoryChangedHandler::class));
+    }
+
+    public function testHandleCreatesAgencyActorGroupAndAttachesRole(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $reviewerAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principal = $this->principal($accountIdentifier);
+        $principalGroup = $this->principalGroup($accountIdentifier, 'Agency Actor');
+        $defaultPrincipalGroup = $this->principalGroup($accountIdentifier, 'Default', true);
+        $defaultPrincipalGroup->addMember($principal->principalIdentifier());
+        $role = $this->role('AGENCY_ACTOR');
+        $event = $this->event($accountIdentifier, AccountCategory::AGENCY, $reviewerAccountIdentifier);
+
+        $principalGroupFactory = self::principalGroupFactoryMock();
+        $principalGroupFactory->shouldReceive('create')
+            ->once()
+            ->with($accountIdentifier, 'Agency Actor', false)
+            ->andReturn($principalGroup);
+
+        $principalGroupRepository = self::principalGroupRepositoryMock();
+        $principalGroupRepository->shouldReceive('findByAccountIdAndName')
+            ->once()
+            ->with($accountIdentifier, 'Agency Actor')
+            ->andReturnNull();
+        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
+            ->once()
+            ->with($accountIdentifier)
+            ->andReturn($defaultPrincipalGroup);
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => $saved->isDefault()
+                && ! $saved->hasMember($principal->principalIdentifier())));
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => $saved->hasRole($role->roleIdentifier())
+                && $saved->hasMember($principal->principalIdentifier())
+                && ! $saved->isDefault()));
+
+        $principalRepository = self::principalRepositoryMock();
+        $principalRepository->shouldReceive('findByAccountId')->once()->with($accountIdentifier)->andReturn([$principal]);
+
+        $roleRepository = self::roleRepositoryMock();
+        $roleRepository->shouldReceive('findByName')->once()->with('AGENCY_ACTOR')->andReturn($role);
+
+        (new AccountCategoryChangedHandler($principalGroupFactory, $principalGroupRepository, $principalRepository, $roleRepository))
+            ->handle($event);
+    }
+
+    public function testHandleCreatesTalentActorGroupAndAttachesRole(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $reviewerAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principalGroup = $this->principalGroup($accountIdentifier, 'Talent Actor');
+        $role = $this->role('TALENT_ACTOR');
+        $event = $this->event($accountIdentifier, AccountCategory::TALENT, $reviewerAccountIdentifier);
+
+        $principalGroupFactory = self::principalGroupFactoryMock();
+        $principalGroupFactory->shouldReceive('create')
+            ->once()
+            ->with($accountIdentifier, 'Talent Actor', false)
+            ->andReturn($principalGroup);
+
+        $principalGroupRepository = self::principalGroupRepositoryMock();
+        $principalGroupRepository->shouldReceive('findByAccountIdAndName')
+            ->once()
+            ->with($accountIdentifier, 'Talent Actor')
+            ->andReturnNull();
+        $principalGroupRepository->shouldNotReceive('findDefaultByAccountId');
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => $saved->hasRole($role->roleIdentifier())
+                && ! $saved->isDefault()));
+
+        $principalRepository = self::principalRepositoryMock();
+        $principalRepository->shouldReceive('findByAccountId')->once()->with($accountIdentifier)->andReturn([]);
+
+        $roleRepository = self::roleRepositoryMock();
+        $roleRepository->shouldReceive('findByName')->once()->with('TALENT_ACTOR')->andReturn($role);
+
+        (new AccountCategoryChangedHandler($principalGroupFactory, $principalGroupRepository, $principalRepository, $roleRepository))
+            ->handle($event);
+    }
+
+    public function testHandleDoesNotDuplicateExistingGroupRoleOrMembers(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principal = $this->principal($accountIdentifier);
+        $role = $this->role('AGENCY_ACTOR');
+        $existingGroup = $this->principalGroup($accountIdentifier, 'Agency Actor');
+        $existingGroup->addRole($role->roleIdentifier());
+        $existingGroup->addMember($principal->principalIdentifier());
+        $defaultPrincipalGroup = $this->principalGroup($accountIdentifier, 'Default', true);
+        $defaultPrincipalGroup->addMember($principal->principalIdentifier());
+
+        $principalGroupFactory = self::principalGroupFactoryMock();
+        $principalGroupFactory->shouldNotReceive('create');
+
+        $principalGroupRepository = self::principalGroupRepositoryMock();
+        $principalGroupRepository->shouldReceive('findByAccountIdAndName')->once()->andReturn($existingGroup);
+        $principalGroupRepository->shouldReceive('findDefaultByAccountId')->once()->with($accountIdentifier)->andReturn($defaultPrincipalGroup);
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => $saved->isDefault()
+                && ! $saved->hasMember($principal->principalIdentifier())));
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => count($saved->roles()) === 1 && count($saved->members()) === 1));
+
+        $principalRepository = self::principalRepositoryMock();
+        $principalRepository->shouldReceive('findByAccountId')->once()->with($accountIdentifier)->andReturn([$principal]);
+
+        $roleRepository = self::roleRepositoryMock();
+        $roleRepository->shouldReceive('findByName')->once()->with('AGENCY_ACTOR')->andReturn($role);
+
+        (new AccountCategoryChangedHandler($principalGroupFactory, $principalGroupRepository, $principalRepository, $roleRepository))
+            ->handle($this->event($accountIdentifier, AccountCategory::AGENCY, new AccountIdentifier(StrTestHelper::generateUuid())));
+    }
+
+    public function testHandleCreatesGroupWhenWikiIsNotCreated(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $role = $this->role('AGENCY_ACTOR');
+        $principalGroup = $this->principalGroup($accountIdentifier, 'Agency Actor');
+
+        $principalGroupFactory = self::principalGroupFactoryMock();
+        $principalGroupFactory->shouldReceive('create')->once()->andReturn($principalGroup);
+
+        $principalGroupRepository = self::principalGroupRepositoryMock();
+        $principalGroupRepository->shouldReceive('findByAccountIdAndName')->once()->andReturnNull();
+        $principalGroupRepository->shouldNotReceive('findDefaultByAccountId');
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => $saved->hasRole($role->roleIdentifier()) && $saved->memberCount() === 0));
+
+        $principalRepository = self::principalRepositoryMock();
+        $principalRepository->shouldReceive('findByAccountId')->once()->with($accountIdentifier)->andReturn([]);
+
+        $roleRepository = self::roleRepositoryMock();
+        $roleRepository->shouldReceive('findByName')->once()->with('AGENCY_ACTOR')->andReturn($role);
+
+        (new AccountCategoryChangedHandler($principalGroupFactory, $principalGroupRepository, $principalRepository, $roleRepository))
+            ->handle($this->event($accountIdentifier, AccountCategory::AGENCY, new AccountIdentifier(StrTestHelper::generateUuid())));
+    }
+
+    public function testHandleDoesNothingForGeneralCategory(): void
+    {
+        $principalGroupFactory = self::principalGroupFactoryMock();
+        $principalGroupFactory->shouldNotReceive('create');
+        $principalGroupRepository = self::principalGroupRepositoryMock();
+        $principalGroupRepository->shouldNotReceive('findByAccountIdAndName');
+        $principalGroupRepository->shouldNotReceive('save');
+        $principalRepository = self::principalRepositoryMock();
+        $principalRepository->shouldNotReceive('findByAccountId');
+        $roleRepository = self::roleRepositoryMock();
+        $roleRepository->shouldNotReceive('findByName');
+
+        (new AccountCategoryChangedHandler($principalGroupFactory, $principalGroupRepository, $principalRepository, $roleRepository))
+            ->handle($this->event(new AccountIdentifier(StrTestHelper::generateUuid()), AccountCategory::GENERAL, new AccountIdentifier(StrTestHelper::generateUuid())));
+    }
+
+    /**
+     * @return PrincipalGroupFactoryInterface&Mockery\MockInterface
+     */
+    private static function principalGroupFactoryMock(): PrincipalGroupFactoryInterface
+    {
+        /** @var PrincipalGroupFactoryInterface&Mockery\MockInterface $mock */
+        $mock = Mockery::mock(PrincipalGroupFactoryInterface::class);
+
+        return $mock;
+    }
+
+    /**
+     * @return PrincipalGroupRepositoryInterface&Mockery\MockInterface
+     */
+    private static function principalGroupRepositoryMock(): PrincipalGroupRepositoryInterface
+    {
+        /** @var PrincipalGroupRepositoryInterface&Mockery\MockInterface $mock */
+        $mock = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+
+        return $mock;
+    }
+
+    /**
+     * @return PrincipalRepositoryInterface&Mockery\MockInterface
+     */
+    private static function principalRepositoryMock(): PrincipalRepositoryInterface
+    {
+        /** @var PrincipalRepositoryInterface&Mockery\MockInterface $mock */
+        $mock = Mockery::mock(PrincipalRepositoryInterface::class);
+
+        return $mock;
+    }
+
+    /**
+     * @return RoleRepositoryInterface&Mockery\MockInterface
+     */
+    private static function roleRepositoryMock(): RoleRepositoryInterface
+    {
+        /** @var RoleRepositoryInterface&Mockery\MockInterface $mock */
+        $mock = Mockery::mock(RoleRepositoryInterface::class);
+
+        return $mock;
+    }
+
+    private function event(AccountIdentifier $accountIdentifier, AccountCategory $newCategory, AccountIdentifier $reviewerAccountIdentifier): AccountCategoryChanged
+    {
+        return new AccountCategoryChanged(
+            $accountIdentifier,
+            AccountCategory::GENERAL,
+            $newCategory,
+            $reviewerAccountIdentifier,
+            new DateTimeImmutable(),
+        );
+    }
+
+    private function principal(AccountIdentifier $accountIdentifier): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            (string) $accountIdentifier,
+            [],
+            [],
+            null,
+            true,
+        );
+    }
+
+    private function principalGroup(AccountIdentifier $accountIdentifier, string $name, bool $isDefault = false): PrincipalGroup
+    {
+        return new PrincipalGroup(
+            new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
+            $accountIdentifier,
+            $name,
+            $isDefault,
+            new DateTimeImmutable(),
+        );
+    }
+
+    private function role(string $name): Role
+    {
+        return new Role(
+            new RoleIdentifier(StrTestHelper::generateUuid()),
+            $name,
+            [],
+            true,
+            new DateTimeImmutable(),
+        );
+    }
+}

--- a/tests/Wiki/Principal/Infrastructure/Repository/PrincipalGroupRepositoryTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Repository/PrincipalGroupRepositoryTest.php
@@ -169,6 +169,100 @@ class PrincipalGroupRepositoryTest extends TestCase
     }
 
     /**
+     * 正常系: AccountIdとNameに紐づくPrincipalGroupを取得できること
+     *
+     * @throws BindingResolutionException
+     */
+    #[Group('useDb')]
+    public function testFindByAccountIdAndName(): void
+    {
+        $accountId = StrTestHelper::generateUuid();
+        $otherAccountId = StrTestHelper::generateUuid();
+        $principalGroupId = StrTestHelper::generateUuid();
+        $sameNameOtherAccountGroupId = StrTestHelper::generateUuid();
+        $otherNameGroupId = StrTestHelper::generateUuid();
+        $principalId = StrTestHelper::generateUuid();
+        $identityId = StrTestHelper::generateUuid();
+        $roleId = StrTestHelper::generateUuid();
+
+        CreateAccount::create($accountId);
+        CreateAccount::create($otherAccountId);
+        CreateIdentity::create(new IdentityIdentifier($identityId), ['email' => 'find-by-account-id-and-name@example.com']);
+        CreatePrincipal::create(
+            new PrincipalIdentifier($principalId),
+            new IdentityIdentifier($identityId),
+        );
+        CreateRole::create(new RoleIdentifier($roleId), ['name' => 'Find By Account And Name Role']);
+        CreatePrincipalGroup::create(
+            new PrincipalGroupIdentifier($principalGroupId),
+            new AccountIdentifier($accountId),
+            [
+                'name' => 'Agency Actor',
+                'is_default' => false,
+            ]
+        );
+        CreatePrincipalGroup::create(
+            new PrincipalGroupIdentifier($sameNameOtherAccountGroupId),
+            new AccountIdentifier($otherAccountId),
+            [
+                'name' => 'Agency Actor',
+                'is_default' => false,
+            ]
+        );
+        CreatePrincipalGroup::create(
+            new PrincipalGroupIdentifier($otherNameGroupId),
+            new AccountIdentifier($accountId),
+            [
+                'name' => 'Other Group',
+                'is_default' => false,
+            ]
+        );
+        CreatePrincipalGroupMembership::create($principalGroupId, $principalId);
+        \Illuminate\Support\Facades\DB::table('wiki_principal_group_role_attachments')->insert([
+            'principal_group_id' => $principalGroupId,
+            'role_id' => $roleId,
+        ]);
+
+        $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
+        $result = $repository->findByAccountIdAndName(new AccountIdentifier($accountId), 'Agency Actor');
+
+        $this->assertNotNull($result);
+        $this->assertSame($principalGroupId, (string) $result->principalGroupIdentifier());
+        $this->assertSame($accountId, (string) $result->accountIdentifier());
+        $this->assertSame('Agency Actor', $result->name());
+        $this->assertFalse($result->isDefault());
+        $this->assertTrue($result->hasMember(new PrincipalIdentifier($principalId)));
+        $this->assertTrue($result->hasRole(new RoleIdentifier($roleId)));
+    }
+
+    /**
+     * 正常系: AccountIdとNameに紐づくPrincipalGroupが存在しない場合、NULLが返却されること
+     *
+     * @throws BindingResolutionException
+     */
+    #[Group('useDb')]
+    public function testFindByAccountIdAndNameWhenNotFound(): void
+    {
+        $accountId = StrTestHelper::generateUuid();
+        $principalGroupId = StrTestHelper::generateUuid();
+
+        CreateAccount::create($accountId);
+        CreatePrincipalGroup::create(
+            new PrincipalGroupIdentifier($principalGroupId),
+            new AccountIdentifier($accountId),
+            [
+                'name' => 'Agency Actor',
+                'is_default' => false,
+            ]
+        );
+
+        $repository = $this->app->make(PrincipalGroupRepositoryInterface::class);
+
+        $this->assertNull($repository->findByAccountIdAndName(new AccountIdentifier($accountId), 'Talent Actor'));
+        $this->assertNull($repository->findByAccountIdAndName(new AccountIdentifier(StrTestHelper::generateUuid()), 'Agency Actor'));
+    }
+
+    /**
      * 正常系: 正しくAccountIdに紐づくデフォルトPrincipalGroupを取得できること
      *
      * @throws BindingResolutionException


### PR DESCRIPTION
## 📝 変更内容

- アカウントカテゴリ変更承認時に `AccountCategoryChanged` イベントを dispatch するようにしました。
- Wiki Principal 側に `AccountCategoryChangedHandler` を追加し、カテゴリに応じた非 Default PrincipalGroup を作成して system role を付与するようにしました。
  - Agency: `Agency Actor` group に `AGENCY_ACTOR` role を付与
  - Talent: `Talent Actor` group に `TALENT_ACTOR` role を付与
- `PrincipalGroupRepositoryInterface` / 実装に account + group name で既存 group を検索する API を追加し、同一 event の再処理で group を重複作成しないようにしました。
- 既存 Wiki Principal が存在する場合は作成/取得したカテゴリ別 group に追加し、Wiki 未作成で Principal がない場合でも group/role attach だけ作成できるようにしました。
- カテゴリ変更承認 UseCase の event dispatch test と Wiki Principal event handler test を追加しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

カテゴリ変更承認時には Account の `category` 更新のみ行われており、Wiki 側でカテゴリ本人用の system role を持つ PrincipalGroup が用意されていませんでした。
Agency/Talent になったアカウントが自身に紐づく Wiki リソースを扱えるよう、Default group とは分離したカテゴリ別 group を作成し、既存の `AGENCY_ACTOR` / `TALENT_ACTOR` system role を付与します。

## 🧪 テスト

### テストの実行確認

- [x] `task cs-fix` を実行し、コードスタイルを確認
- [x] `docker-compose run --rm --no-deps php composer phpstan` を実行し、静的解析がパスすることを確認
- [x] `docker-compose run --rm --no-deps php ./vendor/bin/phpunit --exclude-group useDb tests/Account/Account/Application/UseCase/Command/ApproveAccountCategoryChangeRequest/ApproveAccountCategoryChangeRequestTest.php tests/Wiki/Principal/Application/EventHandler/AccountCategoryChangedHandlerTest.php` を実行し、追加/関連テストがパスすることを確認
- [x] `task test-no-db` を実行し、DB 非依存テストがパスすることを確認
- [x] `docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php ./vendor/bin/phpunit --no-coverage tests/Wiki/Principal/Infrastructure/Repository/PrincipalGroupRepositoryTest.php` を実行し、追加した repository API 周辺の DB テストがパスすることを確認
- [x] `docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php ./vendor/bin/phpunit --no-coverage` を実行し、全 PHPUnit テストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- 自動テストで以下を確認しました。
  - Agency へのカテゴリ変更承認時に Wiki 側非 Default group が作成され、`AGENCY_ACTOR` role が attach されること
  - Talent へのカテゴリ変更承認時に Wiki 側非 Default group が作成され、`TALENT_ACTOR` role が attach されること
  - 同じ event を複数回処理しても group / role / member が重複しないこと
  - Wiki 未作成で Principal が存在しない場合でも group / role attach が作成できること

## 🔍 レビューのポイント

- Account コンテキストから Wiki Principal への連携を domain event + Wiki EventHandler で分離している点
- Default group にカテゴリ由来 role を混ぜず、カテゴリ別の非 Default group を作成している点
- group 名による冪等性検索で重複作成を防ぎ、`PrincipalGroup::addRole()` / `hasMember()` により role/member の重複も避けている点
- Wiki 未作成でも PrincipalGroup と role attach が成立するよう、Principal 追加を任意としている点

### Review skills used / unavailable skills and alternative review

- `qa-review`, `test-review`, `security-review`, `architecture-review` は Hermes global skills / Codex skills / repository-local search で見つからなかったため、同一セッション内で代替レビューを実施しました。
- QA: Issue #531 の受け入れ条件（Agency/Talent group 作成、role attach、冪等性、Wiki 未作成ケース）に対応するテストが揃っていることを確認しました。
- Test: targeted PHPUnit、DB 非依存全体、repository DB テスト、全 PHPUnit、PHPStan、CS Fixer を実行しパスを確認しました。
- Security: system role 名は固定値のみを使用し、ユーザー入力を role 検索や group 名へ直接流し込まないこと、Default group に強い role を混ぜないことを確認しました。
- Architecture: Account UseCase は event dispatch までに留め、Wiki Principal group 作成は Wiki 側 EventHandler に分離しました。repository 追加 API は account + name の明示検索に限定し、既存の domain entity の重複防止ロジックを利用しています。
- 未対応のレビュー指摘: なし

## 📖 関連情報

### 関連Issue・タスク

Closes #531

## ⚠️ 注意事項

- 新規 migration はありません。
- `AGENCY_ACTOR` / `TALENT_ACTOR` は既存の system role seeder に存在する前提です。存在しない場合は handler が `RuntimeException` を投げ、権限 group の不完全作成を避けます。
- SSH push は `Permission denied (publickey)` で失敗したため、`gh auth token` を使った一回限りの HTTPS URL push で branch を作成しました。`origin` remote は SSH のまま維持し、branch upstream は `origin/issue-531-wiki-principal-group` に復元済みです。

## 📸 スクリーンショット・デモ

- UI 変更はありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
