### PR TITLE
chore: Renovateとpnpmのリリース待機期間を3日に変更

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,1 @@
-minimumReleaseAge: 20160
+minimumReleaseAge: 4320

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
             "matchFileNames": ["package.json", "pnpm-lock.yaml"],
             "matchDepTypes": ["devDependencies"],
             "groupName": "root tooling devDependencies",
-            "stabilityDays": 3
+            "minimumReleaseAge": "3 days"
         },
         {
             "description": "Composer require をまとめる",
@@ -28,7 +28,7 @@
             "matchFileNames": ["composer.json", "composer.lock"],
             "matchDepTypes": ["require"],
             "groupName": "composer require",
-            "stabilityDays": 3,
+            "minimumReleaseAge": "3 days",
             "schedule": ["before 4am on monday"]
         },
         {
@@ -37,7 +37,7 @@
             "matchFileNames": ["composer.json", "composer.lock"],
             "matchDepTypes": ["require-dev"],
             "groupName": "composer require-dev",
-            "stabilityDays": 3,
+            "minimumReleaseAge": "3 days",
             "schedule": ["before 4am on monday"]
         },
         {
@@ -45,7 +45,7 @@
             "matchManagers": ["github-actions"],
             "matchFileNames": [".github/workflows/**"],
             "groupName": "github-actions",
-            "stabilityDays": 3,
+            "minimumReleaseAge": "3 days",
             "schedule": ["before 4am on monday"]
         }
     ],


### PR DESCRIPTION
## 変更内容

- pnpm の `minimumReleaseAge` を 14日から3日に変更
- Renovate の `stabilityDays` を `minimumReleaseAge: "3 days"` に置き換え
- npm / Composer / GitHub Actions の Renovate package rule を3日待機に統一

## 変更の種類

- [x] ビルド/CI

## 変更理由・背景

Renovate PR の artifact 更新時に、pnpm の `minimumReleaseAge` が14日設定のため新しすぎる依存バージョンが lockfile 更新で拒否されていました。14日は運用上長いため、Renovate 側と pnpm 側の待機期間を3日に揃えます。

## テスト

- [x] `jq . renovate.json`
- [x] `git diff --check main...HEAD`

## レビューのポイント

- pnpm の `minimumReleaseAge: 4320` が3日相当であること
- Renovate の待機設定が `minimumReleaseAge: "3 days"` に統一されていること
- package rule の対象範囲が意図通り変わっていないこと

## 関連情報

関連Issueなし

## 注意事項

特になし
