### PR TITLE
Wikiプリンシパルグループ一覧Query APIを追加

### DIFF
--- a/application/Http/Action/Account/Member/Query/ListMembers/ListMembersRequest.php
+++ b/application/Http/Action/Account/Member/Query/ListMembers/ListMembersRequest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Application\Http\Action\Account\Member\Query\ListMembers;
 
+use Application\Http\Action\Concerns\ResolvesLanguage;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ListMembersRequest extends FormRequest
 {
+    use ResolvesLanguage;
+
     public function authorize(): bool
     {
         return true;
@@ -17,10 +20,5 @@ class ListMembersRequest extends FormRequest
     public function rules(): array
     {
         return [];
-    }
-
-    public function language(): string
-    {
-        return (string) $this->header('Accept-Language', (string) config('app.fallback_locale'));
     }
 }

--- a/application/Http/Action/Wiki/Principal/Query/ListPrincipalGroups/ListPrincipalGroupsAction.php
+++ b/application/Http/Action/Wiki/Principal/Query/ListPrincipalGroups/ListPrincipalGroupsAction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Wiki\Principal\Query\ListPrincipalGroups;
+
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Illuminate\Http\JsonResponse;
+use Psr\Log\LoggerInterface;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInput;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInterface;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupReadModel;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ListPrincipalGroupsAction
+{
+    public function __construct(
+        private ListPrincipalGroupsInterface $listPrincipalGroups,
+        // 防御的catch内でのみ利用され、PHPStanのchecked exception解析では未到達扱いになるため。
+        // @phpstan-ignore property.onlyWritten
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /** @throws InternalServerErrorHttpException */
+    public function __invoke(ListPrincipalGroupsRequest $request): JsonResponse
+    {
+        try {
+            $principalGroups = $this->listPrincipalGroups->process(new ListPrincipalGroupsInput(
+                new AccountIdentifier($request->accountIdentifier()),
+            ));
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json([
+            'principalGroups' => array_map(
+                static fn (PrincipalGroupReadModel $principalGroup): array => $principalGroup->toArray(),
+                $principalGroups
+            ),
+        ], Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Wiki/Principal/Query/ListPrincipalGroups/ListPrincipalGroupsRequest.php
+++ b/application/Http/Action/Wiki/Principal/Query/ListPrincipalGroups/ListPrincipalGroupsRequest.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Application\Http\Action\Account\PrincipalGroup\Query\ListPrincipalGroups;
+namespace Application\Http\Action\Wiki\Principal\Query\ListPrincipalGroups;
 
-use Application\Http\Action\Concerns\ResolvesLanguage;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ListPrincipalGroupsRequest extends FormRequest
 {
-    use ResolvesLanguage;
-
     public function authorize(): bool
     {
         return true;
@@ -19,6 +16,13 @@ class ListPrincipalGroupsRequest extends FormRequest
     /** @return array<string, mixed> */
     public function rules(): array
     {
-        return [];
+        return [
+            'accountIdentifier' => ['required', 'uuid'],
+        ];
+    }
+
+    public function accountIdentifier(): string
+    {
+        return (string) $this->query('accountIdentifier');
     }
 }

--- a/application/Models/Wiki/Principal.php
+++ b/application/Models/Wiki/Principal.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Application\Models\Wiki;
 
+use Application\Models\Identity\Identity;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
@@ -17,6 +19,7 @@ use Illuminate\Support\Carbon;
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
  * @property-read Collection<int, PrincipalGroupMembership> $memberships
+ * @property-read Identity|null $identity
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',
@@ -44,5 +47,13 @@ class Principal extends Model
     public function memberships(): HasMany
     {
         return $this->hasMany(PrincipalGroupMembership::class, 'principal_id', 'id');
+    }
+
+    /**
+     * @return BelongsTo<Identity, $this>
+     */
+    public function identity(): BelongsTo
+    {
+        return $this->belongsTo(Identity::class, 'identity_id', 'id');
     }
 }

--- a/application/Models/Wiki/PrincipalGroupMembership.php
+++ b/application/Models/Wiki/PrincipalGroupMembership.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Carbon;
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
  * @property-read PrincipalGroup|null $principalGroup
+ * @property-read Principal|null $principal
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'principal_group_id',
@@ -47,5 +48,13 @@ class PrincipalGroupMembership extends Model
     public function principalGroup(): BelongsTo
     {
         return $this->belongsTo(PrincipalGroup::class, 'principal_group_id', 'id');
+    }
+
+    /**
+     * @return BelongsTo<Principal, $this>
+     */
+    public function principal(): BelongsTo
+    {
+        return $this->belongsTo(Principal::class, 'principal_id', 'id');
     }
 }

--- a/application/Providers/Wiki/UseCaseServiceProvider.php
+++ b/application/Providers/Wiki/UseCaseServiceProvider.php
@@ -62,7 +62,9 @@ use Source\Wiki\Principal\Application\UseCase\Command\RemovePrincipalFromPrincip
 use Source\Wiki\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembers;
 use Source\Wiki\Principal\Application\UseCase\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersInterface;
 use Source\Wiki\Principal\Application\UseCase\Query\GetCurrentPrincipal\GetCurrentPrincipalInterface;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInterface;
 use Source\Wiki\Principal\Infrastructure\Query\GetCurrentPrincipal;
+use Source\Wiki\Principal\Infrastructure\Query\ListPrincipalGroups;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWiki;
 use Source\Wiki\Wiki\Application\UseCase\Command\ApproveWiki\ApproveWikiInterface;
 use Source\Wiki\Wiki\Application\UseCase\Command\AutoCreateWiki\AutoCreateWiki;
@@ -143,6 +145,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(DetachRoleFromPrincipalGroupInterface::class, DetachRoleFromPrincipalGroup::class);
         $this->app->singleton(UpdatePrincipalGroupMembersInterface::class, UpdatePrincipalGroupMembers::class);
         $this->app->singleton(GetCurrentPrincipalInterface::class, GetCurrentPrincipal::class);
+        $this->app->singleton(ListPrincipalGroupsInterface::class, ListPrincipalGroups::class);
         $this->app->singleton(RequestCertificationInterface::class, RequestCertification::class);
         $this->app->singleton(ApproveCertificationInterface::class, ApproveCertification::class);
         $this->app->singleton(RejectCertificationInterface::class, RejectCertification::class);

--- a/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
+++ b/doc/openapi/KPool.WikiPrivateApi.openapi.yaml
@@ -1050,6 +1050,42 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/MutatePrincipalGroupMemberRequestBody'
+  /principal-groups:
+    get:
+      operationId: PrincipalOperations_listPrincipalGroups
+      description: List Wiki principal groups for management.
+      parameters:
+        - name: accountIdentifier
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          explode: false
+      responses:
+        '200':
+          description: Response returned when Wiki principal groups are listed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPrincipalGroupsResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /principal-groups/members:
     patch:
       operationId: PrincipalOperations_updatePrincipalGroupMembers
@@ -3785,7 +3821,7 @@ components:
         principalGroups:
           type: array
           items:
-            $ref: '#/components/schemas/PrincipalGroupSummary'
+            $ref: '#/components/schemas/PrincipalGroupManagementSummary'
           description: Principal groups.
       description: List of Wiki principal groups.
     ListRelatedProfilesResponseBody:
@@ -3989,6 +4025,64 @@ components:
           type: string
           description: Timestamp when the policy was created.
       description: Summary of a policy.
+    PrincipalGroupManagementSummary:
+      type: object
+      required:
+        - principalGroupIdentifier
+        - accountIdentifier
+        - name
+        - roleIdentifiers
+        - isDefault
+        - members
+      properties:
+        principalGroupIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Principal group identifier.
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Owning account identifier.
+        name:
+          type: string
+          description: Principal group name.
+        roleIdentifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Role identifiers attached to the principal group.
+        isDefault:
+          type: boolean
+          description: Whether this is the default principal group.
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/PrincipalGroupMemberSummary'
+          description: Members of the principal group.
+      description: Principal group summary for management.
+    PrincipalGroupMemberSummary:
+      type: object
+      required:
+        - principalIdentifier
+        - identityIdentifier
+        - identityName
+        - email
+      properties:
+        principalIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Principal identifier.
+        identityIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Identity identifier linked to the principal.
+        identityName:
+          type: string
+          description: Identity display name.
+        email:
+          type: string
+          description: Identity email address.
+      description: Principal group member summary for management.
     PrincipalGroupSummary:
       type: object
       required:

--- a/routes/wiki_private_api.php
+++ b/routes/wiki_private_api.php
@@ -31,6 +31,7 @@ use Application\Http\Action\Wiki\Principal\Command\DetachRoleFromPrincipalGroup\
 use Application\Http\Action\Wiki\Principal\Command\RemovePrincipalFromPrincipalGroup\RemovePrincipalFromPrincipalGroupAction;
 use Application\Http\Action\Wiki\Principal\Command\UpdatePrincipalGroupMembers\UpdatePrincipalGroupMembersAction;
 use Application\Http\Action\Wiki\Principal\Query\GetCurrentPrincipal\GetCurrentPrincipalAction;
+use Application\Http\Action\Wiki\Principal\Query\ListPrincipalGroups\ListPrincipalGroupsAction;
 use Application\Http\Action\Wiki\VideoLink\Command\SaveVideoLinks\SaveVideoLinksAction;
 use Application\Http\Action\Wiki\Wiki\Command\ApproveWiki\ApproveWikiAction;
 use Application\Http\Action\Wiki\Wiki\Command\AutoCreateWiki\AutoCreateWikiAction;
@@ -112,6 +113,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.wiki'])->group(function
 Route::get('/principal/me', GetCurrentPrincipalAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::post('/principal/create', CreatePrincipalAction::class)->middleware(['auth.api', 'resolve.actor']);
 Route::middleware('auth.api')->group(function () {
+    Route::get('/principal-groups', ListPrincipalGroupsAction::class);
     Route::post('/principal-group/create', CreatePrincipalGroupAction::class);
     Route::post('/principal-group/{principalGroupId}/add-member', AddPrincipalToPrincipalGroupAction::class);
     Route::post('/principal-group/{principalGroupId}/remove-member', RemovePrincipalFromPrincipalGroupAction::class);

--- a/src/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInput.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups;
+
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+readonly class ListPrincipalGroupsInput implements ListPrincipalGroupsInputPort
+{
+    public function __construct(private AccountIdentifier $accountIdentifier)
+    {
+    }
+
+    public function accountIdentifier(): AccountIdentifier
+    {
+        return $this->accountIdentifier;
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInputPort.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInputPort.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups;
+
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+
+interface ListPrincipalGroupsInputPort
+{
+    public function accountIdentifier(): AccountIdentifier;
+}

--- a/src/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInterface.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups;
+
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupReadModel;
+
+interface ListPrincipalGroupsInterface
+{
+    /** @return array<int, PrincipalGroupReadModel> */
+    public function process(ListPrincipalGroupsInputPort $input): array;
+}

--- a/src/Wiki/Principal/Application/UseCase/Query/PrincipalGroupMemberReadModel.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/PrincipalGroupMemberReadModel.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query;
+
+readonly class PrincipalGroupMemberReadModel
+{
+    public function __construct(
+        private string $principalIdentifier,
+        private string $identityIdentifier,
+        private string $identityName,
+        private string $email,
+    ) {
+    }
+
+    public function principalIdentifier(): string
+    {
+        return $this->principalIdentifier;
+    }
+
+    public function identityIdentifier(): string
+    {
+        return $this->identityIdentifier;
+    }
+
+    public function identityName(): string
+    {
+        return $this->identityName;
+    }
+
+    public function email(): string
+    {
+        return $this->email;
+    }
+
+    /** @return array<string, string> */
+    public function toArray(): array
+    {
+        return [
+            'principalIdentifier' => $this->principalIdentifier,
+            'identityIdentifier' => $this->identityIdentifier,
+            'identityName' => $this->identityName,
+            'email' => $this->email,
+        ];
+    }
+}

--- a/src/Wiki/Principal/Application/UseCase/Query/PrincipalGroupReadModel.php
+++ b/src/Wiki/Principal/Application/UseCase/Query/PrincipalGroupReadModel.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Application\UseCase\Query;
+
+readonly class PrincipalGroupReadModel
+{
+    /**
+     * @param array<int, string> $roleIdentifiers
+     * @param array<int, PrincipalGroupMemberReadModel> $members
+     */
+    public function __construct(
+        private string $principalGroupIdentifier,
+        private string $accountIdentifier,
+        private string $name,
+        private array $roleIdentifiers,
+        private bool $isDefault,
+        private array $members,
+    ) {
+    }
+
+    public function principalGroupIdentifier(): string
+    {
+        return $this->principalGroupIdentifier;
+    }
+
+    public function accountIdentifier(): string
+    {
+        return $this->accountIdentifier;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /** @return array<int, string> */
+    public function roleIdentifiers(): array
+    {
+        return $this->roleIdentifiers;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    /** @return array<int, PrincipalGroupMemberReadModel> */
+    public function members(): array
+    {
+        return $this->members;
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'principalGroupIdentifier' => $this->principalGroupIdentifier,
+            'accountIdentifier' => $this->accountIdentifier,
+            'name' => $this->name,
+            'roleIdentifiers' => $this->roleIdentifiers,
+            'isDefault' => $this->isDefault,
+            'members' => array_map(static fn (PrincipalGroupMemberReadModel $member): array => $member->toArray(), $this->members),
+        ];
+    }
+}

--- a/src/Wiki/Principal/Infrastructure/Query/ListPrincipalGroups.php
+++ b/src/Wiki/Principal/Infrastructure/Query/ListPrincipalGroups.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Wiki\Principal\Infrastructure\Query;
+
+use Application\Models\Wiki\PrincipalGroup as PrincipalGroupModel;
+use Illuminate\Database\Eloquent\Collection;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInputPort;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInterface;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupMemberReadModel;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupReadModel;
+
+readonly class ListPrincipalGroups implements ListPrincipalGroupsInterface
+{
+    /** @return array<int, PrincipalGroupReadModel> */
+    public function process(ListPrincipalGroupsInputPort $input): array
+    {
+        /** @var Collection<int, PrincipalGroupModel> $groups */
+        $groups = PrincipalGroupModel::query()
+            ->with(['memberships.principal.identity', 'roleAttachments'])
+            ->where('account_id', (string) $input->accountIdentifier())
+            ->orderBy('created_at')
+            ->get();
+
+        return $groups->map(static fn (PrincipalGroupModel $group): PrincipalGroupReadModel => new PrincipalGroupReadModel(
+            principalGroupIdentifier: $group->id,
+            accountIdentifier: $group->account_id,
+            name: $group->name,
+            roleIdentifiers: $group->roleAttachments->map(static fn ($attachment): string => $attachment->role_id)->values()->all(),
+            isDefault: $group->is_default,
+            members: $group->memberships->map(static function ($membership): PrincipalGroupMemberReadModel {
+                $principal = $membership->principal;
+                $identity = $principal->identity;
+
+                return new PrincipalGroupMemberReadModel(
+                    principalIdentifier: $principal->id,
+                    identityIdentifier: $principal->identity_id,
+                    identityName: $identity->identity_name,
+                    email: $identity->email,
+                );
+            })->values()->all(),
+        ))->values()->all();
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInputTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Query/ListPrincipalGroups/ListPrincipalGroupsInputTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups;
+
+use PHPUnit\Framework\TestCase;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInput;
+use Tests\Helper\StrTestHelper;
+
+class ListPrincipalGroupsInputTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+
+        $input = new ListPrincipalGroupsInput($accountIdentifier);
+
+        $this->assertSame($accountIdentifier, $input->accountIdentifier());
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Query/PrincipalGroupMemberReadModelTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Query/PrincipalGroupMemberReadModelTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Query;
+
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupMemberReadModel;
+use Tests\Helper\StrTestHelper;
+
+class PrincipalGroupMemberReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $principalIdentifier = StrTestHelper::generateUuid();
+        $identityIdentifier = StrTestHelper::generateUuid();
+
+        $readModel = new PrincipalGroupMemberReadModel($principalIdentifier, $identityIdentifier, 'alice', 'alice@example.com');
+
+        $this->assertSame($principalIdentifier, $readModel->principalIdentifier());
+        $this->assertSame($identityIdentifier, $readModel->identityIdentifier());
+        $this->assertSame('alice', $readModel->identityName());
+        $this->assertSame('alice@example.com', $readModel->email());
+        $this->assertSame([
+            'principalIdentifier' => $principalIdentifier,
+            'identityIdentifier' => $identityIdentifier,
+            'identityName' => 'alice',
+            'email' => 'alice@example.com',
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Principal/Application/UseCase/Query/PrincipalGroupReadModelTest.php
+++ b/tests/Wiki/Principal/Application/UseCase/Query/PrincipalGroupReadModelTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Application\UseCase\Query;
+
+use PHPUnit\Framework\TestCase;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupMemberReadModel;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupReadModel;
+use Tests\Helper\StrTestHelper;
+
+class PrincipalGroupReadModelTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        $principalGroupIdentifier = StrTestHelper::generateUuid();
+        $accountIdentifier = StrTestHelper::generateUuid();
+        $roleIdentifier = StrTestHelper::generateUuid();
+        $principalIdentifier = StrTestHelper::generateUuid();
+        $identityIdentifier = StrTestHelper::generateUuid();
+        $members = [new PrincipalGroupMemberReadModel($principalIdentifier, $identityIdentifier, 'alice', 'alice@example.com')];
+
+        $readModel = new PrincipalGroupReadModel(
+            principalGroupIdentifier: $principalGroupIdentifier,
+            accountIdentifier: $accountIdentifier,
+            name: 'Administrators',
+            roleIdentifiers: [$roleIdentifier],
+            isDefault: false,
+            members: $members,
+        );
+
+        $this->assertSame($principalGroupIdentifier, $readModel->principalGroupIdentifier());
+        $this->assertSame($accountIdentifier, $readModel->accountIdentifier());
+        $this->assertSame('Administrators', $readModel->name());
+        $this->assertSame([$roleIdentifier], $readModel->roleIdentifiers());
+        $this->assertFalse($readModel->isDefault());
+        $this->assertSame($members, $readModel->members());
+        $this->assertSame([
+            'principalGroupIdentifier' => $principalGroupIdentifier,
+            'accountIdentifier' => $accountIdentifier,
+            'name' => 'Administrators',
+            'roleIdentifiers' => [$roleIdentifier],
+            'isDefault' => false,
+            'members' => [[
+                'principalIdentifier' => $principalIdentifier,
+                'identityIdentifier' => $identityIdentifier,
+                'identityName' => 'alice',
+                'email' => 'alice@example.com',
+            ]],
+        ], $readModel->toArray());
+    }
+}

--- a/tests/Wiki/Principal/Infrastructure/Query/ListPrincipalGroupsTest.php
+++ b/tests/Wiki/Principal/Infrastructure/Query/ListPrincipalGroupsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wiki\Principal\Infrastructure\Query;
+
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInput;
+use Source\Wiki\Principal\Application\UseCase\Query\ListPrincipalGroups\ListPrincipalGroupsInterface;
+use Source\Wiki\Principal\Application\UseCase\Query\PrincipalGroupReadModel;
+use Source\Wiki\Principal\Domain\ValueObject\PrincipalGroupIdentifier;
+use Source\Wiki\Principal\Domain\ValueObject\RoleIdentifier;
+use Source\Wiki\Principal\Infrastructure\Query\ListPrincipalGroups;
+use Source\Wiki\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Tests\Helper\CreateAccount;
+use Tests\Helper\CreateIdentity;
+use Tests\Helper\CreatePrincipal;
+use Tests\Helper\CreatePrincipalGroup;
+use Tests\Helper\CreatePrincipalGroupMembership;
+use Tests\Helper\CreateRole;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ListPrincipalGroupsTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $this->assertInstanceOf(ListPrincipalGroups::class, $this->app->make(ListPrincipalGroupsInterface::class));
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsPrincipalGroupsForAccountInCreatedOrder(): void
+    {
+        $accountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $otherAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $accountIdentifier);
+        CreateAccount::create((string) $otherAccountIdentifier);
+
+        $firstGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $secondGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        $otherGroupIdentifier = new PrincipalGroupIdentifier(StrTestHelper::generateUuid());
+        CreatePrincipalGroup::create($firstGroupIdentifier, $accountIdentifier, ['name' => 'Admins', 'is_default' => true]);
+        CreatePrincipalGroup::create($secondGroupIdentifier, $accountIdentifier, ['name' => 'Editors']);
+        CreatePrincipalGroup::create($otherGroupIdentifier, $otherAccountIdentifier, ['name' => 'Other']);
+
+        DB::table('wiki_principal_groups')->where('id', (string) $firstGroupIdentifier)->update(['created_at' => now()->subMinute()]);
+        DB::table('wiki_principal_groups')->where('id', (string) $secondGroupIdentifier)->update(['created_at' => now()]);
+
+        $roleIdentifier = new RoleIdentifier(StrTestHelper::generateUuid());
+        CreateRole::create($roleIdentifier);
+        DB::table('wiki_principal_group_role_attachments')->insert([
+            'principal_group_id' => (string) $firstGroupIdentifier,
+            'role_id' => (string) $roleIdentifier,
+        ]);
+
+        $principalIdentifier = new PrincipalIdentifier(StrTestHelper::generateUuid());
+        $identityIdentifier = new IdentityIdentifier(StrTestHelper::generateUuid());
+        CreateIdentity::create($identityIdentifier, ['identityName' => 'alice', 'email' => 'alice@example.com']);
+        CreatePrincipal::create($principalIdentifier, $identityIdentifier);
+        CreatePrincipalGroupMembership::create((string) $firstGroupIdentifier, (string) $principalIdentifier);
+
+        $groups = (new ListPrincipalGroups())->process(new ListPrincipalGroupsInput($accountIdentifier));
+
+        $this->assertCount(2, $groups);
+        $this->assertInstanceOf(PrincipalGroupReadModel::class, $groups[0]);
+        $this->assertSame((string) $firstGroupIdentifier, $groups[0]->principalGroupIdentifier());
+        $this->assertSame((string) $secondGroupIdentifier, $groups[1]->principalGroupIdentifier());
+        $this->assertSame([
+            'principalGroupIdentifier' => (string) $firstGroupIdentifier,
+            'accountIdentifier' => (string) $accountIdentifier,
+            'name' => 'Admins',
+            'roleIdentifiers' => [(string) $roleIdentifier],
+            'isDefault' => true,
+            'members' => [[
+                'principalIdentifier' => (string) $principalIdentifier,
+                'identityIdentifier' => (string) $identityIdentifier,
+                'identityName' => 'alice',
+                'email' => 'alice@example.com',
+            ]],
+        ], $groups[0]->toArray());
+    }
+}

--- a/typespec/services/wiki-private-api/common.tsp
+++ b/typespec/services/wiki-private-api/common.tsp
@@ -726,6 +726,34 @@ model PrincipalGroupSummary {
   createdAt: string;
 }
 
+@doc("Principal group member summary for management.")
+model PrincipalGroupMemberSummary {
+  @doc("Principal identifier.")
+  principalIdentifier: Uuid;
+  @doc("Identity identifier linked to the principal.")
+  identityIdentifier: Uuid;
+  @doc("Identity display name.")
+  identityName: string;
+  @doc("Identity email address.")
+  email: string;
+}
+
+@doc("Principal group summary for management.")
+model PrincipalGroupManagementSummary {
+  @doc("Principal group identifier.")
+  principalGroupIdentifier: Uuid;
+  @doc("Owning account identifier.")
+  accountIdentifier: Uuid;
+  @doc("Principal group name.")
+  name: string;
+  @doc("Role identifiers attached to the principal group.")
+  roleIdentifiers: Uuid[];
+  @doc("Whether this is the default principal group.")
+  isDefault: boolean;
+  @doc("Members of the principal group.")
+  members: PrincipalGroupMemberSummary[];
+}
+
 @doc("Summary of a role.")
 model RoleSummary {
   @doc("Role identifier.")
@@ -806,5 +834,5 @@ model PolicyStatement {
 @doc("List of Wiki principal groups.")
 model ListPrincipalGroupsResponseBody {
   @doc("Principal groups.")
-  principalGroups: PrincipalGroupSummary[];
+  principalGroups: PrincipalGroupManagementSummary[];
 }

--- a/typespec/services/wiki-private-api/principal.tsp
+++ b/typespec/services/wiki-private-api/principal.tsp
@@ -95,6 +95,12 @@ model OkPrincipalGroupResponse {
   @body body: PrincipalGroupSummary;
 }
 
+@doc("Response returned when Wiki principal groups are listed.")
+model ListPrincipalGroupsResponse {
+  @statusCode statusCode: 200;
+  @body body: ListPrincipalGroupsResponseBody;
+}
+
 @doc("Response returned when multiple Wiki principal group memberships are updated.")
 model UpdatePrincipalGroupMembersResponse {
   @statusCode statusCode: 200;
@@ -126,6 +132,13 @@ interface PrincipalOperations {
   createPrincipal(
     @body body: CreatePrincipalRequestBody,
   ): CreatePrincipalResponse | KPool.Common.ConflictProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
+  @get
+  @route("/principal-groups")
+  @doc("List Wiki principal groups for management.")
+  listPrincipalGroups(
+    @query accountIdentifier: Uuid,
+  ): ListPrincipalGroupsResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
 
   @post
   @route("/principal-group/create")


### PR DESCRIPTION
## 📝 変更内容

- Wiki Private API に `GET /principal-groups?accountIdentifier=...` を追加しました。
- 管理画面向けに `principalGroupIdentifier`, `accountIdentifier`, `name`, `roleIdentifiers`, `isDefault`, `members` を返す Query 用 ReadModel / UseCase / Infrastructure Query / HTTP Action を追加しました。
- `members[]` には `principalIdentifier`, `identityIdentifier`, `identityName`, `email` を含め、所属メンバー編集の初期状態を復元できるようにしました。
- Wiki principal / membership Eloquent model に Query で必要な `identity` / `principal` relation を追加しました。
- TypeSpec と `doc/openapi/KPool.WikiPrivateApi.openapi.yaml` を更新しました。
- 入力 DTO、ReadModel、HTTP Action、DB Query のテストを追加しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki PrincipalGroup は Command API が先行しており、管理 UI が既存グループ、所属メンバー、付与ロールを一覧取得する Query API が不足していました。
`memberCount` 中心の既存 `PrincipalGroupSummary` では所属メンバー編集に必要な `principalIdentifier` やロール付与状態が取得できないため、Command 用 summary とは分けて管理画面向けの Query response を追加しています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、すべてのテストがパスすることを確認
  - `task check`: OK（PHP CS Fixer 変更なし、PHPStan No errors、PHPUnit 3045 tests / 9830 assertions）
- [x] 新しく追加した機能に対するテストを作成
  - `ListPrincipalGroupsInputTest`
  - `PrincipalGroupReadModelTest`
  - `PrincipalGroupMemberReadModelTest`
  - `ListPrincipalGroupsActionTest`
  - `ListPrincipalGroupsTest`
- [x] 既存のテストが壊れていないことを確認
  - `task test filter=ListPrincipalGroupsTest`: OK（関連既存 Account 側テストも含めて 5 tests / 13 assertions）

### 動作確認

- `task openapi-generate`: TypeSpec compile / OpenAPI 生成成功
- `task test-no-db filter=ListPrincipalGroupsInputTest`: OK
- `task test-no-db filter=PrincipalGroupReadModelTest`: OK
- `task test-no-db filter=PrincipalGroupMemberReadModelTest`: OK
- `task test-no-db filter=ListPrincipalGroupsActionTest`: OK
- `task phpstan`: No errors

## 🔍 レビューのポイント

- `GET /principal-groups` の query parameter を `accountIdentifier` としている点が、既存 Wiki PrincipalGroup Command API の account 指定方針と合っているか。
- Query 用 response を既存の薄い `PrincipalGroupSummary` と分離し、Command response へ影響しない形にしている点。
- `roleAttachments` と `memberships.principal.identity` から、管理画面に必要な `roleIdentifiers` / `members` を構築している点。
- DB Query テストで対象 account の group のみを作成順で返すこと、member / role が構築されることを確認している点。

## 📖 関連情報

### 関連Issue・タスク

Closes #545

## ⚠️ 注意事項

- DB マイグレーションはありません。
- project review skills `qa-review`, `test-review`, `security-review`, `architecture-review` は Hermes / Codex / repo-local で見つからなかったため、代替として同一セッション内で同期セルフレビューを実施しました。
  - QA: Issue の受け入れ条件に対して、GET route / response fields / account filter / TypeSpec & OpenAPI / DI binding / tests が揃っていることを確認しました。
  - Test: 追加テストと `task check` の通過を確認しました。
  - Security: `auth.api` 配下に route を追加し、Query 実装では `account_id` で必ず絞り込むため別 account の group が混入しないことを確認しました。
  - Architecture: Wiki Query 用 ReadModel / UseCase interface / Infrastructure Query を追加し、既存 Command 用 summary へ管理画面用項目を混ぜない構成にしていることを確認しました。
- 未対応のレビュー指摘はありません。

## 📸 スクリーンショット・デモ

API / backend の変更のため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
