### PR TITLE
refactor: Wiki Principalのスコープ解決をAccount経由に変更

### DIFF
--- a/application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapper.php
+++ b/application/Http/Action/Wiki/Wiki/Command/Support/WikiCommandPayloadMapper.php
@@ -27,7 +27,7 @@ final class WikiCommandPayloadMapper
             ResourceType::GROUP => GroupBasic::fromArray(self::groupBasic($basic)),
             ResourceType::TALENT => TalentBasic::fromArray(self::talentBasic($basic)),
             ResourceType::SONG => SongBasic::fromArray(self::songBasic($basic)),
-            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->value . ' resource type does not have a Basic.'),
+            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->name . ' resource type does not have a Basic.'),
         };
     }
 

--- a/application/Models/Wiki/Principal.php
+++ b/application/Models/Wiki/Principal.php
@@ -12,9 +12,6 @@ use Illuminate\Support\Carbon;
 /**
  * @property string $id
  * @property string $identity_id
- * @property ?string $agency_id
- * @property array<string> $group_ids
- * @property array<string> $talent_ids
  * @property ?string $delegation_identifier
  * @property bool $enabled
  * @property ?Carbon $created_at
@@ -24,9 +21,6 @@ use Illuminate\Support\Carbon;
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',
     'identity_id',
-    'agency_id',
-    'group_ids',
-    'talent_ids',
     'delegation_identifier',
     'enabled',
 ])]
@@ -40,8 +34,6 @@ class Principal extends Model
     protected function casts(): array
     {
         return [
-            'group_ids' => 'array',
-            'talent_ids' => 'array',
             'enabled' => 'boolean',
         ];
     }

--- a/application/Providers/Wiki/DomainServiceProvider.php
+++ b/application/Providers/Wiki/DomainServiceProvider.php
@@ -48,6 +48,7 @@ use Source\Wiki\OfficialCertification\Infrastructure\Repository\OfficialCertific
 use Source\Wiki\OfficialCertification\Infrastructure\Service\OfficialResourceUpdater;
 use Source\Wiki\Principal\Application\Service\AffiliationQueryServiceInterface;
 use Source\Wiki\Principal\Application\Service\ContributionPointServiceInterface;
+use Source\Wiki\Principal\Application\Service\PrincipalWikiScopeResolverInterface;
 use Source\Wiki\Principal\Domain\Factory\AffiliationGrantFactoryInterface;
 use Source\Wiki\Principal\Domain\Factory\PolicyFactoryInterface;
 use Source\Wiki\Principal\Domain\Factory\PrincipalFactoryInterface;
@@ -73,6 +74,7 @@ use Source\Wiki\Principal\Infrastructure\Repository\RoleRepository;
 use Source\Wiki\Principal\Infrastructure\Service\AffiliationConditionValueResolver;
 use Source\Wiki\Principal\Infrastructure\Service\AffiliationQueryService;
 use Source\Wiki\Principal\Infrastructure\Service\PolicyEvaluator;
+use Source\Wiki\Principal\Infrastructure\Service\PrincipalWikiScopeResolver;
 use Source\Wiki\Shared\Domain\Service\NormalizationServiceInterface;
 use Source\Wiki\Shared\Infrastructure\Service\NormalizationService;
 use Source\Wiki\VideoLink\Application\UseCase\Command\SaveVideoLinks\SaveVideoLinks;
@@ -131,6 +133,7 @@ class DomainServiceProvider extends ServiceProvider
         $this->app->singleton(PrincipalGroupRepositoryInterface::class, PrincipalGroupRepository::class);
         $this->app->singleton(PolicyRepositoryInterface::class, PolicyRepository::class);
         $this->app->singleton(RoleRepositoryInterface::class, RoleRepository::class);
+        $this->app->singleton(PrincipalWikiScopeResolverInterface::class, PrincipalWikiScopeResolver::class);
         $this->app->singleton(ConditionValueResolverInterface::class, AffiliationConditionValueResolver::class);
         $this->app->singleton(PolicyEvaluatorInterface::class, PolicyEvaluator::class);
         $this->app->singleton(AffiliationQueryServiceInterface::class, AffiliationQueryService::class);

--- a/database/migrations/2024_01_01_000003_create_wiki_principals_table.php
+++ b/database/migrations/2024_01_01_000003_create_wiki_principals_table.php
@@ -14,9 +14,6 @@ return new class extends Migration
         Schema::create('wiki_principals', static function (Blueprint $table) {
             $table->uuid('id')->primary()->comment('プリンシパル ID');
             $table->uuid('identity_id')->comment('Identity ID');
-            $table->uuid('agency_id')->nullable()->comment('事務所ID');
-            $table->json('talent_ids')->default('[]')->comment('タレントID');
-            $table->json('group_ids')->default('[]')->comment('グループID');
             $table->uuid('delegation_identifier')->nullable()->comment('委譲ID (nullなら本人)');
             $table->boolean('enabled')->default(true)->comment('有効フラグ');
             $table->timestamps();

--- a/database/seeders/OperationsAccountSeeder.php
+++ b/database/seeders/OperationsAccountSeeder.php
@@ -108,9 +108,6 @@ class OperationsAccountSeeder extends Seeder
         DB::table('wiki_principals')->upsert([[
             'id' => $principalId,
             'identity_id' => $identityId,
-            'agency_id' => null,
-            'group_ids' => json_encode([], JSON_THROW_ON_ERROR),
-            'talent_ids' => json_encode([], JSON_THROW_ON_ERROR),
             'delegation_identifier' => null,
             'enabled' => true,
             'created_at' => $now,

--- a/database/seeders/SystemPolicySeeder.php
+++ b/database/seeders/SystemPolicySeeder.php
@@ -166,7 +166,7 @@ class SystemPolicySeeder extends Seeder
             new ConditionClause(
                 ConditionKey::RESOURCE_AGENCY_ID,
                 ConditionOperator::EQUALS,
-                ConditionValue::PRINCIPAL_AGENCY_ID,
+                ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS,
             ),
         ]);
     }
@@ -177,7 +177,7 @@ class SystemPolicySeeder extends Seeder
             new ConditionClause(
                 ConditionKey::RESOURCE_TALENT_ID,
                 ConditionOperator::IN,
-                ConditionValue::PRINCIPAL_TALENT_IDS,
+                ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS,
             ),
         ]);
     }

--- a/src/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandler.php
+++ b/src/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandler.php
@@ -184,7 +184,7 @@ readonly class AffiliationActivatedHandler
                 [ResourceType::GROUP],
                 new Condition([
                     new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
-                    new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_IDS),
+                    new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS),
                 ]),
             ),
             // Song (Group経由): AgencyがSongに紐づいている AND 自身が所属するGroupがSongに紐づいている
@@ -194,7 +194,7 @@ readonly class AffiliationActivatedHandler
                 [ResourceType::SONG],
                 new Condition([
                     new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
-                    new ConditionClause(ConditionKey::RESOURCE_GROUP_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_WIKI_GROUP_IDS),
+                    new ConditionClause(ConditionKey::RESOURCE_GROUP_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS),
                 ]),
             ),
             // Song (Talent経由): AgencyがSongに紐づいている AND 自身のTalentがSongに紐づいている
@@ -204,7 +204,7 @@ readonly class AffiliationActivatedHandler
                 [ResourceType::SONG],
                 new Condition([
                     new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
-                    new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_IDS),
+                    new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS),
                 ]),
             ),
         ];
@@ -229,7 +229,7 @@ readonly class AffiliationActivatedHandler
                     new ConditionClause(
                         ConditionKey::RESOURCE_TALENT_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS,
+                        ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS,
                     ),
                 ]),
             ),

--- a/src/Wiki/Principal/Application/Service/PrincipalWikiScopeResolverInterface.php
+++ b/src/Wiki/Principal/Application/Service/PrincipalWikiScopeResolverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\Service;
+
+use Source\Wiki\Principal\Domain\Entity\Principal;
+
+interface PrincipalWikiScopeResolverInterface
+{
+    /** @return string[] */
+    public function agencyWikiIdentifiers(Principal $principal): array;
+
+    /** @return string[] */
+    public function groupWikiIdentifiers(Principal $principal): array;
+
+    /** @return string[] */
+    public function talentGroupWikiIdentifiers(Principal $principal): array;
+
+    /** @return string[] */
+    public function talentWikiIdentifiers(Principal $principal): array;
+
+    /** @return string[] */
+    public function affiliatedTalentWikiIdentifiers(Principal $principal): array;
+}

--- a/src/Wiki/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
+++ b/src/Wiki/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Source\Wiki\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers;
 
 use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface as AccountPrincipalRepositoryInterface;
 use Source\Account\Shared\Domain\ValueObject\AccountType;
 use Source\Wiki\Principal\Application\Exception\CannotRemoveLastWikiAdministratorException;
 use Source\Wiki\Principal\Application\Exception\PrincipalGroupNotFoundException;
@@ -29,6 +30,7 @@ readonly class UpdatePrincipalGroupMembers implements UpdatePrincipalGroupMember
         private PrincipalRepositoryInterface $principalRepository,
         private RoleRepositoryInterface $roleRepository,
         private PolicyEvaluatorInterface $policyEvaluator,
+        private AccountPrincipalRepositoryInterface $accountPrincipalRepository,
     ) {
     }
 
@@ -39,7 +41,7 @@ readonly class UpdatePrincipalGroupMembers implements UpdatePrincipalGroupMember
         }
 
         $operator = $this->principalRepository->findById($input->operatorPrincipalIdentifier());
-        if ($operator === null || $operator->agencyId() !== (string) $input->accountIdentifier()) {
+        if ($operator === null || ! $this->belongsToAccount($operator, $input)) {
             throw new AccountUpdateForbiddenException();
         }
 
@@ -87,10 +89,18 @@ readonly class UpdatePrincipalGroupMembers implements UpdatePrincipalGroupMember
     {
         foreach ($principalIdentifiers as $principalIdentifier) {
             $principal = $principalsById[(string) $principalIdentifier] ?? null;
-            if ($principal === null || $principal->agencyId() !== (string) $input->accountIdentifier()) {
+            if ($principal === null || ! $this->belongsToAccount($principal, $input)) {
                 throw new PrincipalNotFoundException();
             }
         }
+    }
+
+    private function belongsToAccount(Principal $principal, UpdatePrincipalGroupMembersInputPort $input): bool
+    {
+        return $this->accountPrincipalRepository->findByIdentityIdentifierAndAccountIdentifier(
+            $principal->identityIdentifier(),
+            $input->accountIdentifier(),
+        ) !== null;
     }
 
     /** @param array<int, PrincipalGroup> $principalGroups */

--- a/src/Wiki/Principal/Domain/Entity/Principal.php
+++ b/src/Wiki/Principal/Domain/Entity/Principal.php
@@ -14,18 +14,12 @@ class Principal
     /**
      * @param PrincipalIdentifier $principalIdentifier
      * @param IdentityIdentifier $identityIdentifier
-     * @param string|null $agencyId
-     * @param string[] $groupIds
-     * @param string[] $talentIds
      * @param DelegationIdentifier|null $delegationIdentifier
      * @param bool $enabled
      */
     public function __construct(
         private readonly PrincipalIdentifier $principalIdentifier,
         private readonly IdentityIdentifier  $identityIdentifier,
-        private readonly ?string             $agencyId,
-        private readonly array               $groupIds,
-        private readonly array               $talentIds,
         private readonly ?DelegationIdentifier $delegationIdentifier = null,
         private bool                         $enabled = true,
     ) {
@@ -39,27 +33,6 @@ class Principal
     public function identityIdentifier(): IdentityIdentifier
     {
         return $this->identityIdentifier;
-    }
-
-    public function agencyId(): ?string
-    {
-        return $this->agencyId;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function groupIds(): array
-    {
-        return $this->groupIds;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function talentIds(): array
-    {
-        return $this->talentIds;
     }
 
     public function delegationIdentifier(): ?DelegationIdentifier

--- a/src/Wiki/Principal/Domain/ValueObject/ConditionValue.php
+++ b/src/Wiki/Principal/Domain/ValueObject/ConditionValue.php
@@ -6,9 +6,10 @@ namespace Source\Wiki\Principal\Domain\ValueObject;
 
 enum ConditionValue: string
 {
-    case PRINCIPAL_AGENCY_ID = '${principal.agencyId}';
-    case PRINCIPAL_WIKI_GROUP_IDS = '${principal.wikiGroupIds}';
-    case PRINCIPAL_TALENT_IDS = '${principal.talentIds}';
-    case PRINCIPAL_AFFILIATED_TALENT_IDS = '${principal.affiliatedTalentIds}';
+    case PRINCIPAL_AGENCY_WIKI_IDENTIFIERS = '${principal.agencyWikiIdentifiers}';
+    case PRINCIPAL_GROUP_WIKI_IDENTIFIERS = '${principal.groupWikiIdentifiers}';
+    case PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS = '${principal.talentGroupWikiIdentifiers}';
+    case PRINCIPAL_TALENT_WIKI_IDENTIFIERS = '${principal.talentWikiIdentifiers}';
+    case PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS = '${principal.affiliatedTalentWikiIdentifiers}';
     case PRINCIPAL_ID = '${principal.id}';
 }

--- a/src/Wiki/Principal/Infrastructure/Factory/PrincipalFactory.php
+++ b/src/Wiki/Principal/Infrastructure/Factory/PrincipalFactory.php
@@ -25,9 +25,6 @@ readonly class PrincipalFactory implements PrincipalFactoryInterface
             new PrincipalIdentifier($this->uuidGenerator->generate()),
             $identityIdentifier,
             null,
-            [],
-            [],
-            null,
             true,
         );
     }
@@ -40,9 +37,6 @@ readonly class PrincipalFactory implements PrincipalFactoryInterface
         return new Principal(
             new PrincipalIdentifier($this->uuidGenerator->generate()),
             $delegatedIdentityIdentifier,
-            $originalPrincipal->agencyId(),
-            $originalPrincipal->groupIds(),
-            $originalPrincipal->talentIds(),
             $delegationIdentifier,
             true,
         );

--- a/src/Wiki/Principal/Infrastructure/Repository/PrincipalRepository.php
+++ b/src/Wiki/Principal/Infrastructure/Repository/PrincipalRepository.php
@@ -82,7 +82,9 @@ class PrincipalRepository implements PrincipalRepositoryInterface
     public function findByAccountId(AccountIdentifier $accountIdentifier): array
     {
         $eloquents = PrincipalEloquent::query()
-            ->where('agency_id', (string) $accountIdentifier)
+            ->select('wiki_principals.*')
+            ->join('account_principals', 'wiki_principals.identity_id', '=', 'account_principals.identity_id')
+            ->where('account_principals.account_id', (string) $accountIdentifier)
             ->get();
 
         return $eloquents->map(fn (PrincipalEloquent $eloquent) => $this->toDomainEntity($eloquent))->all();
@@ -98,9 +100,6 @@ class PrincipalRepository implements PrincipalRepositoryInterface
             ['id' => (string) $principal->principalIdentifier()],
             [
                 'identity_id' => (string) $principal->identityIdentifier(),
-                'agency_id' => $principal->agencyId(),
-                'group_ids' => $principal->groupIds(),
-                'talent_ids' => $principal->talentIds(),
                 'delegation_identifier' => $principal->delegationIdentifier() !== null
                     ? (string) $principal->delegationIdentifier()
                     : null,
@@ -134,9 +133,6 @@ class PrincipalRepository implements PrincipalRepositoryInterface
         return new Principal(
             new PrincipalIdentifier($eloquent->id),
             new IdentityIdentifier($eloquent->identity_id),
-            $eloquent->agency_id,
-            $eloquent->group_ids,
-            $eloquent->talent_ids,
             $eloquent->delegation_identifier !== null
                 ? new DelegationIdentifier($eloquent->delegation_identifier)
                 : null,

--- a/src/Wiki/Principal/Infrastructure/Service/AffiliationConditionValueResolver.php
+++ b/src/Wiki/Principal/Infrastructure/Service/AffiliationConditionValueResolver.php
@@ -4,53 +4,23 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Infrastructure\Service;
 
-use Source\Account\Affiliation\Domain\Repository\AffiliationRepositoryInterface;
-use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
-use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\Service\PrincipalWikiScopeResolverInterface;
 use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Service\ConditionValueResolverInterface;
 use Source\Wiki\Principal\Domain\ValueObject\ConditionValue;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
-use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
 
 class AffiliationConditionValueResolver extends PrincipalConditionValueResolver implements ConditionValueResolverInterface
 {
-    public function __construct(
-        private readonly AffiliationRepositoryInterface $affiliationRepository,
-        private readonly WikiRepositoryInterface $wikiRepository,
-    ) {
+    public function __construct(PrincipalWikiScopeResolverInterface $principalWikiScopeResolver)
+    {
+        parent::__construct($principalWikiScopeResolver);
     }
 
     /**
-     * @return string|string[]|bool|null
+     * @return string|string[]|bool
      */
-    public function resolve(ConditionValue|string|bool $value, Principal $principal): string|array|bool|null
+    public function resolve(ConditionValue|string|bool $value, Principal $principal): string|array|bool
     {
-        if ($value !== ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS) {
-            return parent::resolve($value, $principal);
-        }
-
-        $agencyId = $principal->agencyId();
-        if ($agencyId === null) {
-            return [];
-        }
-
-        $affiliations = $this->affiliationRepository->findByAgencyAccount(
-            new AccountIdentifier($agencyId),
-            AffiliationStatus::ACTIVE,
-        );
-
-        $talentIds = [];
-        foreach ($affiliations as $affiliation) {
-            $wiki = $this->wikiRepository->findByOwnerAccountId(
-                $affiliation->talentAccountIdentifier(),
-                ResourceType::TALENT,
-            );
-            if ($wiki !== null) {
-                $talentIds[(string) $wiki->wikiIdentifier()] = (string) $wiki->wikiIdentifier();
-            }
-        }
-
-        return array_values($talentIds);
+        return parent::resolve($value, $principal);
     }
 }

--- a/src/Wiki/Principal/Infrastructure/Service/PolicyEvaluator.php
+++ b/src/Wiki/Principal/Infrastructure/Service/PolicyEvaluator.php
@@ -214,13 +214,16 @@ readonly class PolicyEvaluator implements PolicyEvaluatorInterface
             return count(array_intersect($resourceValue, $conditionValue)) > 0;
         }
 
-        // スカラー同士の比較
-        if (! is_array($resourceValue) && ! is_array($conditionValue)) {
-            return $resourceValue === $conditionValue;
+        if (is_array($resourceValue) && ! is_array($conditionValue)) {
+            return in_array($conditionValue, $resourceValue, true);
         }
 
-        // 型が異なる場合は false
-        return false;
+        if (! is_array($resourceValue) && is_array($conditionValue)) {
+            return in_array($resourceValue, $conditionValue, true);
+        }
+
+        // スカラー同士の比較
+        return $resourceValue === $conditionValue;
     }
 
     /**

--- a/src/Wiki/Principal/Infrastructure/Service/PrincipalConditionValueResolver.php
+++ b/src/Wiki/Principal/Infrastructure/Service/PrincipalConditionValueResolver.php
@@ -4,27 +4,33 @@ declare(strict_types=1);
 
 namespace Source\Wiki\Principal\Infrastructure\Service;
 
+use Source\Wiki\Principal\Application\Service\PrincipalWikiScopeResolverInterface;
 use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Service\ConditionValueResolverInterface;
 use Source\Wiki\Principal\Domain\ValueObject\ConditionValue;
 
 class PrincipalConditionValueResolver implements ConditionValueResolverInterface
 {
+    public function __construct(private readonly PrincipalWikiScopeResolverInterface $principalWikiScopeResolver)
+    {
+    }
+
     /**
-     * @return string|string[]|bool|null
+     * @return string|string[]|bool
      */
-    public function resolve(ConditionValue|string|bool $value, Principal $principal): string|array|bool|null
+    public function resolve(ConditionValue|string|bool $value, Principal $principal): string|array|bool
     {
         if (! $value instanceof ConditionValue) {
             return $value;
         }
 
         return match ($value) {
-            ConditionValue::PRINCIPAL_AGENCY_ID => $principal->agencyId(),
-            ConditionValue::PRINCIPAL_WIKI_GROUP_IDS => $principal->groupIds(),
-            ConditionValue::PRINCIPAL_TALENT_IDS => $principal->talentIds(),
+            ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS => $this->principalWikiScopeResolver->agencyWikiIdentifiers($principal),
+            ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS => $this->principalWikiScopeResolver->groupWikiIdentifiers($principal),
+            ConditionValue::PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS => $this->principalWikiScopeResolver->talentGroupWikiIdentifiers($principal),
+            ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS => $this->principalWikiScopeResolver->talentWikiIdentifiers($principal),
             ConditionValue::PRINCIPAL_ID => (string) $principal->principalIdentifier(),
-            ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS => [],
+            ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS => $this->principalWikiScopeResolver->affiliatedTalentWikiIdentifiers($principal),
         };
     }
 }

--- a/src/Wiki/Principal/Infrastructure/Service/PrincipalWikiScopeResolver.php
+++ b/src/Wiki/Principal/Infrastructure/Service/PrincipalWikiScopeResolver.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Infrastructure\Service;
+
+use Application\Models\Account\Principal as AccountPrincipalEloquent;
+use Application\Models\Wiki\Wiki as WikiEloquent;
+use Illuminate\Support\Facades\DB;
+use Source\Account\Affiliation\Domain\Repository\AffiliationRepositoryInterface;
+use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\Service\PrincipalWikiScopeResolverInterface;
+use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
+
+readonly class PrincipalWikiScopeResolver implements PrincipalWikiScopeResolverInterface
+{
+    public function __construct(
+        private AffiliationRepositoryInterface $affiliationRepository,
+        private WikiRepositoryInterface $wikiRepository,
+    ) {
+    }
+
+    /** @return string[] */
+    public function agencyWikiIdentifiers(Principal $principal): array
+    {
+        return $this->ownedWikiIdentifiers($principal, ResourceType::AGENCY);
+    }
+
+    /** @return string[] */
+    public function groupWikiIdentifiers(Principal $principal): array
+    {
+        return $this->ownedWikiIdentifiers($principal, ResourceType::GROUP);
+    }
+
+    /** @return string[] */
+    public function talentGroupWikiIdentifiers(Principal $principal): array
+    {
+        $talentWikiIdentifiers = $this->talentWikiIdentifiers($principal);
+        if (empty($talentWikiIdentifiers)) {
+            return [];
+        }
+
+        return DB::table('wiki_talent_basic_groups')
+            ->whereIn('wiki_id', $talentWikiIdentifiers)
+            ->pluck('group_identifier')
+            ->map(static fn (mixed $id): string => (string) $id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /** @return string[] */
+    public function talentWikiIdentifiers(Principal $principal): array
+    {
+        return $this->ownedWikiIdentifiers($principal, ResourceType::TALENT);
+    }
+
+    /** @return string[] */
+    public function affiliatedTalentWikiIdentifiers(Principal $principal): array
+    {
+        $talentWikiIdentifiers = [];
+
+        foreach ($this->accountIdentifiers($principal) as $accountIdentifier) {
+            $affiliations = $this->affiliationRepository->findByAgencyAccount(
+                new AccountIdentifier($accountIdentifier),
+                AffiliationStatus::ACTIVE,
+            );
+
+            foreach ($affiliations as $affiliation) {
+                $wiki = $this->wikiRepository->findByOwnerAccountId(
+                    $affiliation->talentAccountIdentifier(),
+                    ResourceType::TALENT,
+                );
+
+                if ($wiki !== null) {
+                    $talentWikiIdentifiers[(string) $wiki->wikiIdentifier()] = (string) $wiki->wikiIdentifier();
+                }
+            }
+        }
+
+        return array_values($talentWikiIdentifiers);
+    }
+
+    /** @return string[] */
+    private function ownedWikiIdentifiers(Principal $principal, ResourceType $resourceType): array
+    {
+        $accountIdentifiers = $this->accountIdentifiers($principal);
+        if (empty($accountIdentifiers)) {
+            return [];
+        }
+
+        return WikiEloquent::query()
+            ->whereIn('owner_account_id', $accountIdentifiers)
+            ->where('resource_type', $resourceType->value)
+            ->pluck('id')
+            ->map(static fn (mixed $id): string => (string) $id)
+            ->all();
+    }
+
+    /** @return string[] */
+    private function accountIdentifiers(Principal $principal): array
+    {
+        return AccountPrincipalEloquent::query()
+            ->where('identity_id', (string) $principal->identityIdentifier())
+            ->pluck('account_id')
+            ->map(static fn (mixed $id): string => (string) $id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/src/Wiki/Wiki/Infrastructure/Repository/DraftWikiRepository.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/DraftWikiRepository.php
@@ -230,7 +230,7 @@ readonly class DraftWikiRepository implements DraftWikiRepositoryInterface
                 $songBasic->groups()->sync($groupIdentifiers ?? []);
                 $songBasic->talents()->sync($talentIdentifiers ?? []);
             })(),
-            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->value . ' resource type does not have a Basic.'),
+            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->name . ' resource type does not have a Basic.'),
         };
     }
 
@@ -242,7 +242,7 @@ readonly class DraftWikiRepository implements DraftWikiRepositoryInterface
             ResourceType::GROUP => $this->buildGroupBasic($model),
             ResourceType::AGENCY => $this->buildAgencyBasic($model),
             ResourceType::SONG => $this->buildSongBasic($model),
-            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->value . ' resource type does not have a Basic.'),
+            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->name . ' resource type does not have a Basic.'),
         };
 
         return new DraftWiki(

--- a/src/Wiki/Wiki/Infrastructure/Repository/WikiRepository.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/WikiRepository.php
@@ -233,7 +233,7 @@ readonly class WikiRepository implements WikiRepositoryInterface
                 $songBasic->groups()->sync($groupIdentifiers ?? []);
                 $songBasic->talents()->sync($talentIdentifiers ?? []);
             })(),
-            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->value . ' resource type does not have a Basic.'),
+            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->name . ' resource type does not have a Basic.'),
         };
     }
 
@@ -276,7 +276,7 @@ readonly class WikiRepository implements WikiRepositoryInterface
             ResourceType::GROUP => $this->buildGroupBasic($model),
             ResourceType::AGENCY => $this->buildAgencyBasic($model),
             ResourceType::SONG => $this->buildSongBasic($model),
-            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->value . ' resource type does not have a Basic.'),
+            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->name . ' resource type does not have a Basic.'),
         };
     }
 

--- a/src/Wiki/Wiki/Infrastructure/Repository/WikiSnapshotRepository.php
+++ b/src/Wiki/Wiki/Infrastructure/Repository/WikiSnapshotRepository.php
@@ -159,7 +159,7 @@ readonly class WikiSnapshotRepository implements WikiSnapshotRepositoryInterface
                 $songBasic->groups()->sync($groupIdentifiers ?? []);
                 $songBasic->talents()->sync($talentIdentifiers ?? []);
             })(),
-            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->value . ' resource type does not have a Basic.'),
+            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->name . ' resource type does not have a Basic.'),
         };
     }
 
@@ -202,7 +202,7 @@ readonly class WikiSnapshotRepository implements WikiSnapshotRepositoryInterface
             ResourceType::GROUP => $this->buildGroupBasic($model),
             ResourceType::AGENCY => $this->buildAgencyBasic($model),
             ResourceType::SONG => $this->buildSongBasic($model),
-            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->value . ' resource type does not have a Basic.'),
+            ResourceType::IMAGE, ResourceType::PRINCIPAL_GROUP => throw new InvalidArgumentException($resourceType->name . ' resource type does not have a Basic.'),
         };
     }
 

--- a/tests/Helper/CreatePrincipal.php
+++ b/tests/Helper/CreatePrincipal.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Helper;
 
 use Illuminate\Support\Facades\DB;
-use JsonException;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 
@@ -13,13 +12,9 @@ class CreatePrincipal
 {
     /**
      * @param array{
-     *     agency_id?: ?string,
-     *     group_ids?: string[],
-     *     talent_ids?: string[],
      *     delegation_identifier?: ?string,
      *     enabled?: bool
      * } $overrides
-     * @throws JsonException
      */
     public static function create(
         PrincipalIdentifier $principalIdentifier,
@@ -29,9 +24,6 @@ class CreatePrincipal
         DB::table('wiki_principals')->insert([
             'id' => (string) $principalIdentifier,
             'identity_id' => (string) $identityIdentifier,
-            'agency_id' => $overrides['agency_id'] ?? null,
-            'group_ids' => json_encode($overrides['group_ids'] ?? [], JSON_THROW_ON_ERROR),
-            'talent_ids' => json_encode($overrides['talent_ids'] ?? [], JSON_THROW_ON_ERROR),
             'delegation_identifier' => $overrides['delegation_identifier'] ?? null,
             'enabled' => $overrides['enabled'] ?? true,
             'created_at' => now(),

--- a/tests/Wiki/Grading/Application/UseCase/Command/ProcessRolePromotion/ProcessRolePromotionTest.php
+++ b/tests/Wiki/Grading/Application/UseCase/Command/ProcessRolePromotion/ProcessRolePromotionTest.php
@@ -129,9 +129,6 @@ class ProcessRolePromotionTest extends TestCase
         $principal = new Principal(
             new PrincipalIdentifier($principalId),
             $identityId,
-            null,
-            [],
-            [],
         );
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
@@ -645,9 +642,6 @@ class ProcessRolePromotionTest extends TestCase
         $principal = new Principal(
             new PrincipalIdentifier($principalId),
             $identityId,
-            null,
-            [],
-            [],
         );
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
@@ -781,9 +775,6 @@ class ProcessRolePromotionTest extends TestCase
         $principal = new Principal(
             new PrincipalIdentifier($principalId),
             $identityId,
-            null,
-            [],
-            [],
         );
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);

--- a/tests/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/ApproveImage/ApproveImageTest.php
@@ -84,7 +84,7 @@ class ApproveImageTest extends TestCase
     {
         $testData = $this->createTestDataForNewImage();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new ApproveImageInput($testData->draftImageIdentifier, $principalIdentifier);
@@ -215,7 +215,7 @@ class ApproveImageTest extends TestCase
     {
         $testData = $this->createTestDataWithInvalidStatus();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
         $input = new ApproveImageInput($testData->draftImageIdentifier, $principalIdentifier);
 
@@ -274,7 +274,7 @@ class ApproveImageTest extends TestCase
     {
         $testData = $this->createTestDataForExistingImage();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new ApproveImageInput($testData->draftImageIdentifier, $principalIdentifier);
@@ -379,7 +379,7 @@ class ApproveImageTest extends TestCase
     {
         $testData = $this->createTestDataForNewImage();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new ApproveImageInput($testData->draftImageIdentifier, $principalIdentifier);

--- a/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/ApproveImageDeletion/ApproveImageDeletionTest.php
@@ -117,7 +117,7 @@ class ApproveImageDeletionTest extends TestCase
         $image = $this->createTestImageWithPendingDeletionRequest();
         $imageIdentifier = $image->imageIdentifier();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);
@@ -210,7 +210,7 @@ class ApproveImageDeletionTest extends TestCase
         $image = $this->createTestImageWithoutDeletionRequest();
         $imageIdentifier = $image->imageIdentifier();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
         $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);
 
@@ -300,7 +300,7 @@ class ApproveImageDeletionTest extends TestCase
         $image = $this->createTestImageWithPendingDeletionRequest();
         $imageIdentifier = $image->imageIdentifier();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new ApproveImageDeletionInput($imageIdentifier, $principalIdentifier);

--- a/tests/Wiki/Image/Application/UseCase/Command/DeleteImage/DeleteImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/DeleteImage/DeleteImageTest.php
@@ -66,7 +66,7 @@ class DeleteImageTest extends TestCase
     {
         $testData = $this->createImageTestData();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new DeleteImageInput($testData->imageIdentifier, $principalIdentifier);
@@ -117,7 +117,7 @@ class DeleteImageTest extends TestCase
     {
         $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $input = new DeleteImageInput($imageIdentifier, $principalIdentifier);
 
         $imageRepository = Mockery::mock(ImageRepositoryInterface::class);
@@ -155,7 +155,7 @@ class DeleteImageTest extends TestCase
     {
         $testData = $this->createImageTestData();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new DeleteImageInput($testData->imageIdentifier, $principalIdentifier);

--- a/tests/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/RejectImage/RejectImageTest.php
@@ -69,7 +69,7 @@ class RejectImageTest extends TestCase
     {
         $testData = $this->createTestData();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new RejectImageInput($testData->draftImageIdentifier, $principalIdentifier);
@@ -124,7 +124,7 @@ class RejectImageTest extends TestCase
     {
         $imageIdentifier = new ImageIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $input = new RejectImageInput($imageIdentifier, $principalIdentifier);
 
         $draftImageRepository = Mockery::mock(DraftImageRepositoryInterface::class);
@@ -166,7 +166,7 @@ class RejectImageTest extends TestCase
     {
         $testData = $this->createTestDataWithInvalidStatus();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
         $input = new RejectImageInput($testData->draftImageIdentifier, $principalIdentifier);
 
@@ -215,7 +215,7 @@ class RejectImageTest extends TestCase
     {
         $testData = $this->createTestData();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new RejectImageInput($testData->draftImageIdentifier, $principalIdentifier);

--- a/tests/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/RejectImageDeletion/RejectImageDeletionTest.php
@@ -64,7 +64,7 @@ class RejectImageDeletionTest extends TestCase
         $image = $this->createTestImageWithPendingDeletionRequest();
         $imageIdentifier = $image->imageIdentifier();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new RejectImageDeletionInput($imageIdentifier, $principalIdentifier, 'Not applicable');
@@ -147,7 +147,7 @@ class RejectImageDeletionTest extends TestCase
         $image = $this->createTestImageWithoutDeletionRequest();
         $imageIdentifier = $image->imageIdentifier();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
         $input = new RejectImageDeletionInput($imageIdentifier, $principalIdentifier, 'comment');
 
@@ -231,7 +231,7 @@ class RejectImageDeletionTest extends TestCase
         $image = $this->createTestImageWithPendingDeletionRequest();
         $imageIdentifier = $image->imageIdentifier();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new RejectImageDeletionInput($imageIdentifier, $principalIdentifier, 'comment');

--- a/tests/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/UnhideImage/UnhideImageTest.php
@@ -66,7 +66,7 @@ class UnhideImageTest extends TestCase
     {
         $testData = $this->createTestData();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new UnhideImageInput($testData->imageIdentifier, $principalIdentifier);
@@ -197,7 +197,7 @@ class UnhideImageTest extends TestCase
     {
         $testData = $this->createTestData();
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new UnhideImageInput($testData->imageIdentifier, $principalIdentifier);

--- a/tests/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageTest.php
+++ b/tests/Wiki/Image/Application/UseCase/Command/UploadImage/UploadImageTest.php
@@ -72,7 +72,7 @@ class UploadImageTest extends TestCase
     public function testProcess(): void
     {
         $testData = $this->createTestData();
-        $principal = new Principal($testData->principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($testData->principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new UploadImageInput(
@@ -162,7 +162,7 @@ class UploadImageTest extends TestCase
     public function testProcessDisallowed(): void
     {
         $testData = $this->createTestData();
-        $principal = new Principal($testData->principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($testData->principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $resource = new Resource(type: ResourceType::IMAGE);
 
         $input = new UploadImageInput(

--- a/tests/Wiki/Image/Infrastructure/Query/ListImageDeletionRequestsTest.php
+++ b/tests/Wiki/Image/Infrastructure/Query/ListImageDeletionRequestsTest.php
@@ -157,7 +157,7 @@ class ListImageDeletionRequestsTest extends TestCase
     private function bindPrincipalRepository(): PrincipalIdentifier
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);
         $principalRepository->shouldReceive('findById')

--- a/tests/Wiki/Principal/Application/EventHandler/AccountCategoryChangedHandlerTest.php
+++ b/tests/Wiki/Principal/Application/EventHandler/AccountCategoryChangedHandlerTest.php
@@ -292,11 +292,6 @@ class AccountCategoryChangedHandlerTest extends TestCase
         return new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            (string) $accountIdentifier,
-            [],
-            [],
-            null,
-            true,
         );
     }
 

--- a/tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php
+++ b/tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php
@@ -556,7 +556,7 @@ class AffiliationActivatedHandlerTest extends TestCase
                 new ConditionClause(
                     ConditionKey::RESOURCE_TALENT_ID,
                     ConditionOperator::IN,
-                    ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS,
+                    ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS,
                 ),
             ],
         );
@@ -573,7 +573,7 @@ class AffiliationActivatedHandlerTest extends TestCase
             ResourceType::GROUP,
             [
                 new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
-                new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_IDS),
+                new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS),
             ],
         );
         $this->assertStatement(
@@ -581,7 +581,7 @@ class AffiliationActivatedHandlerTest extends TestCase
             ResourceType::SONG,
             [
                 new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
-                new ConditionClause(ConditionKey::RESOURCE_GROUP_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_WIKI_GROUP_IDS),
+                new ConditionClause(ConditionKey::RESOURCE_GROUP_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS),
             ],
         );
         $this->assertStatement(
@@ -589,7 +589,7 @@ class AffiliationActivatedHandlerTest extends TestCase
             ResourceType::SONG,
             [
                 new ConditionClause(ConditionKey::RESOURCE_AGENCY_ID, ConditionOperator::EQUALS, $agencyId),
-                new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_IDS),
+                new ConditionClause(ConditionKey::RESOURCE_TALENT_ID, ConditionOperator::IN, ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS),
             ],
         );
     }
@@ -617,11 +617,6 @@ class AffiliationActivatedHandlerTest extends TestCase
         return new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            (string) $accountIdentifier,
-            [],
-            [],
-            null,
-            true,
         );
     }
 

--- a/tests/Wiki/Principal/Application/EventHandler/DelegatedIdentityCreatedHandlerTest.php
+++ b/tests/Wiki/Principal/Application/EventHandler/DelegatedIdentityCreatedHandlerTest.php
@@ -173,9 +173,6 @@ class DelegatedIdentityCreatedHandlerTest extends TestCase
         return new Principal(
             $principalIdentifier,
             $identityIdentifier,
-            null,
-            [],
-            [],
         );
     }
 
@@ -187,9 +184,6 @@ class DelegatedIdentityCreatedHandlerTest extends TestCase
         return new Principal(
             $principalIdentifier,
             $identityIdentifier,
-            null,
-            [],
-            [],
             $delegationIdentifier,
         );
     }

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalOutputTest.php
@@ -24,9 +24,6 @@ class CreatePrincipalOutputTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             $identityIdentifier,
-            null,
-            [],
-            [],
         );
 
         $output = new CreatePrincipalOutput();

--- a/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/CreatePrincipal/CreatePrincipalTest.php
@@ -53,7 +53,7 @@ class CreatePrincipalTest extends TestCase
         $principalGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
         $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
 
-        $principal = new Principal($principalIdentifier, $identityIdentifier, null, [], []);
+        $principal = new Principal($principalIdentifier, $identityIdentifier);
         $defaultPrincipalGroup = new PrincipalGroup(
             $principalGroupIdentifier,
             $accountIdentifier,
@@ -137,7 +137,7 @@ class CreatePrincipalTest extends TestCase
         $wikiAdministratorRoleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
         $collaboratorRoleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
 
-        $principal = new Principal($principalIdentifier, $identityIdentifier, null, [], []);
+        $principal = new Principal($principalIdentifier, $identityIdentifier);
         $accountPrincipal = new AccountPrincipal($accountPrincipalIdentifier, $identityIdentifier, $accountIdentifier);
         $ownerRole = new AccountRole($ownerRoleIdentifier, AccountRole::OWNER, [], true);
         $ownerGroup = new AccountPrincipalGroup(
@@ -238,7 +238,7 @@ class CreatePrincipalTest extends TestCase
         $accountPrincipalIdentifier = new AccountPrincipalIdentifier(StrTestHelper::generateUuid());
         $ownerRoleIdentifier = new AccountRoleIdentifier(StrTestHelper::generateUuid());
 
-        $principal = new Principal($principalIdentifier, $identityIdentifier, null, [], []);
+        $principal = new Principal($principalIdentifier, $identityIdentifier);
         $accountPrincipal = new AccountPrincipal($accountPrincipalIdentifier, $identityIdentifier, $accountIdentifier);
         $ownerRole = new AccountRole($ownerRoleIdentifier, AccountRole::OWNER, [], true);
         $ownerGroup = new AccountPrincipalGroup(
@@ -310,7 +310,7 @@ class CreatePrincipalTest extends TestCase
         $ownerRoleIdentifier = new AccountRoleIdentifier(StrTestHelper::generateUuid());
         $wikiAdministratorRoleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
 
-        $principal = new Principal($principalIdentifier, $identityIdentifier, null, [], []);
+        $principal = new Principal($principalIdentifier, $identityIdentifier);
         $accountPrincipal = new AccountPrincipal($accountPrincipalIdentifier, $identityIdentifier, $accountIdentifier);
         $ownerRole = new AccountRole($ownerRoleIdentifier, AccountRole::OWNER, [], true);
         $ownerGroup = new AccountPrincipalGroup(
@@ -393,7 +393,7 @@ class CreatePrincipalTest extends TestCase
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
-        $principal = new Principal($principalIdentifier, $identityIdentifier, null, [], []);
+        $principal = new Principal($principalIdentifier, $identityIdentifier);
         $defaultPrincipalGroup = new PrincipalGroup(
             new PrincipalGroupIdentifier(StrTestHelper::generateUuid()),
             $accountIdentifier,
@@ -471,9 +471,6 @@ class CreatePrincipalTest extends TestCase
             ->andReturn(new Principal(
                 new PrincipalIdentifier(StrTestHelper::generateUuid()),
                 $identityIdentifier,
-                null,
-                [],
-                [],
             ));
         $principalRepository->shouldNotReceive('save');
 

--- a/tests/Wiki/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Command/UpdatePrincipalGroupMembers/UpdatePrincipalGroupMembersTest.php
@@ -7,7 +7,10 @@ namespace Tests\Wiki\Principal\Application\UseCase\Command\UpdatePrincipalGroupM
 use DateTimeImmutable;
 use Mockery;
 use Source\Account\Account\Application\Exception\AccountUpdateForbiddenException;
+use Source\Account\Principal\Domain\Entity\Principal as AccountPrincipal;
+use Source\Account\Principal\Domain\Repository\PrincipalRepositoryInterface as AccountPrincipalRepositoryInterface;
 use Source\Account\Shared\Domain\ValueObject\AccountType;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier as AccountPrincipalIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Principal\Application\Exception\CannotRemoveLastWikiAdministratorException;
@@ -73,8 +76,10 @@ class UpdatePrincipalGroupMembersTest extends TestCase
             ->with($operator, Action::PRINCIPAL_GROUP_MANAGE, Mockery::on(static fn (Resource $resource): bool => $resource->type() === ResourceType::PRINCIPAL_GROUP))
             ->andReturnTrue();
 
+        $accountPrincipalRepository = $this->accountPrincipalRepositoryMock($accountIdentifier, $operator, $member);
+
         $output = new UpdatePrincipalGroupMembersOutput();
-        (new UpdatePrincipalGroupMembers($principalGroupRepository, $principalRepository, $roleRepository, $policyEvaluator))->process(
+        (new UpdatePrincipalGroupMembers($principalGroupRepository, $principalRepository, $roleRepository, $policyEvaluator, $accountPrincipalRepository))->process(
             new UpdatePrincipalGroupMembersInput(
                 $accountIdentifier,
                 $operator->principalIdentifier(),
@@ -96,6 +101,7 @@ class UpdatePrincipalGroupMembersTest extends TestCase
             self::principalRepositoryMock(),
             self::roleRepositoryMock(),
             self::policyEvaluatorMock(),
+            self::accountPrincipalRepositoryEmptyMock(),
         ))->process(
             new UpdatePrincipalGroupMembersInput(
                 new AccountIdentifier(StrTestHelper::generateUuid()),
@@ -134,9 +140,11 @@ class UpdatePrincipalGroupMembersTest extends TestCase
         $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
         $policyEvaluator->shouldReceive('evaluate')->once()->andReturnTrue();
 
+        $accountPrincipalRepository = $this->accountPrincipalRepositoryMock($accountIdentifier, $operator);
+
         $this->expectException(CannotRemoveLastWikiAdministratorException::class);
 
-        (new UpdatePrincipalGroupMembers($principalGroupRepository, $principalRepository, $roleRepository, $policyEvaluator))->process(
+        (new UpdatePrincipalGroupMembers($principalGroupRepository, $principalRepository, $roleRepository, $policyEvaluator, $accountPrincipalRepository))->process(
             new UpdatePrincipalGroupMembersInput(
                 $accountIdentifier,
                 $operator->principalIdentifier(),
@@ -179,9 +187,39 @@ class UpdatePrincipalGroupMembersTest extends TestCase
         return $mock;
     }
 
+    private static function accountPrincipalRepositoryEmptyMock(): AccountPrincipalRepositoryInterface
+    {
+        /** @var AccountPrincipalRepositoryInterface&Mockery\MockInterface $mock */
+        $mock = Mockery::mock(AccountPrincipalRepositoryInterface::class);
+
+        return $mock;
+    }
+
+    private function accountPrincipalRepositoryMock(AccountIdentifier $accountIdentifier, Principal ...$principals): AccountPrincipalRepositoryInterface
+    {
+        /** @var AccountPrincipalRepositoryInterface&Mockery\MockInterface $mock */
+        $mock = Mockery::mock(AccountPrincipalRepositoryInterface::class);
+
+        foreach ($principals as $principal) {
+            $mock->shouldReceive('findByIdentityIdentifierAndAccountIdentifier')
+                ->once()
+                ->with(
+                    $principal->identityIdentifier(),
+                    $accountIdentifier,
+                )
+                ->andReturn(new AccountPrincipal(
+                    new AccountPrincipalIdentifier(StrTestHelper::generateUuid()),
+                    $principal->identityIdentifier(),
+                    $accountIdentifier,
+                ));
+        }
+
+        return $mock;
+    }
+
     private function principal(AccountIdentifier $accountIdentifier): Principal
     {
-        return new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), new IdentityIdentifier(StrTestHelper::generateUuid()), (string) $accountIdentifier, [], []);
+        return new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), new IdentityIdentifier(StrTestHelper::generateUuid()));
     }
 
     private function principalGroup(AccountIdentifier $accountIdentifier, string $name): PrincipalGroup

--- a/tests/Wiki/Principal/Domain/Entity/PrincipalTest.php
+++ b/tests/Wiki/Principal/Domain/Entity/PrincipalTest.php
@@ -23,35 +23,12 @@ class PrincipalTest extends TestCase
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
-        $agencyId = StrTestHelper::generateUuid();
-        $groupIds = [
-            StrTestHelper::generateUuid(),
-            StrTestHelper::generateUuid(),
-        ];
-        $memberIds = [StrTestHelper::generateUuid()];
         $principal = new Principal(
             $principalIdentifier,
             $identityIdentifier,
-            $agencyId,
-            $groupIds,
-            $memberIds,
         );
         $this->assertSame((string)$principalIdentifier, (string)$principal->principalIdentifier());
         $this->assertSame((string)$identityIdentifier, (string)$principal->identityIdentifier());
-        $this->assertSame($agencyId, $principal->agencyId());
-        $this->assertSame($groupIds, $principal->groupIds());
-        $this->assertSame($memberIds, $principal->talentIds());
-
-        $principal = new Principal(
-            $principalIdentifier,
-            $identityIdentifier,
-            null,
-            [],
-            [],
-        );
-        $this->assertNull($principal->agencyId());
-        $this->assertEmpty($principal->groupIds());
-        $this->assertEmpty($principal->talentIds());
     }
 
     /**
@@ -62,9 +39,6 @@ class PrincipalTest extends TestCase
         $principal = new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            [],
         );
 
         $this->assertNull($principal->delegationIdentifier());
@@ -81,9 +55,6 @@ class PrincipalTest extends TestCase
         $principal = new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            [],
             $delegationIdentifier,
             true,
         );
@@ -102,9 +73,6 @@ class PrincipalTest extends TestCase
         $principal = new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            [],
             $delegationIdentifier,
             true,
         );
@@ -126,9 +94,6 @@ class PrincipalTest extends TestCase
         $principal = new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            [],
         );
 
         $this->expectException(CannotChangeNonDelegatedPrincipalException::class);

--- a/tests/Wiki/Principal/Domain/ValueObject/ConditionClauseTest.php
+++ b/tests/Wiki/Principal/Domain/ValueObject/ConditionClauseTest.php
@@ -20,12 +20,12 @@ class ConditionClauseTest extends TestCase
         $clause = new ConditionClause(
             ConditionKey::RESOURCE_AGENCY_ID,
             ConditionOperator::EQUALS,
-            ConditionValue::PRINCIPAL_AGENCY_ID,
+            ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS,
         );
 
         $this->assertSame(ConditionKey::RESOURCE_AGENCY_ID, $clause->key());
         $this->assertSame(ConditionOperator::EQUALS, $clause->operator());
-        $this->assertSame(ConditionValue::PRINCIPAL_AGENCY_ID, $clause->value());
+        $this->assertSame(ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS, $clause->value());
     }
 
     /**
@@ -68,11 +68,11 @@ class ConditionClauseTest extends TestCase
         $clause = new ConditionClause(
             ConditionKey::RESOURCE_GROUP_ID,
             ConditionOperator::IN,
-            ConditionValue::PRINCIPAL_WIKI_GROUP_IDS,
+            ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS,
         );
 
         $this->assertSame(ConditionKey::RESOURCE_GROUP_ID, $clause->key());
         $this->assertSame(ConditionOperator::IN, $clause->operator());
-        $this->assertSame(ConditionValue::PRINCIPAL_WIKI_GROUP_IDS, $clause->value());
+        $this->assertSame(ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS, $clause->value());
     }
 }

--- a/tests/Wiki/Principal/Domain/ValueObject/ConditionTest.php
+++ b/tests/Wiki/Principal/Domain/ValueObject/ConditionTest.php
@@ -21,7 +21,7 @@ class ConditionTest extends TestCase
         $clause = new ConditionClause(
             ConditionKey::RESOURCE_AGENCY_ID,
             ConditionOperator::EQUALS,
-            ConditionValue::PRINCIPAL_AGENCY_ID,
+            ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS,
         );
 
         $condition = new Condition([$clause]);
@@ -38,7 +38,7 @@ class ConditionTest extends TestCase
         $clause1 = new ConditionClause(
             ConditionKey::RESOURCE_AGENCY_ID,
             ConditionOperator::EQUALS,
-            ConditionValue::PRINCIPAL_AGENCY_ID,
+            ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS,
         );
         $clause2 = new ConditionClause(
             ConditionKey::RESOURCE_IS_OFFICIAL,

--- a/tests/Wiki/Principal/Domain/ValueObject/ConditionValueTest.php
+++ b/tests/Wiki/Principal/Domain/ValueObject/ConditionValueTest.php
@@ -16,11 +16,12 @@ class ConditionValueTest extends TestCase
     {
         $cases = ConditionValue::cases();
 
-        $this->assertCount(5, $cases);
-        $this->assertContains(ConditionValue::PRINCIPAL_AGENCY_ID, $cases);
-        $this->assertContains(ConditionValue::PRINCIPAL_WIKI_GROUP_IDS, $cases);
-        $this->assertContains(ConditionValue::PRINCIPAL_TALENT_IDS, $cases);
-        $this->assertContains(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS, $cases);
+        $this->assertCount(6, $cases);
+        $this->assertContains(ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS, $cases);
+        $this->assertContains(ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS, $cases);
+        $this->assertContains(ConditionValue::PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS, $cases);
+        $this->assertContains(ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS, $cases);
+        $this->assertContains(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS, $cases);
         $this->assertContains(ConditionValue::PRINCIPAL_ID, $cases);
     }
 
@@ -29,10 +30,11 @@ class ConditionValueTest extends TestCase
      */
     public function test_case_values(): void
     {
-        $this->assertSame('${principal.agencyId}', ConditionValue::PRINCIPAL_AGENCY_ID->value);
-        $this->assertSame('${principal.wikiGroupIds}', ConditionValue::PRINCIPAL_WIKI_GROUP_IDS->value);
-        $this->assertSame('${principal.talentIds}', ConditionValue::PRINCIPAL_TALENT_IDS->value);
-        $this->assertSame('${principal.affiliatedTalentIds}', ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS->value);
+        $this->assertSame('${principal.agencyWikiIdentifiers}', ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS->value);
+        $this->assertSame('${principal.groupWikiIdentifiers}', ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS->value);
+        $this->assertSame('${principal.talentGroupWikiIdentifiers}', ConditionValue::PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS->value);
+        $this->assertSame('${principal.talentWikiIdentifiers}', ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS->value);
+        $this->assertSame('${principal.affiliatedTalentWikiIdentifiers}', ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS->value);
         $this->assertSame('${principal.id}', ConditionValue::PRINCIPAL_ID->value);
     }
 }

--- a/tests/Wiki/Principal/Domain/ValueObject/StatementTest.php
+++ b/tests/Wiki/Principal/Domain/ValueObject/StatementTest.php
@@ -29,7 +29,7 @@ class StatementTest extends TestCase
             new ConditionClause(
                 ConditionKey::RESOURCE_AGENCY_ID,
                 ConditionOperator::EQUALS,
-                ConditionValue::PRINCIPAL_AGENCY_ID,
+                ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS,
             ),
         ]);
 

--- a/tests/Wiki/Principal/Http/Action/Command/CreatePrincipal/CreatePrincipalActionTest.php
+++ b/tests/Wiki/Principal/Http/Action/Command/CreatePrincipal/CreatePrincipalActionTest.php
@@ -54,9 +54,6 @@ class CreatePrincipalActionTest extends TestCase
                     $output->setPrincipal(new \Source\Wiki\Principal\Domain\Entity\Principal(
                         new \Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier($principalIdentifier),
                         new \Source\Shared\Domain\ValueObject\IdentityIdentifier($identityIdentifier),
-                        null,
-                        [],
-                        [],
                     ));
 
                     return true;

--- a/tests/Wiki/Principal/Infrastructure/Factory/PrincipalFactoryTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Factory/PrincipalFactoryTest.php
@@ -33,9 +33,6 @@ class PrincipalFactoryTest extends TestCase
 
         $this->assertTrue(UuidValidator::isValid((string)$principal->principalIdentifier()));
         $this->assertSame($identityIdentifier, $principal->identityIdentifier());
-        $this->assertNull($principal->agencyId());
-        $this->assertEmpty($principal->groupIds());
-        $this->assertEmpty($principal->talentIds());
         $this->assertNull($principal->delegationIdentifier());
         $this->assertFalse($principal->isDelegatedPrincipal());
         $this->assertTrue($principal->isEnabled());
@@ -49,16 +46,9 @@ class PrincipalFactoryTest extends TestCase
      */
     public function testCreateDelegatedPrincipal(): void
     {
-        $agencyId = StrTestHelper::generateUuid();
-        $groupIds = [StrTestHelper::generateUuid(), StrTestHelper::generateUuid()];
-        $talentIds = [StrTestHelper::generateUuid()];
-
         $originalPrincipal = new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            $agencyId,
-            $groupIds,
-            $talentIds,
         );
 
         $delegationIdentifier = new DelegationIdentifier(StrTestHelper::generateUuid());
@@ -77,9 +67,6 @@ class PrincipalFactoryTest extends TestCase
             (string)$delegatedPrincipal->principalIdentifier()
         );
         $this->assertSame($delegatedIdentityIdentifier, $delegatedPrincipal->identityIdentifier());
-        $this->assertSame($agencyId, $delegatedPrincipal->agencyId());
-        $this->assertSame($groupIds, $delegatedPrincipal->groupIds());
-        $this->assertSame($talentIds, $delegatedPrincipal->talentIds());
         $this->assertSame($delegationIdentifier, $delegatedPrincipal->delegationIdentifier());
         $this->assertTrue($delegatedPrincipal->isDelegatedPrincipal());
         $this->assertTrue($delegatedPrincipal->isEnabled());

--- a/tests/Wiki/Principal/Infrastructure/Repository/PolicyRepositoryTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Repository/PolicyRepositoryTest.php
@@ -258,7 +258,7 @@ class PolicyRepositoryTest extends TestCase
             new ConditionClause(
                 ConditionKey::RESOURCE_AGENCY_ID,
                 ConditionOperator::EQUALS,
-                ConditionValue::PRINCIPAL_AGENCY_ID,
+                ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS,
             ),
         ]);
 
@@ -299,7 +299,7 @@ class PolicyRepositoryTest extends TestCase
         $clause = $retrievedCondition->clauses()[0];
         $this->assertSame(ConditionKey::RESOURCE_AGENCY_ID, $clause->key());
         $this->assertSame(ConditionOperator::EQUALS, $clause->operator());
-        $this->assertSame(ConditionValue::PRINCIPAL_AGENCY_ID, $clause->value());
+        $this->assertSame(ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS, $clause->value());
     }
 
     /**

--- a/tests/Wiki/Principal/Infrastructure/Repository/PrincipalRepositoryTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Repository/PrincipalRepositoryTest.php
@@ -13,6 +13,7 @@ use Source\Shared\Domain\ValueObject\IdentityIdentifier;
 use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\Repository\PrincipalRepositoryInterface;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\CreateAccount;
 use Tests\Helper\CreateIdentity;
 use Tests\Helper\CreatePrincipal;
 use Tests\Helper\StrTestHelper;
@@ -111,18 +112,11 @@ class PrincipalRepositoryTest extends TestCase
         CreateIdentity::create($identityIdentifier);
 
         $principalId = StrTestHelper::generateUuid();
-        $agencyId = StrTestHelper::generateUuid();
-        $groupId = StrTestHelper::generateUuid();
-        $groupIds = [$groupId];
-        $talentIds = [StrTestHelper::generateUuid()];
         $delegationIdentifier = new DelegationIdentifier(StrTestHelper::generateUuid());
 
         $principal = new Principal(
             new PrincipalIdentifier($principalId),
             $identityIdentifier,
-            $agencyId,
-            $groupIds,
-            $talentIds,
             $delegationIdentifier,
         );
 
@@ -132,13 +126,12 @@ class PrincipalRepositoryTest extends TestCase
         $this->assertDatabaseHas('wiki_principals', [
             'id' => $principalId,
             'identity_id' => (string) $identityIdentifier,
-            'agency_id' => $agencyId,
             'delegation_identifier' => (string) $delegationIdentifier,
         ]);
 
         $saved = $repository->findById(new PrincipalIdentifier($principalId));
         $this->assertNotNull($saved);
-        $this->assertSame($groupIds, $saved->groupIds());
+        $this->assertSame((string) $identityIdentifier, (string) $saved->identityIdentifier());
     }
 
     /**
@@ -161,9 +154,6 @@ class PrincipalRepositoryTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             $identityIdentifier,
-            null,
-            [],
-            [],
         );
 
         $repository = $this->app->make(PrincipalRepositoryInterface::class);
@@ -282,16 +272,15 @@ class PrincipalRepositoryTest extends TestCase
         ]);
 
         $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $accountIdentifier);
 
         $principalIdentifier1 = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        CreatePrincipal::create($principalIdentifier1, $identityIdentifier1, [
-            'agency_id' => (string) $accountIdentifier,
-        ]);
+        CreatePrincipal::create($principalIdentifier1, $identityIdentifier1);
+        $this->createAccountPrincipal($identityIdentifier1, $accountIdentifier);
 
         $principalIdentifier2 = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        CreatePrincipal::create($principalIdentifier2, $identityIdentifier2, [
-            'agency_id' => (string) $accountIdentifier,
-        ]);
+        CreatePrincipal::create($principalIdentifier2, $identityIdentifier2);
+        $this->createAccountPrincipal($identityIdentifier2, $accountIdentifier);
 
         $repository = $this->app->make(PrincipalRepositoryInterface::class);
         $results = $repository->findByAccountId($accountIdentifier);
@@ -300,6 +289,17 @@ class PrincipalRepositoryTest extends TestCase
         $principalIds = array_map(fn ($p) => (string) $p->principalIdentifier(), $results);
         $this->assertContains((string) $principalIdentifier1, $principalIds);
         $this->assertContains((string) $principalIdentifier2, $principalIds);
+    }
+
+    private function createAccountPrincipal(IdentityIdentifier $identityIdentifier, AccountIdentifier $accountIdentifier): void
+    {
+        \Illuminate\Support\Facades\DB::table('account_principals')->insert([
+            'id' => StrTestHelper::generateUuid(),
+            'identity_id' => (string) $identityIdentifier,
+            'account_id' => (string) $accountIdentifier,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
     }
 
     /**

--- a/tests/Wiki/Principal/Infrastructure/Service/AffiliationConditionValueResolverTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Service/AffiliationConditionValueResolverTest.php
@@ -4,123 +4,38 @@ declare(strict_types=1);
 
 namespace Tests\Wiki\Principal\Infrastructure\Service;
 
-use DateTimeImmutable;
 use Mockery;
-use Source\Account\Affiliation\Domain\Entity\Affiliation;
-use Source\Account\Affiliation\Domain\Repository\AffiliationRepositoryInterface;
-use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
-use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
-use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\Service\PrincipalWikiScopeResolverInterface;
 use Source\Wiki\Principal\Domain\Entity\Principal;
 use Source\Wiki\Principal\Domain\ValueObject\ConditionValue;
 use Source\Wiki\Principal\Infrastructure\Service\AffiliationConditionValueResolver;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
-use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
-use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
-use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
 use Tests\Helper\StrTestHelper;
 use Tests\TestCase;
 
 class AffiliationConditionValueResolverTest extends TestCase
 {
-    public function testResolveAffiliatedTalentIdsReturnsEmptyArrayWhenTalentWikiDoesNotExist(): void
+    public function testResolveAffiliatedTalentWikiIdentifiersDelegatesToScopeResolver(): void
     {
-        $agencyAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
-        $talentAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
-        $affiliation = $this->activeAffiliation($agencyAccountId, $talentAccountId);
-        $principal = $this->principal((string) $agencyAccountId);
-
-        /** @var AffiliationRepositoryInterface&Mockery\MockInterface $affiliationRepository */
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationRepository->shouldReceive('findByAgencyAccount')
-            ->once()
-            ->with(Mockery::on(fn (AccountIdentifier $id) => (string) $id === (string) $agencyAccountId), AffiliationStatus::ACTIVE)
-            ->andReturn([$affiliation]);
-
-        /** @var WikiRepositoryInterface&Mockery\MockInterface $wikiRepository */
-        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
-        $wikiRepository->shouldReceive('findByOwnerAccountId')
-            ->once()
-            ->with($talentAccountId, ResourceType::TALENT)
-            ->andReturnNull();
-
-        $resolver = new AffiliationConditionValueResolver($affiliationRepository, $wikiRepository);
-
-        $this->assertSame([], $resolver->resolve(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS, $principal));
-    }
-
-    public function testResolveAffiliatedTalentIdsReturnsTalentWikiIdsAtEvaluationTime(): void
-    {
-        $agencyAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
-        $talentAccountId = new AccountIdentifier(StrTestHelper::generateUuid());
-        $talentWikiId = new WikiIdentifier(StrTestHelper::generateUuid());
-        $affiliation = $this->activeAffiliation($agencyAccountId, $talentAccountId);
-        $principal = $this->principal((string) $agencyAccountId);
-
-        /** @var AffiliationRepositoryInterface&Mockery\MockInterface $affiliationRepository */
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        $affiliationRepository->shouldReceive('findByAgencyAccount')
-            ->once()
-            ->with(Mockery::on(fn (AccountIdentifier $id) => (string) $id === (string) $agencyAccountId), AffiliationStatus::ACTIVE)
-            ->andReturn([$affiliation]);
-
-        $wiki = Mockery::mock(\Source\Wiki\Wiki\Domain\Entity\Wiki::class);
-        $wiki->shouldReceive('wikiIdentifier')->andReturn($talentWikiId);
-
-        /** @var WikiRepositoryInterface&Mockery\MockInterface $wikiRepository */
-        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
-        $wikiRepository->shouldReceive('findByOwnerAccountId')
-            ->once()
-            ->with($talentAccountId, ResourceType::TALENT)
-            ->andReturn($wiki);
-
-        $resolver = new AffiliationConditionValueResolver($affiliationRepository, $wikiRepository);
-
-        $this->assertSame([(string) $talentWikiId], $resolver->resolve(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS, $principal));
-    }
-
-    public function testResolveExistingPrincipalValuesFallsBackToPrincipalResolver(): void
-    {
-        $agencyId = StrTestHelper::generateUuid();
-        $principal = $this->principal($agencyId);
-        /** @var AffiliationRepositoryInterface $affiliationRepository */
-        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
-        /** @var WikiRepositoryInterface $wikiRepository */
-        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
-        $resolver = new AffiliationConditionValueResolver(
-            $affiliationRepository,
-            $wikiRepository,
-        );
-
-        $this->assertSame($agencyId, $resolver->resolve(ConditionValue::PRINCIPAL_AGENCY_ID, $principal));
-    }
-
-    private function principal(?string $agencyId): Principal
-    {
-        return new Principal(
+        $principal = new Principal(
             new PrincipalIdentifier(StrTestHelper::generateUuid()),
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            $agencyId,
-            [],
-            [],
         );
-    }
+        $talentWikiIdentifiers = [StrTestHelper::generateUuid()];
 
-    private function activeAffiliation(
-        AccountIdentifier $agencyAccountId,
-        AccountIdentifier $talentAccountId,
-    ): Affiliation {
-        return new Affiliation(
-            new AffiliationIdentifier(StrTestHelper::generateUuid()),
-            $agencyAccountId,
-            $talentAccountId,
-            $agencyAccountId,
-            AffiliationStatus::ACTIVE,
-            null,
-            new DateTimeImmutable('-1 day'),
-            new DateTimeImmutable(),
-            null,
+        /** @var PrincipalWikiScopeResolverInterface&Mockery\MockInterface $scopeResolver */
+        $scopeResolver = Mockery::mock(PrincipalWikiScopeResolverInterface::class);
+        $scopeResolver->shouldReceive('affiliatedTalentWikiIdentifiers')
+            ->once()
+            ->with($principal)
+            ->andReturn($talentWikiIdentifiers);
+
+        $resolver = new AffiliationConditionValueResolver($scopeResolver);
+
+        $this->assertSame(
+            $talentWikiIdentifiers,
+            $resolver->resolve(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS, $principal),
         );
     }
 }

--- a/tests/Wiki/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Service/PolicyEvaluatorTest.php
@@ -28,7 +28,6 @@ use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
 use Source\Wiki\Principal\Domain\ValueObject\Statement;
 use Source\Wiki\Principal\Infrastructure\Service\PolicyEvaluator;
-use Source\Wiki\Principal\Infrastructure\Service\PrincipalConditionValueResolver;
 use Source\Wiki\Shared\Domain\ValueObject\Action;
 use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
 use Source\Wiki\Shared\Domain\ValueObject\Resource;
@@ -51,6 +50,9 @@ class PolicyEvaluatorTest extends TestCase
 
     /** @phpstan-ignore property.uninitialized (setUp で初期化) */
     private PrincipalGroupRepositoryInterface $principalGroupRepository;
+
+    /** @var array<string, array{agency: string[], groups: string[], talentGroups: string[], talents: string[], affiliatedTalents: string[]}> */
+    private array $principalScopes = [];
 
     protected function setUp(): void
     {
@@ -87,14 +89,49 @@ class PolicyEvaluatorTest extends TestCase
             new PrincipalIdentifier($principalId),
             new IdentityIdentifier($identityId),
         );
+        $this->principalScopes[$principalId] = [
+            'agency' => $agencyId === null ? [] : [$agencyId],
+            'groups' => $groupIds,
+            'talentGroups' => $groupIds,
+            'talents' => $talentIds,
+            'affiliatedTalents' => [],
+        ];
 
         return new Principal(
             new PrincipalIdentifier($principalId),
             new IdentityIdentifier($identityId),
-            $agencyId,
-            $groupIds,
-            $talentIds
         );
+    }
+
+    private function conditionValueResolver(): ConditionValueResolverInterface
+    {
+        /** @var ConditionValueResolverInterface&Mockery\MockInterface $resolver */
+        $resolver = Mockery::mock(ConditionValueResolverInterface::class);
+        $resolver->shouldReceive('resolve')
+            ->andReturnUsing(function (ConditionValue|string|bool $value, Principal $principal): string|array|bool {
+                if (! $value instanceof ConditionValue) {
+                    return $value;
+                }
+
+                $scope = $this->principalScopes[(string) $principal->principalIdentifier()] ?? [
+                    'agency' => [],
+                    'groups' => [],
+                    'talentGroups' => [],
+                    'talents' => [],
+                    'affiliatedTalents' => [],
+                ];
+
+                return match ($value) {
+                    ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS => $scope['agency'],
+                    ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS => $scope['groups'],
+                    ConditionValue::PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS => $scope['talentGroups'],
+                    ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS => $scope['talents'],
+                    ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS => $scope['affiliatedTalents'],
+                    ConditionValue::PRINCIPAL_ID => (string) $principal->principalIdentifier(),
+                };
+            });
+
+        return $resolver;
     }
 
     /**
@@ -210,7 +247,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::AGENCY);
@@ -239,7 +276,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::AGENCY);
@@ -269,7 +306,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::AGENCY);
@@ -294,7 +331,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::AGENCY);
@@ -347,7 +384,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::AGENCY);
@@ -421,7 +458,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::AGENCY);
@@ -444,7 +481,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:agencyId eq ${principal.agencyId}
+     * 正常系: Condition評価 - resource:agencyId eq ${principal.agencyWikiIdentifiers}
      */
     #[Group('useDb')]
     public function testConditionAgencyIdEquals(): void
@@ -461,7 +498,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_AGENCY_ID,
                         ConditionOperator::EQUALS,
-                        ConditionValue::PRINCIPAL_AGENCY_ID
+                        ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -479,7 +516,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         // 自分のAgencyへのAPPROVEは許可
@@ -505,7 +542,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:groupId eq ${principal.wikiGroupIds}（配列同士の比較）.
+     * 正常系: Condition評価 - resource:groupId eq ${principal.groupWikiIdentifiers}（配列同士の比較）.
      */
     #[Group('useDb')]
     public function testConditionGroupIdsEqualsArrayIntersection(): void
@@ -522,7 +559,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::EQUALS,
-                        ConditionValue::PRINCIPAL_WIKI_GROUP_IDS
+                        ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -540,7 +577,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         // 交差がある場合は許可
@@ -559,7 +596,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:agencyId ne ${principal.agencyId}.
+     * 正常系: Condition評価 - resource:agencyId ne ${principal.agencyWikiIdentifiers}.
      */
     #[Group('useDb')]
     public function testConditionAgencyIdNotEquals(): void
@@ -576,7 +613,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_AGENCY_ID,
                         ConditionOperator::NOT_EQUALS,
-                        ConditionValue::PRINCIPAL_AGENCY_ID
+                        ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -594,7 +631,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $otherAgency = new Resource(ResourceType::AGENCY, $otherAgencyId);
@@ -628,7 +665,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::EQUALS,
-                        ConditionValue::PRINCIPAL_AGENCY_ID
+                        ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -646,7 +683,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::GROUP, null, [$groupId]);
@@ -657,7 +694,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:groupId in ${principal.wikiGroupIds}
+     * 正常系: Condition評価 - resource:groupId in ${principal.groupWikiIdentifiers}
      */
     #[Group('useDb')]
     public function testConditionGroupIdIn(): void
@@ -674,7 +711,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_WIKI_GROUP_IDS
+                        ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -692,7 +729,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         // 自分のGroupへのAPPROVEは許可
@@ -711,7 +748,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:agencyId in ${principal.agencyId}（スカラー比較）.
+     * 正常系: Condition評価 - resource:agencyId in ${principal.agencyWikiIdentifiers}（スカラー比較）.
      */
     #[Group('useDb')]
     public function testConditionAgencyIdInScalar(): void
@@ -727,7 +764,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_AGENCY_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_AGENCY_ID
+                        ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -745,7 +782,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $ownAgency = new Resource(ResourceType::AGENCY, $principalAgencyId);
@@ -762,7 +799,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:agencyId in ${principal.agencyId} でresourceがnullの場合は拒否.
+     * 正常系: Condition評価 - resource:agencyId in ${principal.agencyWikiIdentifiers} でresourceがnullの場合は拒否.
      */
     #[Group('useDb')]
     public function testConditionAgencyIdInWithNullResource(): void
@@ -778,7 +815,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_AGENCY_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_AGENCY_ID
+                        ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -796,7 +833,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::AGENCY);
@@ -821,7 +858,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_WIKI_GROUP_IDS
+                        ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -839,7 +876,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::GROUP, null, [StrTestHelper::generateUuid()]);
@@ -850,7 +887,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:groupId not_in ${principal.wikiGroupIds}.
+     * 正常系: Condition評価 - resource:groupId not_in ${principal.groupWikiIdentifiers}.
      */
     #[Group('useDb')]
     public function testConditionGroupIdNotIn(): void
@@ -866,7 +903,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::NOT_IN,
-                        ConditionValue::PRINCIPAL_WIKI_GROUP_IDS
+                        ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -884,7 +921,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $otherGroup = new Resource(ResourceType::GROUP, null, [StrTestHelper::generateUuid()]);
@@ -901,7 +938,7 @@ class PolicyEvaluatorTest extends TestCase
     }
 
     /**
-     * 正常系: Condition評価 - resource:talentId in ${principal.talentIds}
+     * 正常系: Condition評価 - resource:talentId in ${principal.talentWikiIdentifiers}
      */
     #[Group('useDb')]
     public function testConditionTalentIdIn(): void
@@ -918,7 +955,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_TALENT_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_TALENT_IDS
+                        ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -936,7 +973,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         // 自分のTalentへのAPPROVEは許可
@@ -973,12 +1010,12 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_AGENCY_ID,
                         ConditionOperator::EQUALS,
-                        ConditionValue::PRINCIPAL_AGENCY_ID
+                        ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS
                     ),
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_WIKI_GROUP_IDS
+                        ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -996,7 +1033,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         // 両方一致する場合は許可
@@ -1055,7 +1092,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::GROUP);
@@ -1064,7 +1101,7 @@ class PolicyEvaluatorTest extends TestCase
             'APPROVE should be denied when isOfficial is false'
         );
 
-        $officialResource = new Resource(ResourceType::GROUP, null, [], [], true);
+        $officialResource = new Resource(ResourceType::GROUP, isOfficial: true);
         $this->assertTrue(
             $policyEvaluator->evaluate($principal, Action::APPROVE, $officialResource),
             'APPROVE should be allowed when isOfficial is true'
@@ -1111,7 +1148,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $resource = new Resource(ResourceType::GROUP);
@@ -1179,7 +1216,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $ownDraft = new Resource(ResourceType::GROUP, editorId: (string) $principal->principalIdentifier());
@@ -1230,7 +1267,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_WIKI_GROUP_IDS
+                        ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -1246,7 +1283,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_TALENT_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_TALENT_IDS
+                        ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -1269,7 +1306,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         $agency = new Resource(ResourceType::AGENCY);
@@ -1326,7 +1363,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_AGENCY_ID,
                         ConditionOperator::EQUALS,
-                        ConditionValue::PRINCIPAL_AGENCY_ID
+                        ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -1347,7 +1384,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         // 自分のAgencyへの承認は許可される
@@ -1405,7 +1442,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_GROUP_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_WIKI_GROUP_IDS
+                        ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -1421,7 +1458,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_TALENT_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_TALENT_IDS
+                        ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS
                     ),
                 ])
             ),
@@ -1442,7 +1479,7 @@ class PolicyEvaluatorTest extends TestCase
             $this->principalGroupRepository,
             $this->roleRepository,
             $this->policyRepository,
-            new PrincipalConditionValueResolver(),
+            $this->conditionValueResolver(),
         );
 
         // Groupが一致するSongへの承認は許可
@@ -1485,7 +1522,7 @@ class PolicyEvaluatorTest extends TestCase
                     new ConditionClause(
                         ConditionKey::RESOURCE_TALENT_ID,
                         ConditionOperator::IN,
-                        ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS,
+                        ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS,
                     ),
                 ])
             ),
@@ -1501,7 +1538,7 @@ class PolicyEvaluatorTest extends TestCase
         /** @var ConditionValueResolverInterface&Mockery\MockInterface $resolver */
         $resolver = Mockery::mock(ConditionValueResolverInterface::class);
         $resolver->shouldReceive('resolve')
-            ->with(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_IDS, $principal)
+            ->with(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS, $principal)
             ->andReturn([], [$talentId]);
 
         $policyEvaluator = new PolicyEvaluator(

--- a/tests/Wiki/Principal/Infrastructure/Service/PrincipalConditionValueResolverTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Service/PrincipalConditionValueResolverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Infrastructure\Service;
+
+use Mockery;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\Service\PrincipalWikiScopeResolverInterface;
+use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Principal\Domain\ValueObject\ConditionValue;
+use Source\Wiki\Principal\Infrastructure\Service\PrincipalConditionValueResolver;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class PrincipalConditionValueResolverTest extends TestCase
+{
+    public function testResolveReturnsLiteralValue(): void
+    {
+        $resolver = new PrincipalConditionValueResolver($this->scopeResolver());
+        $principal = $this->principal();
+
+        $this->assertSame('literal', $resolver->resolve('literal', $principal));
+        $this->assertTrue($resolver->resolve(true, $principal));
+        $this->assertFalse($resolver->resolve(false, $principal));
+    }
+
+    public function testResolvePrincipalValues(): void
+    {
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
+        $agencyWikiIdentifiers = [StrTestHelper::generateUuid()];
+        $groupWikiIdentifiers = [StrTestHelper::generateUuid(), StrTestHelper::generateUuid()];
+        $talentGroupWikiIdentifiers = [StrTestHelper::generateUuid()];
+        $talentWikiIdentifiers = [StrTestHelper::generateUuid(), StrTestHelper::generateUuid()];
+        $affiliatedTalentWikiIdentifiers = [StrTestHelper::generateUuid()];
+
+        /** @var PrincipalWikiScopeResolverInterface&Mockery\MockInterface $scopeResolver */
+        $scopeResolver = Mockery::mock(PrincipalWikiScopeResolverInterface::class);
+        $scopeResolver->shouldReceive('agencyWikiIdentifiers')->once()->with($principal)->andReturn($agencyWikiIdentifiers);
+        $scopeResolver->shouldReceive('groupWikiIdentifiers')->once()->with($principal)->andReturn($groupWikiIdentifiers);
+        $scopeResolver->shouldReceive('talentGroupWikiIdentifiers')->once()->with($principal)->andReturn($talentGroupWikiIdentifiers);
+        $scopeResolver->shouldReceive('talentWikiIdentifiers')->once()->with($principal)->andReturn($talentWikiIdentifiers);
+        $scopeResolver->shouldReceive('affiliatedTalentWikiIdentifiers')->once()->with($principal)->andReturn($affiliatedTalentWikiIdentifiers);
+
+        $resolver = new PrincipalConditionValueResolver($scopeResolver);
+
+        $this->assertSame($agencyWikiIdentifiers, $resolver->resolve(ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS, $principal));
+        $this->assertSame($groupWikiIdentifiers, $resolver->resolve(ConditionValue::PRINCIPAL_GROUP_WIKI_IDENTIFIERS, $principal));
+        $this->assertSame($talentGroupWikiIdentifiers, $resolver->resolve(ConditionValue::PRINCIPAL_TALENT_GROUP_WIKI_IDENTIFIERS, $principal));
+        $this->assertSame($talentWikiIdentifiers, $resolver->resolve(ConditionValue::PRINCIPAL_TALENT_WIKI_IDENTIFIERS, $principal));
+        $this->assertSame($affiliatedTalentWikiIdentifiers, $resolver->resolve(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS, $principal));
+        $this->assertSame((string) $principalIdentifier, $resolver->resolve(ConditionValue::PRINCIPAL_ID, $principal));
+    }
+
+    public function testResolveReturnsEmptyArrayWhenPrincipalHasNoScope(): void
+    {
+        $resolver = new PrincipalConditionValueResolver($this->scopeResolver());
+
+        $this->assertSame([], $resolver->resolve(ConditionValue::PRINCIPAL_AGENCY_WIKI_IDENTIFIERS, $this->principal()));
+        $this->assertSame([], $resolver->resolve(ConditionValue::PRINCIPAL_AFFILIATED_TALENT_WIKI_IDENTIFIERS, $this->principal()));
+    }
+
+    private function principal(): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+        );
+    }
+
+    private function scopeResolver(): PrincipalWikiScopeResolverInterface
+    {
+        /** @var PrincipalWikiScopeResolverInterface&Mockery\MockInterface $scopeResolver */
+        $scopeResolver = Mockery::mock(PrincipalWikiScopeResolverInterface::class);
+        $scopeResolver->shouldReceive('agencyWikiIdentifiers')->andReturn([]);
+        $scopeResolver->shouldReceive('groupWikiIdentifiers')->andReturn([]);
+        $scopeResolver->shouldReceive('talentGroupWikiIdentifiers')->andReturn([]);
+        $scopeResolver->shouldReceive('talentWikiIdentifiers')->andReturn([]);
+        $scopeResolver->shouldReceive('affiliatedTalentWikiIdentifiers')->andReturn([]);
+
+        return $scopeResolver;
+    }
+}

--- a/tests/Wiki/Principal/Infrastructure/Service/PrincipalWikiScopeResolverTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Service/PrincipalWikiScopeResolverTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Infrastructure\Service;
+
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Account\Affiliation\Domain\Entity\Affiliation;
+use Source\Account\Affiliation\Domain\Repository\AffiliationRepositoryInterface;
+use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
+use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Domain\Entity\Principal;
+use Source\Wiki\Principal\Infrastructure\Service\PrincipalWikiScopeResolver;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Wiki\Shared\Domain\ValueObject\ResourceType;
+use Source\Wiki\Wiki\Domain\Repository\WikiRepositoryInterface;
+use Source\Wiki\Wiki\Domain\ValueObject\WikiIdentifier;
+use Tests\Helper\CreateAccount;
+use Tests\Helper\CreateIdentity;
+use Tests\Helper\CreateWiki;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class PrincipalWikiScopeResolverTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testResolveOwnedWikiIdentifiersFromPrincipalIdentityAccounts(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $agencyWikiIdentifier = StrTestHelper::generateUuid();
+        $groupWikiIdentifier = StrTestHelper::generateUuid();
+        $talentGroupWikiIdentifier = StrTestHelper::generateUuid();
+        $talentWikiIdentifier = StrTestHelper::generateUuid();
+
+        CreateIdentity::create($identityIdentifier);
+        CreateAccount::create((string) $accountIdentifier);
+        $this->createAccountPrincipal($identityIdentifier, $accountIdentifier);
+        CreateWiki::create($agencyWikiIdentifier, ResourceType::AGENCY->value, [
+            'owner_account_id' => (string) $accountIdentifier,
+            'slug' => 'agency-' . $agencyWikiIdentifier,
+        ]);
+        CreateWiki::create($groupWikiIdentifier, ResourceType::GROUP->value, [
+            'owner_account_id' => (string) $accountIdentifier,
+            'slug' => 'group-' . $groupWikiIdentifier,
+        ]);
+        CreateWiki::create($talentGroupWikiIdentifier, ResourceType::GROUP->value, [
+            'slug' => 'talent-group-' . $talentGroupWikiIdentifier,
+        ]);
+        CreateWiki::create(
+            $talentWikiIdentifier,
+            ResourceType::TALENT->value,
+            [
+                'owner_account_id' => (string) $accountIdentifier,
+                'slug' => 'talent-' . $talentWikiIdentifier,
+            ],
+            [
+                'group_identifiers' => json_encode([$talentGroupWikiIdentifier]),
+            ],
+        );
+
+        /** @var AffiliationRepositoryInterface&Mockery\MockInterface $affiliationRepository */
+        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
+        /** @var WikiRepositoryInterface&Mockery\MockInterface $wikiRepository */
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $resolver = new PrincipalWikiScopeResolver($affiliationRepository, $wikiRepository);
+        $principal = new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), $identityIdentifier);
+
+        $this->assertSame([$agencyWikiIdentifier], $resolver->agencyWikiIdentifiers($principal));
+        $this->assertSame([$groupWikiIdentifier], $resolver->groupWikiIdentifiers($principal));
+        $this->assertSame([$talentGroupWikiIdentifier], $resolver->talentGroupWikiIdentifiers($principal));
+        $this->assertSame([$talentWikiIdentifier], $resolver->talentWikiIdentifiers($principal));
+    }
+
+    #[Group('useDb')]
+    public function testResolveAffiliatedTalentWikiIdentifiersFromPrincipalIdentityAccounts(): void
+    {
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $talentWikiIdentifier = new WikiIdentifier(StrTestHelper::generateUuid());
+        $principal = new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), $identityIdentifier);
+
+        CreateIdentity::create($identityIdentifier);
+        CreateAccount::create((string) $agencyAccountIdentifier);
+        $this->createAccountPrincipal($identityIdentifier, $agencyAccountIdentifier);
+        $affiliation = new Affiliation(
+            new AffiliationIdentifier(StrTestHelper::generateUuid()),
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            $agencyAccountIdentifier,
+            AffiliationStatus::ACTIVE,
+            null,
+            new DateTimeImmutable(),
+            new DateTimeImmutable(),
+            null,
+        );
+
+        /** @var AffiliationRepositoryInterface&Mockery\MockInterface $affiliationRepository */
+        $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
+        $affiliationRepository->shouldReceive('findByAgencyAccount')
+            ->once()
+            ->with(
+                Mockery::on(static fn (AccountIdentifier $id): bool => (string) $id === (string) $agencyAccountIdentifier),
+                AffiliationStatus::ACTIVE,
+            )
+            ->andReturn([$affiliation]);
+
+        $wiki = Mockery::mock(\Source\Wiki\Wiki\Domain\Entity\Wiki::class);
+        $wiki->shouldReceive('wikiIdentifier')->andReturn($talentWikiIdentifier);
+        /** @var WikiRepositoryInterface&Mockery\MockInterface $wikiRepository */
+        $wikiRepository = Mockery::mock(WikiRepositoryInterface::class);
+        $wikiRepository->shouldReceive('findByOwnerAccountId')
+            ->once()
+            ->with($talentAccountIdentifier, ResourceType::TALENT)
+            ->andReturn($wiki);
+
+        $resolver = new PrincipalWikiScopeResolver($affiliationRepository, $wikiRepository);
+
+        $this->assertSame([(string) $talentWikiIdentifier], $resolver->affiliatedTalentWikiIdentifiers($principal));
+    }
+
+    private function createAccountPrincipal(IdentityIdentifier $identityIdentifier, AccountIdentifier $accountIdentifier): void
+    {
+        DB::table('account_principals')->insert([
+            'id' => StrTestHelper::generateUuid(),
+            'identity_id' => (string) $identityIdentifier,
+            'account_id' => (string) $accountIdentifier,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/tests/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/ApproveWiki/ApproveWikiTest.php
@@ -86,7 +86,7 @@ class ApproveWikiTest extends TestCase
     public function testProcess(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyApproveWiki = $this->createDummyApproveWiki(
             operatorIdentifier: $principalIdentifier,
@@ -327,7 +327,7 @@ class ApproveWikiTest extends TestCase
         $dummyApproveWiki = $this->createDummyApproveWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new ApproveWikiInput(
             $dummyApproveWiki->wikiIdentifier,
@@ -384,7 +384,7 @@ class ApproveWikiTest extends TestCase
     public function testDuplicateSlug(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyApproveWiki = $this->createDummyApproveWiki(
             operatorIdentifier: $principalIdentifier,
@@ -451,7 +451,7 @@ class ApproveWikiTest extends TestCase
     public function testExistsApprovedDraftWiki(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyApproveWiki = $this->createDummyApproveWiki(
             operatorIdentifier: $principalIdentifier,
@@ -522,7 +522,7 @@ class ApproveWikiTest extends TestCase
     public function testInconsistentVersions(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyApproveWiki = $this->createDummyApproveWiki(
             operatorIdentifier: $principalIdentifier,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/AutoCreateWiki/AutoCreateWikiTest.php
@@ -48,7 +48,7 @@ class AutoCreateWikiTest extends TestCase
     public function testProcessWithAdministrator(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $payload = $this->makePayload();
         $generatedData = $this->makeGeneratedWikiData();
@@ -104,7 +104,7 @@ class AutoCreateWikiTest extends TestCase
     public function testProcessWithSeniorCollaborator(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $payload = $this->makePayload();
         $generatedData = $this->makeGeneratedWikiData();
@@ -158,7 +158,7 @@ class AutoCreateWikiTest extends TestCase
     public function testProcessWithUnauthorizedRole(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $payload = $this->makePayload();
 
@@ -229,7 +229,7 @@ class AutoCreateWikiTest extends TestCase
     public function testProcessWithEmptyGeneratedData(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $payload = $this->makePayload();
         $emptyGeneratedData = new GeneratedWikiData(

--- a/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/CreateWiki/CreateWikiTest.php
@@ -119,7 +119,7 @@ class CreateWikiTest extends TestCase
         $testData = $this->createDummyCreateWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $title = new SeoTitle('TWICE Wiki');
         $metaDescription = new MetaDescription('Profile for TWICE.');
         $keywords = new SeoKeywords(['TWICE', 'K-pop']);
@@ -179,7 +179,7 @@ class CreateWikiTest extends TestCase
         $testData = $this->createDummyCreateWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $title = new SeoTitle('TWICE Wiki');
         $metaDescription = new MetaDescription('Profile for TWICE.');
         $keywords = new SeoKeywords(['TWICE', 'K-pop']);

--- a/tests/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/DeleteWiki/DeleteWikiTest.php
@@ -228,7 +228,7 @@ class DeleteWikiTest extends TestCase
         bool $isAllowed,
         bool $expectDelete = false,
     ): void {
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
         $draftWikiRepository->shouldReceive('findById')->once()->with($draftWiki->wikiIdentifier())->andReturn($draftWiki);

--- a/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/EditWiki/EditWikiTest.php
@@ -71,7 +71,7 @@ class EditWikiTest extends TestCase
         $testData = $this->createDummyEditWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $updatedBasic = new GroupBasic(
             name: new Name('ITZY'),
@@ -250,7 +250,7 @@ class EditWikiTest extends TestCase
         $testData = $this->createDummyEditWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new EditWikiInput(
             $testData->wikiIdentifier,
@@ -306,7 +306,7 @@ class EditWikiTest extends TestCase
         $testData = $this->createDummyEditWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new EditWikiInput(
             $testData->wikiIdentifier,
@@ -383,7 +383,7 @@ class EditWikiTest extends TestCase
         $testData = $this->createDummyEditWiki($status);
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new EditWikiInput(
             $testData->wikiIdentifier,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/MergeWiki/MergeWikiTest.php
@@ -72,7 +72,7 @@ class MergeWikiTest extends TestCase
         $mergedAt = new DateTimeImmutable('2026-01-02 12:00:00');
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $updatedBasic = new GroupBasic(
             name: new Name('ITZY'),
@@ -255,7 +255,7 @@ class MergeWikiTest extends TestCase
         $mergedAt = new DateTimeImmutable('2026-01-02 12:00:00');
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new MergeWikiInput(
             $testData->wikiIdentifier,
@@ -311,7 +311,7 @@ class MergeWikiTest extends TestCase
         $mergedAt = new DateTimeImmutable('2026-01-02 12:00:00');
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new MergeWikiInput(
             $testData->wikiIdentifier,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/PublishWiki/PublishWikiTest.php
@@ -100,7 +100,7 @@ class PublishWikiTest extends TestCase
     public function testProcessWhenAlreadyPublished(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyPublishWiki = $this->createDummyPublishWiki(
             hasPublishedWiki: true,
@@ -209,7 +209,7 @@ class PublishWikiTest extends TestCase
     public function testProcessUsesDraftPublishedWikiIdentifier(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyPublishWiki = $this->createDummyPublishWiki(
             hasPublishedWiki: true,
@@ -319,7 +319,7 @@ class PublishWikiTest extends TestCase
     public function testProcessForTheFirstTime(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyPublishWiki = $this->createDummyPublishWiki(
             hasPublishedWiki: false,
@@ -412,7 +412,7 @@ class PublishWikiTest extends TestCase
     public function testProcessForNewTranslatedLanguageUsesResolvedLatestVersion(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyPublishWiki = $this->createDummyPublishWiki(
             hasPublishedWiki: false,
@@ -667,7 +667,7 @@ class PublishWikiTest extends TestCase
         $dummyPublishWiki = $this->createDummyPublishWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new PublishWikiInput(
             $dummyPublishWiki->wikiIdentifier,
@@ -725,7 +725,7 @@ class PublishWikiTest extends TestCase
         $dummyPublishWiki = $this->createDummyPublishWiki(hasPublishedWiki: true);
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new PublishWikiInput(
             $dummyPublishWiki->wikiIdentifier,
@@ -787,7 +787,7 @@ class PublishWikiTest extends TestCase
         $dummyPublishWiki = $this->createDummyPublishWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new PublishWikiInput(
             $dummyPublishWiki->wikiIdentifier,
@@ -841,7 +841,7 @@ class PublishWikiTest extends TestCase
     public function testProcessWithAdministrator(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyPublishWiki = $this->createDummyPublishWiki(
             operatorIdentifier: new PrincipalIdentifier((string) $principalIdentifier),
@@ -932,7 +932,7 @@ class PublishWikiTest extends TestCase
     public function testProcessGrantsContributionPointsOnNewCreation(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $approverIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $mergerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 
@@ -1053,7 +1053,7 @@ class PublishWikiTest extends TestCase
     public function testProcessGrantsContributionPointsOnUpdate(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
         $approverIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
         $mergerIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
 

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RejectWiki/RejectWikiTest.php
@@ -78,7 +78,7 @@ class RejectWikiTest extends TestCase
     public function testProcess(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummyRejectWiki = $this->createDummyRejectWiki(
             operatorIdentifier: $principalIdentifier,
@@ -295,7 +295,7 @@ class RejectWikiTest extends TestCase
         $dummyRejectWiki = $this->createDummyRejectWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new RejectWikiInput(
             $dummyRejectWiki->wikiIdentifier,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/RollbackWiki/RollbackWikiTest.php
@@ -90,9 +90,6 @@ class RollbackWikiTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            []
         );
 
         $input = new RollbackWikiInput(
@@ -188,9 +185,6 @@ class RollbackWikiTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            []
         );
 
         $input = new RollbackWikiInput(
@@ -285,9 +279,6 @@ class RollbackWikiTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            []
         );
 
         $input = new RollbackWikiInput(
@@ -434,9 +425,6 @@ class RollbackWikiTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            []
         );
 
         $input = new RollbackWikiInput(
@@ -505,9 +493,6 @@ class RollbackWikiTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            []
         );
 
         $input = new RollbackWikiInput(
@@ -567,9 +552,6 @@ class RollbackWikiTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            []
         );
 
         $input = new RollbackWikiInput(

--- a/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/SubmitWiki/SubmitWikiTest.php
@@ -78,7 +78,7 @@ class SubmitWikiTest extends TestCase
     public function testProcess(): void
     {
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $dummySubmitWiki = $this->createDummySubmitWiki(
             operatorIdentifier: $principalIdentifier,
@@ -239,7 +239,7 @@ class SubmitWikiTest extends TestCase
         $dummySubmitWiki = $this->createDummySubmitWiki(status: ApprovalStatus::Approved);
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new SubmitWikiInput(
             $dummySubmitWiki->wikiIdentifier,
@@ -289,7 +289,7 @@ class SubmitWikiTest extends TestCase
         $dummySubmitWiki = $this->createDummySubmitWiki();
 
         $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $input = new SubmitWikiInput(
             $dummySubmitWiki->wikiIdentifier,

--- a/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/TranslateWiki/TranslateWikiTest.php
@@ -70,9 +70,6 @@ class TranslateWikiTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            [],
         );
 
         $input = new TranslateWikiInput(
@@ -294,9 +291,6 @@ class TranslateWikiTest extends TestCase
         $principal = new Principal(
             $testData->principalIdentifier,
             new IdentityIdentifier(StrTestHelper::generateUuid()),
-            null,
-            [],
-            [],
         );
 
         $input = new TranslateWikiInput(

--- a/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiTest.php
+++ b/tests/Wiki/Wiki/Application/UseCase/Command/WithdrawWiki/WithdrawWikiTest.php
@@ -212,7 +212,7 @@ class WithdrawWikiTest extends TestCase
         bool $expectSave = false,
         ?WikiHistory $history = null,
     ): void {
-        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()), null, [], []);
+        $principal = new Principal($principalIdentifier, new IdentityIdentifier(StrTestHelper::generateUuid()));
 
         $draftWikiRepository = Mockery::mock(DraftWikiRepositoryInterface::class);
         $draftWikiRepository->shouldReceive('findById')->once()->with($draftWiki->wikiIdentifier())->andReturn($draftWiki);

--- a/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
+++ b/tests/Wiki/Wiki/Infrastructure/Query/ListDraftWikisTest.php
@@ -208,9 +208,6 @@ class ListDraftWikisTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f712'),
-            null,
-            [],
-            [],
         );
 
         CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f611', 'group', [
@@ -251,9 +248,6 @@ class ListDraftWikisTest extends TestCase
         $principal = new Principal(
             $principalIdentifier,
             new IdentityIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f722'),
-            null,
-            [],
-            [],
         );
 
         CreateDraftWiki::create('01965bb2-bcc9-7c6f-8b90-89f7f217f621', 'talent', [
@@ -414,9 +408,6 @@ class ListDraftWikisTest extends TestCase
         $principal = new Principal(
             $this->defaultPrincipalIdentifier(),
             new IdentityIdentifier('01965bb2-bcc9-7c6f-8b90-89f7f217f701'),
-            null,
-            [],
-            [],
         );
 
         $principalRepository = Mockery::mock(PrincipalRepositoryInterface::class);


### PR DESCRIPTION
## 変更内容

- Wiki Principal から agency/group/talent のスコープ情報を削除
- Identity に紐づく Account と Wiki owner の関係から Principal の Wiki スコープを解決する `PrincipalWikiScopeResolver` を追加
- Policy 条件値を `${principal.*Ids}` から `${principal.*WikiIdentifiers}` 系へ変更
- PrincipalGroup メンバー更新時の所属確認を `agencyId` 比較から Account Principal 経由の確認へ変更
- 変更に合わせて Repository、Seeder、Policy 評価、関連テストを更新

## 変更の種類

- [x] リファクタリング
- [x] テスト

## 変更理由・背景

Wiki Principal に Account/Wiki スコープ情報を重複して保持せず、Account 側の Principal 関係と Wiki owner 情報を正として扱うため。

## テスト

- [ ] `task test`
- [ ] `task phpstan`

※ このPR作成作業中には未実行です。

## レビューのポイント

- `PrincipalWikiScopeResolver` のスコープ解決が Account / Wiki / Affiliation の責務境界として妥当か
- Policy 条件値の置き換えで既存認可の意味が変わっていないか
- `UpdatePrincipalGroupMembers` の所属確認が期待する Account Principal 関係を参照できているか
- `wiki_principals` からスコープ列を削除する影響範囲

## 関連情報

関連Issueなし

## 注意事項

- `wiki_principals` の `agency_id`, `group_ids`, `talent_ids` を削除しています
