### PR TITLE
Affiliation終了時のWiki権限剥奪を新設計に合わせて整理

### DIFF
--- a/src/Wiki/Principal/Application/EventHandler/AffiliationTerminatedHandler.php
+++ b/src/Wiki/Principal/Application/EventHandler/AffiliationTerminatedHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Wiki\Principal\Application\EventHandler;
 
 use Source\Account\Affiliation\Domain\Event\AffiliationTerminated;
+use Source\Wiki\Principal\Domain\Entity\PrincipalGroup;
 use Source\Wiki\Principal\Domain\Repository\AffiliationGrantRepositoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PolicyRepositoryInterface;
 use Source\Wiki\Principal\Domain\Repository\PrincipalGroupRepositoryInterface;
@@ -27,28 +28,57 @@ readonly class AffiliationTerminatedHandler
         );
 
         foreach ($affiliationGrants as $affiliationGrant) {
-            // Role を削除
-            $role = $this->roleRepository->findById($affiliationGrant->roleIdentifier());
-            if ($role !== null) {
-                $this->roleRepository->delete($role);
-            }
-
-            // Policy を削除
-            $policy = $this->policyRepository->findById($affiliationGrant->policyIdentifier());
-            if ($policy !== null) {
-                $this->policyRepository->delete($policy);
-            }
-
-            // PrincipalGroup を削除（Default でない場合のみ）
             $principalGroup = $this->principalGroupRepository->findById(
                 $affiliationGrant->principalGroupIdentifier()
             );
-            if ($principalGroup !== null && ! $principalGroup->isDefault()) {
+
+            if ($principalGroup !== null && $this->isAffiliationPrincipalGroup($principalGroup)) {
+                $this->restoreMembersToDefaultGroup($principalGroup);
+                $principalGroup->removeRole($affiliationGrant->roleIdentifier());
+                $this->principalGroupRepository->save($principalGroup);
                 $this->principalGroupRepository->delete($principalGroup);
             }
 
-            // AffiliationGrant 記録を削除
+            $role = $this->roleRepository->findById($affiliationGrant->roleIdentifier());
+            if ($role !== null && ! $role->isSystemRole()) {
+                $this->roleRepository->delete($role);
+            }
+
+            $policy = $this->policyRepository->findById($affiliationGrant->policyIdentifier());
+            if ($policy !== null && ! $policy->isSystemPolicy()) {
+                $this->policyRepository->delete($policy);
+            }
+
             $this->affiliationGrantRepository->delete($affiliationGrant);
+        }
+    }
+
+    private function isAffiliationPrincipalGroup(PrincipalGroup $principalGroup): bool
+    {
+        return ! $principalGroup->isDefault()
+            && str_starts_with($principalGroup->name(), 'Affiliation - ');
+    }
+
+    private function restoreMembersToDefaultGroup(PrincipalGroup $principalGroup): void
+    {
+        $defaultPrincipalGroup = $this->principalGroupRepository->findDefaultByAccountId(
+            $principalGroup->accountIdentifier()
+        );
+
+        if ($defaultPrincipalGroup === null) {
+            return;
+        }
+
+        $defaultPrincipalGroupChanged = false;
+        foreach ($principalGroup->members() as $principalIdentifier) {
+            if (! $defaultPrincipalGroup->hasMember($principalIdentifier)) {
+                $defaultPrincipalGroup->addMember($principalIdentifier);
+                $defaultPrincipalGroupChanged = true;
+            }
+        }
+
+        if ($defaultPrincipalGroupChanged) {
+            $this->principalGroupRepository->save($defaultPrincipalGroup);
         }
     }
 }

--- a/tests/Wiki/Principal/Application/EventHandler/AffiliationTerminatedHandlerTest.php
+++ b/tests/Wiki/Principal/Application/EventHandler/AffiliationTerminatedHandlerTest.php
@@ -24,6 +24,7 @@ use Source\Wiki\Principal\Domain\ValueObject\AffiliationGrantType;
 use Source\Wiki\Principal\Domain\ValueObject\PolicyIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
@@ -64,12 +65,7 @@ class AffiliationTerminatedHandlerTest extends TestCase
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
 
-        $event = new AffiliationTerminated(
-            $affiliationIdentifier,
-            $agencyAccountIdentifier,
-            $talentAccountIdentifier,
-            new DateTimeImmutable(),
-        );
+        $event = $this->createEvent($affiliationIdentifier, $agencyAccountIdentifier, $talentAccountIdentifier);
 
         $talentSideGrant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
         $agencySideGrant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::AGENCY_SIDE);
@@ -77,13 +73,15 @@ class AffiliationTerminatedHandlerTest extends TestCase
         $talentSidePrincipalGroup = $this->createPrincipalGroup($talentAccountIdentifier, false);
         $agencySidePrincipalGroup = $this->createPrincipalGroup($agencyAccountIdentifier, false);
 
+        $talentDefaultPrincipalGroup = $this->createPrincipalGroup($talentAccountIdentifier, true);
+        $agencyDefaultPrincipalGroup = $this->createPrincipalGroup($agencyAccountIdentifier, true);
+
         $talentSidePolicy = $this->createPolicy($talentSideGrant->policyIdentifier());
         $agencySidePolicy = $this->createPolicy($agencySideGrant->policyIdentifier());
 
         $talentSideRole = $this->createRole($talentSideGrant->roleIdentifier());
         $agencySideRole = $this->createRole($agencySideGrant->roleIdentifier());
 
-        // Mocks
         $affiliationGrantRepository = Mockery::mock(AffiliationGrantRepositoryInterface::class);
         $affiliationGrantRepository
             ->shouldReceive('findByAffiliationId')
@@ -136,6 +134,19 @@ class AffiliationTerminatedHandlerTest extends TestCase
             ->once()
             ->andReturn($agencySidePrincipalGroup);
         $principalGroupRepository
+            ->shouldReceive('findDefaultByAccountId')
+            ->with($talentAccountIdentifier)
+            ->once()
+            ->andReturn($talentDefaultPrincipalGroup);
+        $principalGroupRepository
+            ->shouldReceive('findDefaultByAccountId')
+            ->with($agencyAccountIdentifier)
+            ->once()
+            ->andReturn($agencyDefaultPrincipalGroup);
+        $principalGroupRepository
+            ->shouldReceive('save')
+            ->twice();
+        $principalGroupRepository
             ->shouldReceive('delete')
             ->twice();
 
@@ -150,6 +161,147 @@ class AffiliationTerminatedHandlerTest extends TestCase
     }
 
     /**
+     * 正常系: Affiliation専用グループのPrincipalがDefaultグループに戻ること.
+     */
+    public function testHandleRestoresAffiliationGroupMembersToDefaultGroup(): void
+    {
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $grant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
+        $affiliationGroup = $this->createPrincipalGroup($accountIdentifier, false, 'Affiliation - Agency 1');
+        $affiliationGroup->addMember($principalIdentifier);
+        $affiliationGroup->addRole($grant->roleIdentifier());
+        $defaultGroup = $this->createPrincipalGroup($accountIdentifier, true, 'Default');
+
+        $principalGroupRepository = $this->mockPrincipalGroupRepositoryForSingleGrant($grant, $affiliationGroup, $defaultGroup);
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => $saved->isDefault()
+                && $saved->hasMember($principalIdentifier)));
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => ! $saved->isDefault()
+                && ! $saved->hasRole($grant->roleIdentifier())));
+        $principalGroupRepository->shouldReceive('delete')->once()->with($affiliationGroup);
+
+        $this->handleSingleGrant($affiliationIdentifier, $grant, $principalGroupRepository);
+    }
+
+    /**
+     * 正常系: 既にDefaultグループに所属しているPrincipalは重複追加されないこと.
+     */
+    public function testHandleDoesNotDuplicateMemberAlreadyInDefaultGroup(): void
+    {
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $grant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
+        $affiliationGroup = $this->createPrincipalGroup($accountIdentifier, false, 'Affiliation - Agency 1');
+        $affiliationGroup->addMember($principalIdentifier);
+        $defaultGroup = $this->createPrincipalGroup($accountIdentifier, true, 'Default');
+        $defaultGroup->addMember($principalIdentifier);
+
+        $principalGroupRepository = $this->mockPrincipalGroupRepositoryForSingleGrant($grant, $affiliationGroup, $defaultGroup);
+        $principalGroupRepository->shouldReceive('save')
+            ->once()
+            ->with(Mockery::on(static fn (PrincipalGroup $saved): bool => ! $saved->isDefault()
+                && $saved->memberCount() === 1));
+        $principalGroupRepository->shouldReceive('delete')->once()->with($affiliationGroup);
+
+        $this->handleSingleGrant($affiliationIdentifier, $grant, $principalGroupRepository);
+
+        $this->assertSame(1, $defaultGroup->memberCount());
+    }
+
+    /**
+     * 正常系: Defaultグループがない場合も失敗しないこと.
+     */
+    public function testHandleDoesNotFailWhenDefaultGroupDoesNotExist(): void
+    {
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $grant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
+        $affiliationGroup = $this->createPrincipalGroup($accountIdentifier, false, 'Affiliation - Agency 1');
+        $affiliationGroup->addMember(new PrincipalIdentifier(StrTestHelper::generateUuid()));
+
+        $principalGroupRepository = $this->mockPrincipalGroupRepositoryForSingleGrant($grant, $affiliationGroup, null);
+        $principalGroupRepository->shouldReceive('save')->once()->with($affiliationGroup);
+        $principalGroupRepository->shouldReceive('delete')->once()->with($affiliationGroup);
+
+        $this->handleSingleGrant($affiliationIdentifier, $grant, $principalGroupRepository);
+    }
+
+    /**
+     * 正常系: カテゴリ由来のPrincipalGroupやDefaultグループは削除しないこと.
+     */
+    public function testHandleDoesNotDeleteDefaultOrCategoryPrincipalGroups(): void
+    {
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $defaultGrant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
+        $actorGrant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::AGENCY_SIDE);
+        $defaultGroup = $this->createPrincipalGroup($accountIdentifier, true, 'Default');
+        $actorGroup = $this->createPrincipalGroup($accountIdentifier, false, 'Agency Actor');
+
+        $affiliationGrantRepository = $this->mockAffiliationGrantRepository($affiliationIdentifier, [$defaultGrant, $actorGrant]);
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findById')->with($defaultGrant->roleIdentifier())->once()->andReturnNull();
+        $roleRepository->shouldReceive('findById')->with($actorGrant->roleIdentifier())->once()->andReturnNull();
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findById')->with($defaultGrant->policyIdentifier())->once()->andReturnNull();
+        $policyRepository->shouldReceive('findById')->with($actorGrant->policyIdentifier())->once()->andReturnNull();
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findById')->with($defaultGrant->principalGroupIdentifier())->once()->andReturn($defaultGroup);
+        $principalGroupRepository->shouldReceive('findById')->with($actorGrant->principalGroupIdentifier())->once()->andReturn($actorGroup);
+        $principalGroupRepository->shouldNotReceive('findDefaultByAccountId');
+        $principalGroupRepository->shouldNotReceive('save');
+        $principalGroupRepository->shouldNotReceive('delete');
+
+        $this->app->instance(AffiliationGrantRepositoryInterface::class, $affiliationGrantRepository);
+        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(PolicyRepositoryInterface::class, $policyRepository);
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
+
+        $this->app->make(AffiliationTerminatedHandler::class)->handle(
+            $this->createEvent($affiliationIdentifier, $accountIdentifier, $accountIdentifier)
+        );
+    }
+
+    /**
+     * 正常系: system role/policy は削除しないこと.
+     */
+    public function testHandleDoesNotDeleteSystemRoleOrPolicy(): void
+    {
+        $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $grant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
+        $systemRole = $this->createRole($grant->roleIdentifier(), true);
+        $systemPolicy = $this->createPolicy($grant->policyIdentifier(), true);
+
+        $affiliationGrantRepository = $this->mockAffiliationGrantRepository($affiliationIdentifier, [$grant]);
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findById')->with($grant->roleIdentifier())->once()->andReturn($systemRole);
+        $roleRepository->shouldNotReceive('delete');
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findById')->with($grant->policyIdentifier())->once()->andReturn($systemPolicy);
+        $policyRepository->shouldNotReceive('delete');
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findById')->with($grant->principalGroupIdentifier())->once()->andReturnNull();
+        $principalGroupRepository->shouldNotReceive('save');
+        $principalGroupRepository->shouldNotReceive('delete');
+
+        $this->app->instance(AffiliationGrantRepositoryInterface::class, $affiliationGrantRepository);
+        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(PolicyRepositoryInterface::class, $policyRepository);
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
+
+        $this->app->make(AffiliationTerminatedHandler::class)->handle(
+            $this->createEvent($affiliationIdentifier, $accountIdentifier, $accountIdentifier)
+        );
+    }
+
+    /**
      * 正常系: Grant が存在しない場合は何もしないこと.
      *
      * @return void
@@ -161,12 +313,7 @@ class AffiliationTerminatedHandlerTest extends TestCase
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
 
-        $event = new AffiliationTerminated(
-            $affiliationIdentifier,
-            $agencyAccountIdentifier,
-            $talentAccountIdentifier,
-            new DateTimeImmutable(),
-        );
+        $event = $this->createEvent($affiliationIdentifier, $agencyAccountIdentifier, $talentAccountIdentifier);
 
         $affiliationGrantRepository = Mockery::mock(AffiliationGrantRepositoryInterface::class);
         $affiliationGrantRepository
@@ -195,74 +342,118 @@ class AffiliationTerminatedHandlerTest extends TestCase
     }
 
     /**
-     * 正常系: デフォルトのPrincipalGroupは削除しないこと.
-     *
-     * @return void
-     * @throws BindingResolutionException
+     * 正常系: 既に一部リソースがない場合も冪等に処理できること.
      */
-    public function testHandleSkipsDefaultPrincipalGroup(): void
+    public function testHandleIsIdempotentWhenSomeResourcesDoNotExist(): void
     {
         $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
-        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
-        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $grant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
 
-        $event = new AffiliationTerminated(
-            $affiliationIdentifier,
-            $agencyAccountIdentifier,
-            $talentAccountIdentifier,
-            new DateTimeImmutable(),
-        );
-
-        $talentSideGrant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
-
-        // Default PrincipalGroup
-        $defaultPrincipalGroup = $this->createPrincipalGroup($talentAccountIdentifier, true);
-        $talentSidePolicy = $this->createPolicy($talentSideGrant->policyIdentifier());
-        $talentSideRole = $this->createRole($talentSideGrant->roleIdentifier());
-
-        $affiliationGrantRepository = Mockery::mock(AffiliationGrantRepositoryInterface::class);
-        $affiliationGrantRepository
-            ->shouldReceive('findByAffiliationId')
-            ->with($affiliationIdentifier)
-            ->once()
-            ->andReturn([$talentSideGrant]);
-        $affiliationGrantRepository
-            ->shouldReceive('delete')
-            ->once();
-
+        $affiliationGrantRepository = $this->mockAffiliationGrantRepository($affiliationIdentifier, [$grant]);
         $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
-        $roleRepository
-            ->shouldReceive('findById')
-            ->once()
-            ->andReturn($talentSideRole);
-        $roleRepository
-            ->shouldReceive('delete')
-            ->once();
-
+        $roleRepository->shouldReceive('findById')->with($grant->roleIdentifier())->once()->andReturnNull();
+        $roleRepository->shouldNotReceive('delete');
         $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
-        $policyRepository
-            ->shouldReceive('findById')
-            ->once()
-            ->andReturn($talentSidePolicy);
-        $policyRepository
-            ->shouldReceive('delete')
-            ->once();
-
+        $policyRepository->shouldReceive('findById')->with($grant->policyIdentifier())->once()->andReturnNull();
+        $policyRepository->shouldNotReceive('delete');
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
-        $principalGroupRepository
-            ->shouldReceive('findById')
-            ->once()
-            ->andReturn($defaultPrincipalGroup);
-        $principalGroupRepository->shouldNotReceive('delete'); // Default なので削除されない
+        $principalGroupRepository->shouldReceive('findById')->with($grant->principalGroupIdentifier())->once()->andReturnNull();
+        $principalGroupRepository->shouldNotReceive('findDefaultByAccountId');
+        $principalGroupRepository->shouldNotReceive('save');
+        $principalGroupRepository->shouldNotReceive('delete');
 
         $this->app->instance(AffiliationGrantRepositoryInterface::class, $affiliationGrantRepository);
         $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
         $this->app->instance(PolicyRepositoryInterface::class, $policyRepository);
         $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
 
-        $handler = $this->app->make(AffiliationTerminatedHandler::class);
+        $this->app->make(AffiliationTerminatedHandler::class)->handle(
+            $this->createEvent($affiliationIdentifier, $accountIdentifier, $accountIdentifier)
+        );
+    }
 
-        $handler->handle($event);
+    private function handleSingleGrant(
+        AffiliationIdentifier $affiliationIdentifier,
+        AffiliationGrant $grant,
+        PrincipalGroupRepositoryInterface $principalGroupRepository,
+    ): void {
+        $affiliationGrantRepository = $this->mockAffiliationGrantRepository($affiliationIdentifier, [$grant]);
+        $role = $this->createRole($grant->roleIdentifier());
+        $roleRepository = Mockery::mock(RoleRepositoryInterface::class);
+        $roleRepository->shouldReceive('findById')->once()->with($grant->roleIdentifier())->andReturn($role);
+        $roleRepository->shouldReceive('delete')->once()->with($role);
+        $policy = $this->createPolicy($grant->policyIdentifier());
+        $policyRepository = Mockery::mock(PolicyRepositoryInterface::class);
+        $policyRepository->shouldReceive('findById')->once()->with($grant->policyIdentifier())->andReturn($policy);
+        $policyRepository->shouldReceive('delete')->once()->with($policy);
+
+        $this->app->instance(AffiliationGrantRepositoryInterface::class, $affiliationGrantRepository);
+        $this->app->instance(RoleRepositoryInterface::class, $roleRepository);
+        $this->app->instance(PolicyRepositoryInterface::class, $policyRepository);
+        $this->app->instance(PrincipalGroupRepositoryInterface::class, $principalGroupRepository);
+
+        $this->app->make(AffiliationTerminatedHandler::class)->handle(
+            $this->createEvent(
+                $affiliationIdentifier,
+                new AccountIdentifier(StrTestHelper::generateUuid()),
+                new AccountIdentifier(StrTestHelper::generateUuid()),
+            )
+        );
+    }
+
+    /**
+     * @param AffiliationGrant[] $grants
+     * @return AffiliationGrantRepositoryInterface&Mockery\MockInterface
+     */
+    private function mockAffiliationGrantRepository(
+        AffiliationIdentifier $affiliationIdentifier,
+        array $grants,
+    ): AffiliationGrantRepositoryInterface {
+        /** @var AffiliationGrantRepositoryInterface&Mockery\MockInterface $affiliationGrantRepository */
+        $affiliationGrantRepository = Mockery::mock(AffiliationGrantRepositoryInterface::class);
+        $affiliationGrantRepository->shouldReceive('findByAffiliationId')
+            ->once()
+            ->with($affiliationIdentifier)
+            ->andReturn($grants);
+        $affiliationGrantRepository->shouldReceive('delete')->times(count($grants));
+
+        return $affiliationGrantRepository;
+    }
+
+    /**
+     * @return PrincipalGroupRepositoryInterface&Mockery\MockInterface
+     */
+    private function mockPrincipalGroupRepositoryForSingleGrant(
+        AffiliationGrant $grant,
+        PrincipalGroup $affiliationGroup,
+        ?PrincipalGroup $defaultGroup,
+    ): PrincipalGroupRepositoryInterface {
+        /** @var PrincipalGroupRepositoryInterface&Mockery\MockInterface $principalGroupRepository */
+        $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
+        $principalGroupRepository->shouldReceive('findById')
+            ->once()
+            ->with($grant->principalGroupIdentifier())
+            ->andReturn($affiliationGroup);
+        $principalGroupRepository->shouldReceive('findDefaultByAccountId')
+            ->once()
+            ->with($affiliationGroup->accountIdentifier())
+            ->andReturn($defaultGroup);
+
+        return $principalGroupRepository;
+    }
+
+    private function createEvent(
+        AffiliationIdentifier $affiliationIdentifier,
+        AccountIdentifier $agencyAccountIdentifier,
+        AccountIdentifier $talentAccountIdentifier,
+    ): AffiliationTerminated {
+        return new AffiliationTerminated(
+            $affiliationIdentifier,
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            new DateTimeImmutable(),
+        );
     }
 
     private function createAffiliationGrant(
@@ -280,35 +471,38 @@ class AffiliationTerminatedHandlerTest extends TestCase
         );
     }
 
-    private function createPrincipalGroup(AccountIdentifier $accountIdentifier, bool $isDefault): PrincipalGroup
-    {
+    private function createPrincipalGroup(
+        AccountIdentifier $accountIdentifier,
+        bool $isDefault,
+        string $name = 'Affiliation - Test',
+    ): PrincipalGroup {
         return new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
             $accountIdentifier,
-            'Test Group',
+            $name,
             $isDefault,
             new DateTimeImmutable(),
         );
     }
 
-    private function createPolicy(PolicyIdentifier $policyIdentifier): Policy
+    private function createPolicy(PolicyIdentifier $policyIdentifier, bool $isSystemPolicy = false): Policy
     {
         return new Policy(
             $policyIdentifier,
             'Test Policy',
             [],
-            false,
+            $isSystemPolicy,
             new DateTimeImmutable(),
         );
     }
 
-    private function createRole(RoleIdentifier $roleIdentifier): Role
+    private function createRole(RoleIdentifier $roleIdentifier, bool $isSystemRole = false): Role
     {
         return new Role(
             $roleIdentifier,
             'Test Role',
             [],
-            false,
+            $isSystemRole,
             new DateTimeImmutable(),
         );
     }


### PR DESCRIPTION
## 📝 変更内容

- `AffiliationTerminatedHandler` で Affiliation 専用 PrincipalGroup を削除する前に、所属 Principal を同一 account の Default PrincipalGroup へ戻すように変更しました。
- Affiliation 専用 group から grant に記録された role を detach してから group を保存・削除するようにしました。
- grant に紐づく role / policy は存在する場合のみ、かつ system role / system policy ではない場合のみ削除するようにしました。
- `Affiliation - ...` ではないカテゴリ由来 group（例: `Agency Actor` / `Talent Actor`）および Default group を削除対象から外しました。
- Affiliation 終了時 cleanup の受け入れ条件に対応する EventHandler テストを追加・更新しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Affiliation 終了時の Wiki 権限剥奪処理を、新しい動的 condition policy / カテゴリ別 PrincipalGroup 設計に合わせるためです。

Affiliation 専用 PrincipalGroup は契約単位の一時的な権限付与の器として扱い、終了時に削除します。一方で、その group に所属していた Principal が終了後に通常の collaborator 相当権限を失わないよう、削除前に Default PrincipalGroup へ復帰させます。

また、カテゴリ由来の `Agency Actor` / `Talent Actor` や標準の `Default` group、および system role / system policy は cleanup 対象にしないようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `docker-compose run --rm --no-deps php ./vendor/bin/phpunit --no-coverage tests/Wiki/Principal/Application/EventHandler/AffiliationTerminatedHandlerTest.php` を実行し、対象テストがパスすることを確認
  - `OK (9 tests, 81 assertions)`
- [x] `docker-compose run --rm --no-deps php composer cs-fix -- --dry-run --diff` を実行し、修正対象がないことを確認
  - `Found 0 of 2536 files that can be fixed`
- [x] `docker-compose run --rm --no-deps php composer phpstan -- --memory-limit=1G` を実行し、静的解析がパスすることを確認
  - `[OK] No errors`
- [x] `task check` を実行し、CS Fixer / PHPStan / 全 PHPUnit がパスすることを確認
  - `Fixed 0 of 2536 files`
  - `[OK] No errors`
  - `OK (3027 tests, 9715 assertions)`
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

自動テストで以下を確認しています。

- Affiliation 専用 group の Principal を Default group に戻すこと
- Default group に既に所属している Principal を重複追加しないこと
- Default group がない場合も失敗しないこと
- Affiliation 専用 group を削除すること
- Default / カテゴリ由来 group は削除しないこと
- Affiliation 専用 role detach を行うこと
- role / policy / grant 削除を行うこと
- 一部リソースが存在しない場合も冪等に処理できること
- system role / system policy は削除しないこと

## 🔍 レビューのポイント

- Affiliation 専用 PrincipalGroup の判定を `Affiliation - ` prefix と `!isDefault()` に限定している点
- Principal を Default group へ戻す処理が重複追加を避けている点
- role detach → group 保存 → group 削除 → role/policy/grant 削除の順序
- system role / system policy を削除しないガード
- Default group が存在しない場合でも handler が失敗しない挙動

## 📖 関連情報

### 関連Issue・タスク

Closes #532

## ⚠️ 注意事項

- SSH push は `git@github.com: Permission denied (publickey).` で失敗したため、`gh` 認証済み token を使った HTTPS の one-off push で branch を push しました。
- `origin` remote は変更せず `git@github-work:kpool09122/kpool-backend.git` のままです。branch upstream は `origin/issue-532-affiliation-terminated-cleanup` に復旧済みです。
- `task check` 初回は既存の別 worktree container が `6380` / `5433` を使用していたため失敗しました。該当 stale container を停止・削除して再実行し、最終的に成功しています。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した

## Review skills / 代替レビュー

プロジェクト指定の review skill は global / Codex / repo-local のいずれでも見つかりませんでした。

Unavailable review skills:

- `qa-review`
- `test-review`
- `security-review`
- `architecture-review`

代替として同一セッション内で同期レビューを実施しました。

- QA review: Issue の受け入れ条件と追加テストを照合し、Default group 復帰、重複回避、Default なし、カテゴリ由来 group 非削除、role detach、role/policy/grant 削除、冪等性を確認しました。
- Test review: 対象 PHPUnit、CS Fixer dry-run、PHPStan、`task check` の実行結果を確認しました。初回の port conflict は stale container 起因で、解消後に full check が成功しています。
- Security review: system role / system policy を削除しないガードを追加し、Affiliation cleanup が標準・カテゴリ由来の権限器を誤削除しないことを確認しました。
- Architecture review: Affiliation 専用 group の cleanup を `AffiliationTerminatedHandler` に閉じ、Default group 復帰処理を private method に分離しました。既存の `PrincipalGroup` API（`members()` / `hasMember()` / `addMember()` / `removeRole()`）を使い、旧 static group 互換や後方互換処理は追加していません。

未対応のレビュー指摘:

- なし
