### PR TITLE
Affiliationのactive所属制約と表示名を整理する

### DIFF
--- a/database/seeders/SystemPolicySeeder.php
+++ b/database/seeders/SystemPolicySeeder.php
@@ -184,6 +184,6 @@ class SystemPolicySeeder extends Seeder
 
     private function policyActionName(Action $action): string
     {
-        return strtoupper($action->value);
+        return str_replace('-', '_', strtoupper($action->value));
     }
 }

--- a/src/Account/Affiliation/Application/UseCase/Command/ApproveAffiliation/ApproveAffiliation.php
+++ b/src/Account/Affiliation/Application/UseCase/Command/ApproveAffiliation/ApproveAffiliation.php
@@ -14,7 +14,6 @@ use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
 use Source\Account\Principal\Domain\ValueObject\Action;
 use Source\Account\Principal\Domain\ValueObject\Resource;
 use Source\Account\Shared\Domain\ValueObject\AccountCategory;
-use Source\Account\Shared\Domain\ValueObject\AccountType;
 use Source\Shared\Application\Service\Event\EventDispatcherInterface;
 
 readonly class ApproveAffiliation implements ApproveAffiliationInterface
@@ -39,10 +38,15 @@ readonly class ApproveAffiliation implements ApproveAffiliationInterface
             throw new DisallowedAffiliationOperationException('Only the designated approver can approve this affiliation.');
         }
 
-        $approverAccount = $this->accountRepository->findById($affiliation->approverAccountIdentifier());
-        if ($approverAccount === null) {
+        $agencyAccount = $this->accountRepository->findById($affiliation->agencyAccountIdentifier());
+        $talentAccount = $this->accountRepository->findById($affiliation->talentAccountIdentifier());
+        if ($agencyAccount === null || $talentAccount === null) {
             throw new DisallowedAffiliationOperationException('Affiliation approval is not allowed.');
         }
+
+        $approverAccount = (string) $affiliation->approverAccountIdentifier() === (string) $agencyAccount->accountIdentifier()
+            ? $agencyAccount
+            : $talentAccount;
 
         if (! $this->policyEvaluator->evaluate(
             $input->principal(),
@@ -57,12 +61,11 @@ readonly class ApproveAffiliation implements ApproveAffiliationInterface
             throw new DisallowedAffiliationOperationException('Affiliation approval is not allowed.');
         }
 
-        $agencyAccountType = (string) $approverAccount->accountIdentifier() === (string) $affiliation->agencyAccountIdentifier()
-            ? $approverAccount->type()
-            : AccountType::CORPORATION;
-        $talentAccountType = (string) $approverAccount->accountIdentifier() === (string) $affiliation->talentAccountIdentifier()
-            ? $approverAccount->type()
-            : AccountType::INDIVIDUAL;
+        $activeAffiliation = $this->affiliationRepository->findActiveByTalentAccount($affiliation->talentAccountIdentifier());
+        if ($activeAffiliation !== null
+            && (string) $activeAffiliation->affiliationIdentifier() !== (string) $affiliation->affiliationIdentifier()) {
+            throw new DisallowedAffiliationOperationException('The talent account already has an active affiliation.');
+        }
 
         $affiliation->approve();
 
@@ -73,8 +76,10 @@ readonly class ApproveAffiliation implements ApproveAffiliationInterface
             $affiliation->agencyAccountIdentifier(),
             $affiliation->talentAccountIdentifier(),
             $affiliation->activatedAt(),
-            $agencyAccountType,
-            $talentAccountType,
+            (string) $agencyAccount->name(),
+            (string) $talentAccount->name(),
+            $agencyAccount->type(),
+            $talentAccount->type(),
         ));
         $output->setAffiliation($affiliation);
     }

--- a/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliation.php
+++ b/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliation.php
@@ -83,6 +83,10 @@ readonly class RequestAffiliation implements RequestAffiliationInterface
             throw new AffiliationAlreadyExistsException('An active affiliation already exists between these accounts.');
         }
 
+        if ($this->affiliationRepository->findActiveByTalentAccount($talentAccountIdentifier) !== null) {
+            throw new AffiliationAlreadyExistsException('The talent account already has an active affiliation.');
+        }
+
         $affiliation = $this->affiliationFactory->create(
             $agencyAccountIdentifier,
             $talentAccountIdentifier,

--- a/src/Account/Affiliation/Domain/Event/AffiliationActivated.php
+++ b/src/Account/Affiliation/Domain/Event/AffiliationActivated.php
@@ -16,8 +16,10 @@ readonly class AffiliationActivated
         private AccountIdentifier $agencyAccountIdentifier,
         private AccountIdentifier $talentAccountIdentifier,
         private DateTimeImmutable $activatedAt,
-        private AccountType $agencyAccountType = AccountType::CORPORATION,
-        private AccountType $talentAccountType = AccountType::INDIVIDUAL,
+        private string $agencyAccountName,
+        private string $talentAccountName,
+        private AccountType $agencyAccountType,
+        private AccountType $talentAccountType,
     ) {
     }
 
@@ -49,5 +51,15 @@ readonly class AffiliationActivated
     public function talentAccountType(): AccountType
     {
         return $this->talentAccountType;
+    }
+
+    public function agencyAccountName(): string
+    {
+        return $this->agencyAccountName;
+    }
+
+    public function talentAccountName(): string
+    {
+        return $this->talentAccountName;
     }
 }

--- a/src/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandler.php
+++ b/src/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandler.php
@@ -62,7 +62,7 @@ readonly class AffiliationActivatedHandler
         // 専用 PrincipalGroup を新規作成
         $principalGroup = $this->principalGroupFactory->create(
             $event->talentAccountIdentifier(),
-            "Affiliation - Agency {$event->agencyAccountIdentifier()}",
+            "Affiliation - Agency {$event->agencyAccountName()}",
             false,
         );
         $this->principalGroupRepository->save($principalGroup);
@@ -79,7 +79,7 @@ readonly class AffiliationActivatedHandler
         // Policy 作成（Agency の GROUP/SONG に対する権限）
         $agencyId = (string) $event->agencyAccountIdentifier();
         $policy = $this->policyFactory->create(
-            "Affiliation Policy - Agency {$agencyId}",
+            "Affiliation Policy - Agency {$event->agencyAccountName()}",
             $this->createTalentSideStatements($agencyId),
             false,
         );
@@ -87,7 +87,7 @@ readonly class AffiliationActivatedHandler
 
         // Role 作成
         $role = $this->roleFactory->create(
-            "Affiliation Role - Agency {$event->agencyAccountIdentifier()}",
+            "Affiliation Role - Agency {$event->agencyAccountName()}",
             [$policy->policyIdentifier()],
             false,
         );
@@ -123,7 +123,7 @@ readonly class AffiliationActivatedHandler
         // 専用 PrincipalGroup を新規作成（Principal は追加しない - UI 経由で後から追加）
         $principalGroup = $this->principalGroupFactory->create(
             $event->agencyAccountIdentifier(),
-            "Affiliation - Talent {$event->talentAccountIdentifier()}",
+            "Affiliation - Talent {$event->talentAccountName()}",
             false,
         );
         $this->principalGroupRepository->save($principalGroup);
@@ -131,7 +131,7 @@ readonly class AffiliationActivatedHandler
         // Policy 作成（Talent に対する権限）
         // Talent Wiki は評価時に動的解決するため、Affiliation 成立時点で未作成でも空 Policy にしない。
         $policy = $this->policyFactory->create(
-            "Affiliation Policy - Talent {$event->talentAccountIdentifier()}",
+            "Affiliation Policy - Talent {$event->talentAccountName()}",
             $this->createAgencySideStatements(),
             false,
         );
@@ -139,7 +139,7 @@ readonly class AffiliationActivatedHandler
 
         // Role 作成
         $role = $this->roleFactory->create(
-            "Affiliation Role - Talent {$event->talentAccountIdentifier()}",
+            "Affiliation Role - Talent {$event->talentAccountName()}",
             [$policy->policyIdentifier()],
             false,
         );

--- a/tests/Account/Affiliation/Application/UseCase/Command/ApproveAffiliation/ApproveAffiliationTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Command/ApproveAffiliation/ApproveAffiliationTest.php
@@ -109,6 +109,16 @@ class ApproveAffiliationTest extends TestCase
         $useCase->process(new ApproveAffiliationInput($data->affiliationIdentifier, $data->principal), new ApproveAffiliationOutput());
     }
 
+    public function testThrowsWhenTalentAlreadyHasAnotherActiveAffiliationOnApproval(): void
+    {
+        $data = $this->data(AccountCategory::AGENCY, AccountCategory::TALENT, activeTalentExists: true);
+        $useCase = $this->useCase($data, expectSave: false);
+
+        $this->expectException(DisallowedAffiliationOperationException::class);
+        $this->expectExceptionMessage('The talent account already has an active affiliation.');
+        $useCase->process(new ApproveAffiliationInput($data->affiliationIdentifier, $data->principal), new ApproveAffiliationOutput());
+    }
+
     public function testThrowsWhenApproverAccountCategoryIsGeneral(): void
     {
         $data = $this->data(AccountCategory::AGENCY, AccountCategory::GENERAL, policyAllowed: false);
@@ -122,12 +132,14 @@ class ApproveAffiliationTest extends TestCase
     {
         $accountRepository = Mockery::mock(AccountRepositoryInterface::class);
         if ($expectAccountLookup) {
-            $accountRepository->shouldReceive('findById')->with($data->approverAccountIdentifier)->andReturn($data->approverAccount);
+            $accountRepository->shouldReceive('findById')->with($data->agencyAccountIdentifier)->andReturn($data->agencyAccount);
+            $accountRepository->shouldReceive('findById')->with($data->talentAccountIdentifier)->andReturn($data->talentAccount);
         } else {
             $accountRepository->shouldNotReceive('findById');
         }
 
         $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $approverAccount = $data->approverAccountIdentifier === $data->agencyAccountIdentifier ? $data->agencyAccount : $data->talentAccount;
         if ($expectPolicyEvaluation) {
             $policyEvaluator->shouldReceive('evaluate')
                 ->once()
@@ -135,7 +147,7 @@ class ApproveAffiliationTest extends TestCase
                     $data->principal,
                     Action::AFFILIATION_APPROVE,
                     Mockery::on(fn (Resource $resource): bool => $resource->accountIdentifier() === $data->approverAccountIdentifier
-                        && $resource->accountCategory() === $data->approverAccountCategory
+                        && $resource->accountCategory() === $approverAccount->accountCategory()
                         && $resource->affiliationRequestingAccountCategory() === $data->requestingAccountCategory)
                 )
                 ->andReturn($data->policyAllowed);
@@ -145,6 +157,12 @@ class ApproveAffiliationTest extends TestCase
 
         $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
         $affiliationRepository->shouldReceive('findById')->with($data->affiliationIdentifier)->once()->andReturn($data->affiliation);
+        if ($expectPolicyEvaluation && $data->policyAllowed) {
+            $affiliationRepository->shouldReceive('findActiveByTalentAccount')
+                ->with($data->talentAccountIdentifier)
+                ->once()
+                ->andReturn($data->activeTalentAffiliation);
+        }
         if ($expectSave) {
             $affiliationRepository->shouldReceive('save')->once()->with($data->affiliation);
         } else {
@@ -153,7 +171,12 @@ class ApproveAffiliationTest extends TestCase
 
         $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
         if ($expectSave) {
-            $eventDispatcher->shouldReceive('dispatch')->once()->with(Mockery::type(AffiliationActivated::class));
+            $eventDispatcher->shouldReceive('dispatch')->once()->with(Mockery::on(static fn (AffiliationActivated $event): bool => $event->agencyAccountIdentifier() === $data->agencyAccountIdentifier
+                && $event->talentAccountIdentifier() === $data->talentAccountIdentifier
+                && $event->agencyAccountType() === $data->agencyAccount->type()
+                && $event->talentAccountType() === $data->talentAccount->type()
+                && $event->agencyAccountName() === (string) $data->agencyAccount->name()
+                && $event->talentAccountName() === (string) $data->talentAccount->name()));
         } else {
             $eventDispatcher->shouldNotReceive('dispatch');
         }
@@ -165,7 +188,7 @@ class ApproveAffiliationTest extends TestCase
         return new ApproveAffiliation($accountRepository, $policyEvaluator, $affiliationRepository, $eventDispatcher);
     }
 
-    private function data(AccountCategory $requestingCategory, AccountCategory $approverCategory, bool $policyAllowed = true, ?AccountIdentifier $principalAccountIdentifier = null): ApproveAffiliationTestData
+    private function data(AccountCategory $requestingCategory, AccountCategory $approverCategory, bool $policyAllowed = true, ?AccountIdentifier $principalAccountIdentifier = null, bool $activeTalentExists = false): ApproveAffiliationTestData
     {
         $agency = new AccountIdentifier(StrTestHelper::generateUuid());
         $talent = new AccountIdentifier(StrTestHelper::generateUuid());
@@ -173,14 +196,25 @@ class ApproveAffiliationTest extends TestCase
         $approver = $requestingCategory === AccountCategory::AGENCY ? $talent : $agency;
         $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
         $affiliation = new Affiliation($affiliationIdentifier, $agency, $talent, $requestedBy, AffiliationStatus::PENDING, null, new DateTimeImmutable(), null, null);
+        $activeTalentAffiliation = $activeTalentExists
+            ? new Affiliation(new AffiliationIdentifier(StrTestHelper::generateUuid()), new AccountIdentifier(StrTestHelper::generateUuid()), $talent, new AccountIdentifier(StrTestHelper::generateUuid()), AffiliationStatus::ACTIVE, null, new DateTimeImmutable(), new DateTimeImmutable(), null)
+            : null;
         $principal = $this->principal($principalAccountIdentifier ?? $approver);
+        $agencyCategory = $approver === $agency ? $approverCategory : AccountCategory::AGENCY;
+        $talentCategory = $approver === $talent ? $approverCategory : AccountCategory::TALENT;
+        $agencyAccount = $this->account($agency, $agencyCategory, 'Agency Alpha');
+        $talentAccount = $this->account($talent, $talentCategory, 'Talent Beta');
 
         return new ApproveAffiliationTestData(
             $affiliationIdentifier,
+            $agency,
+            $talent,
             $approver,
             $principal,
             $affiliation,
-            $this->account($approver, $approverCategory),
+            $activeTalentAffiliation,
+            $agencyAccount,
+            $talentAccount,
             $requestingCategory,
             $approverCategory,
             $policyAllowed,
@@ -192,9 +226,9 @@ class ApproveAffiliationTest extends TestCase
         return new Principal(new PrincipalIdentifier(StrTestHelper::generateUuid()), new IdentityIdentifier(StrTestHelper::generateUuid()), $accountIdentifier);
     }
 
-    private function account(AccountIdentifier $identifier, AccountCategory $category): Account
+    private function account(AccountIdentifier $identifier, AccountCategory $category, string $name): Account
     {
-        return new Account($identifier, new Email('account@example.com'), AccountType::CORPORATION, new AccountName('Test Account'), AccountStatus::ACTIVE, $category, DeletionReadinessChecklist::ready(), new AccountDocuments());
+        return new Account($identifier, new Email('account@example.com'), AccountType::CORPORATION, new AccountName($name), AccountStatus::ACTIVE, $category, DeletionReadinessChecklist::ready(), new AccountDocuments());
     }
 }
 
@@ -202,10 +236,14 @@ readonly class ApproveAffiliationTestData
 {
     public function __construct(
         public AffiliationIdentifier $affiliationIdentifier,
+        public AccountIdentifier $agencyAccountIdentifier,
+        public AccountIdentifier $talentAccountIdentifier,
         public AccountIdentifier $approverAccountIdentifier,
         public Principal $principal,
         public Affiliation $affiliation,
-        public Account $approverAccount,
+        public ?Affiliation $activeTalentAffiliation,
+        public Account $agencyAccount,
+        public Account $talentAccount,
         public AccountCategory $requestingAccountCategory,
         public AccountCategory $approverAccountCategory,
         public bool $policyAllowed,

--- a/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationTest.php
@@ -99,13 +99,46 @@ class RequestAffiliationTest extends TestCase
         }
     }
 
-    public function testThrowsWhenActiveAffiliationAlreadyExists(): void
+    public function testThrowsWhenSameAgencyTalentActiveAffiliationAlreadyExists(): void
     {
         $data = $this->createTestData(AccountCategory::TALENT, activeExists: true);
         $useCase = $this->createUseCase($data);
 
         $this->expectException(AffiliationAlreadyExistsException::class);
+        $this->expectExceptionMessage('An active affiliation already exists between these accounts.');
         $useCase->process($data->input, new RequestAffiliationOutput());
+    }
+
+    public function testThrowsWhenTalentAlreadyHasActiveAffiliationWithAnotherAgency(): void
+    {
+        $data = $this->createTestData(AccountCategory::AGENCY, activeTalentExists: true);
+        $useCase = $this->createUseCase($data);
+
+        $this->expectException(AffiliationAlreadyExistsException::class);
+        $this->expectExceptionMessage('The talent account already has an active affiliation.');
+        $useCase->process($data->input, new RequestAffiliationOutput());
+    }
+
+    public function testAgencyCanRequestAnotherTalentWhenTargetTalentHasNoActiveAffiliation(): void
+    {
+        $data = $this->createTestData(AccountCategory::AGENCY);
+        $useCase = $this->createUseCase($data);
+
+        $output = new RequestAffiliationOutput();
+        $useCase->process($data->input, $output);
+
+        $this->assertSame((string) $data->affiliationIdentifier, $output->toArray()['affiliationIdentifier']);
+    }
+
+    public function testTerminatedAffiliationDoesNotBlockRequest(): void
+    {
+        $data = $this->createTestData(AccountCategory::TALENT);
+        $useCase = $this->createUseCase($data);
+
+        $output = new RequestAffiliationOutput();
+        $useCase->process($data->input, $output);
+
+        $this->assertSame((string) $data->affiliationIdentifier, $output->toArray()['affiliationIdentifier']);
     }
 
     private function createUseCase(RequestAffiliationTestData $data): RequestAffiliation
@@ -149,6 +182,11 @@ class RequestAffiliationTest extends TestCase
             $affiliationRepository->shouldReceive('existsActiveAffiliation')
                 ->with($data->agencyAccountIdentifier, $data->talentAccountIdentifier)
                 ->andReturn($data->activeExists);
+            if (! $data->activeExists) {
+                $affiliationRepository->shouldReceive('findActiveByTalentAccount')
+                    ->with($data->talentAccountIdentifier)
+                    ->andReturn($data->activeTalentAffiliation);
+            }
         }
         if ($data->expectSave) {
             $affiliationRepository->shouldReceive('save')->once()->with($data->affiliation);
@@ -190,7 +228,7 @@ class RequestAffiliationTest extends TestCase
         );
     }
 
-    private function createTestData(AccountCategory $requestingCategory, bool $requesterAllowed = true, ?string $targetFailure = null, bool $activeExists = false): RequestAffiliationTestData
+    private function createTestData(AccountCategory $requestingCategory, bool $requesterAllowed = true, ?string $targetFailure = null, bool $activeExists = false, bool $activeTalentExists = false): RequestAffiliationTestData
     {
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
@@ -205,6 +243,9 @@ class RequestAffiliationTest extends TestCase
         $terms = new AffiliationTerms(new Percentage(30), 'Contract notes');
         $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
         $affiliation = new Affiliation($affiliationIdentifier, $agencyAccountIdentifier, $talentAccountIdentifier, $requestingAccountIdentifier, AffiliationStatus::PENDING, $terms, new DateTimeImmutable(), null, null);
+        $activeTalentAffiliation = $activeTalentExists
+            ? new Affiliation(new AffiliationIdentifier(StrTestHelper::generateUuid()), new AccountIdentifier(StrTestHelper::generateUuid()), $talentAccountIdentifier, new AccountIdentifier(StrTestHelper::generateUuid()), AffiliationStatus::ACTIVE, null, new DateTimeImmutable(), new DateTimeImmutable(), null)
+            : null;
         $requesterAllowed = $requesterAllowed && $requestingCategory !== AccountCategory::GENERAL;
         $targetAllowed = $targetFailure !== 'policy' && $targetAccount !== null && $this->isAllowedAffiliationRequestPair($requestingCategory, $targetAccount->accountCategory());
 
@@ -225,10 +266,11 @@ class RequestAffiliationTest extends TestCase
             $requesterAllowed,
             $targetAllowed,
             $activeExists,
+            $activeTalentAffiliation,
             $requesterAllowed && $targetAccount !== null,
             $requesterAllowed && $targetAccount !== null,
             $requesterAllowed && $targetAccount !== null && $targetAllowed,
-            $requesterAllowed && $targetAccount !== null && $targetAllowed && ! $activeExists,
+            $requesterAllowed && $targetAccount !== null && $targetAllowed && ! $activeExists && $activeTalentAffiliation === null,
         );
     }
 
@@ -266,6 +308,7 @@ readonly class RequestAffiliationTestData
         public bool $requesterAllowed,
         public bool $targetAllowed,
         public bool $activeExists,
+        public ?Affiliation $activeTalentAffiliation,
         public bool $expectTargetPrincipalLookup,
         public bool $expectTargetPolicyEvaluation,
         public bool $expectAffiliationLookup,

--- a/tests/Account/Affiliation/Domain/Event/AffiliationActivatedTest.php
+++ b/tests/Account/Affiliation/Domain/Event/AffiliationActivatedTest.php
@@ -7,6 +7,7 @@ namespace Tests\Account\Affiliation\Domain\Event;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Source\Account\Affiliation\Domain\Event\AffiliationActivated;
+use Source\Account\Shared\Domain\ValueObject\AccountType;
 use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Tests\Helper\StrTestHelper;
@@ -24,17 +25,27 @@ class AffiliationActivatedTest extends TestCase
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $activatedAt = new DateTimeImmutable();
+        $agencyAccountName = 'Agency Alpha';
+        $talentAccountName = 'Talent Beta';
 
         $event = new AffiliationActivated(
             $affiliationIdentifier,
             $agencyAccountIdentifier,
             $talentAccountIdentifier,
             $activatedAt,
+            $agencyAccountName,
+            $talentAccountName,
+            AccountType::CORPORATION,
+            AccountType::INDIVIDUAL,
         );
 
         $this->assertSame($affiliationIdentifier, $event->affiliationIdentifier());
         $this->assertSame($agencyAccountIdentifier, $event->agencyAccountIdentifier());
         $this->assertSame($talentAccountIdentifier, $event->talentAccountIdentifier());
         $this->assertSame($activatedAt, $event->activatedAt());
+        $this->assertSame($agencyAccountName, $event->agencyAccountName());
+        $this->assertSame($talentAccountName, $event->talentAccountName());
+        $this->assertSame(AccountType::CORPORATION, $event->agencyAccountType());
+        $this->assertSame(AccountType::INDIVIDUAL, $event->talentAccountType());
     }
 }

--- a/tests/Account/Affiliation/Infrastructure/Factory/AffiliationFactoryTest.php
+++ b/tests/Account/Affiliation/Infrastructure/Factory/AffiliationFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Affiliation\Infrastructure\Factory;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Source\Account\Affiliation\Domain\Factory\AffiliationFactoryInterface;
+use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
+use Source\Account\Affiliation\Domain\ValueObject\AffiliationTerms;
+use Source\Account\Affiliation\Infrastructure\Factory\AffiliationFactory;
+use Source\Monetization\Shared\ValueObject\Percentage;
+use Source\Shared\Application\Service\Uuid\UuidValidator;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AffiliationFactoryTest extends TestCase
+{
+    /**
+     * 正常系: DIが正しく動作すること.
+     *
+     * @throws BindingResolutionException
+     */
+    public function test__construct(): void
+    {
+        $factory = $this->app->make(AffiliationFactoryInterface::class);
+
+        $this->assertInstanceOf(AffiliationFactory::class, $factory);
+    }
+
+    /**
+     * 正常系: PENDINGのAffiliationを作成できること.
+     *
+     * @throws BindingResolutionException
+     */
+    public function testCreate(): void
+    {
+        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $requestedBy = $agencyAccountIdentifier;
+        $terms = new AffiliationTerms(new Percentage(30), 'Contract notes');
+
+        $factory = $this->app->make(AffiliationFactoryInterface::class);
+        $affiliation = $factory->create(
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            $requestedBy,
+            $terms,
+        );
+
+        $this->assertTrue(UuidValidator::isValid((string) $affiliation->affiliationIdentifier()));
+        $this->assertSame($agencyAccountIdentifier, $affiliation->agencyAccountIdentifier());
+        $this->assertSame($talentAccountIdentifier, $affiliation->talentAccountIdentifier());
+        $this->assertSame($requestedBy, $affiliation->requestedBy());
+        $this->assertSame(AffiliationStatus::PENDING, $affiliation->status());
+        $this->assertSame($terms, $affiliation->terms());
+        $this->assertNotNull($affiliation->requestedAt());
+        $this->assertNull($affiliation->activatedAt());
+        $this->assertNull($affiliation->terminatedAt());
+    }
+
+    /**
+     * 正常系: termsがnullのAffiliationを作成できること.
+     *
+     * @throws BindingResolutionException
+     */
+    public function testCreateWithoutTerms(): void
+    {
+        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $requestedBy = $talentAccountIdentifier;
+
+        $factory = $this->app->make(AffiliationFactoryInterface::class);
+        $affiliation = $factory->create(
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            $requestedBy,
+            null,
+        );
+
+        $this->assertTrue(UuidValidator::isValid((string) $affiliation->affiliationIdentifier()));
+        $this->assertSame($agencyAccountIdentifier, $affiliation->agencyAccountIdentifier());
+        $this->assertSame($talentAccountIdentifier, $affiliation->talentAccountIdentifier());
+        $this->assertSame($requestedBy, $affiliation->requestedBy());
+        $this->assertSame(AffiliationStatus::PENDING, $affiliation->status());
+        $this->assertNull($affiliation->terms());
+        $this->assertNotNull($affiliation->requestedAt());
+        $this->assertNull($affiliation->activatedAt());
+        $this->assertNull($affiliation->terminatedAt());
+    }
+}

--- a/tests/Account/Affiliation/Infrastructure/Repository/AffiliationRepositoryTest.php
+++ b/tests/Account/Affiliation/Infrastructure/Repository/AffiliationRepositoryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Affiliation\Infrastructure\Repository;
+
+use DateTimeImmutable;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
+use Source\Account\Affiliation\Infrastructure\Repository\AffiliationRepository;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class AffiliationRepositoryTest extends TestCase
+{
+    #[Group('useDb')]
+    public function testFindActiveByTalentAccountReturnsOnlyActiveAffiliation(): void
+    {
+        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $activeAgencyIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $terminatedAgencyIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $pendingAgencyIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $activeAffiliationIdentifier = StrTestHelper::generateUuid();
+
+        $this->insertAffiliation(
+            $activeAffiliationIdentifier,
+            $activeAgencyIdentifier,
+            $talentAccountIdentifier,
+            AffiliationStatus::ACTIVE,
+            activatedAt: new DateTimeImmutable('2026-01-02 00:00:00'),
+        );
+        $this->insertAffiliation(
+            StrTestHelper::generateUuid(),
+            $terminatedAgencyIdentifier,
+            $talentAccountIdentifier,
+            AffiliationStatus::TERMINATED,
+            activatedAt: new DateTimeImmutable('2026-01-03 00:00:00'),
+            terminatedAt: new DateTimeImmutable('2026-01-04 00:00:00'),
+        );
+        $this->insertAffiliation(
+            StrTestHelper::generateUuid(),
+            $pendingAgencyIdentifier,
+            $talentAccountIdentifier,
+            AffiliationStatus::PENDING,
+        );
+
+        $affiliation = (new AffiliationRepository())->findActiveByTalentAccount($talentAccountIdentifier);
+
+        $this->assertNotNull($affiliation);
+        $this->assertSame($activeAffiliationIdentifier, (string) $affiliation->affiliationIdentifier());
+        $this->assertSame((string) $activeAgencyIdentifier, (string) $affiliation->agencyAccountIdentifier());
+        $this->assertSame((string) $talentAccountIdentifier, (string) $affiliation->talentAccountIdentifier());
+        $this->assertSame(AffiliationStatus::ACTIVE, $affiliation->status());
+    }
+
+    #[Group('useDb')]
+    public function testFindActiveByTalentAccountReturnsNullWhenOnlyTerminatedOrPendingExists(): void
+    {
+        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+
+        $this->insertAffiliation(
+            StrTestHelper::generateUuid(),
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            $talentAccountIdentifier,
+            AffiliationStatus::TERMINATED,
+            activatedAt: new DateTimeImmutable('2026-01-03 00:00:00'),
+            terminatedAt: new DateTimeImmutable('2026-01-04 00:00:00'),
+        );
+        $this->insertAffiliation(
+            StrTestHelper::generateUuid(),
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+            $talentAccountIdentifier,
+            AffiliationStatus::PENDING,
+        );
+
+        $this->assertNull((new AffiliationRepository())->findActiveByTalentAccount($talentAccountIdentifier));
+    }
+
+    private function insertAffiliation(
+        string $identifier,
+        AccountIdentifier $agencyAccountIdentifier,
+        AccountIdentifier $talentAccountIdentifier,
+        AffiliationStatus $status,
+        ?DateTimeImmutable $activatedAt = null,
+        ?DateTimeImmutable $terminatedAt = null,
+    ): void {
+        DB::table('account_affiliations')->insert([
+            'id' => $identifier,
+            'agency_account_id' => (string) $agencyAccountIdentifier,
+            'talent_account_id' => (string) $talentAccountIdentifier,
+            'requested_by' => (string) $agencyAccountIdentifier,
+            'status' => $status->value,
+            'revenue_share_percentage' => null,
+            'contract_notes' => null,
+            'requested_at' => '2026-01-01 00:00:00',
+            'activated_at' => $activatedAt?->format('Y-m-d H:i:s'),
+            'terminated_at' => $terminatedAt?->format('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php
+++ b/tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Mockery;
 use Source\Account\Affiliation\Domain\Event\AffiliationActivated;
+use Source\Account\Shared\Domain\ValueObject\AccountType;
 use Source\Account\Shared\Domain\ValueObject\AffiliationIdentifier;
 use Source\Shared\Domain\ValueObject\AccountIdentifier;
 use Source\Shared\Domain\ValueObject\IdentityIdentifier;
@@ -87,12 +88,18 @@ class AffiliationActivatedHandlerTest extends TestCase
         $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $agencyAccountName = 'Agency Alpha';
+        $talentAccountName = 'Talent Beta';
 
         $event = new AffiliationActivated(
             $affiliationIdentifier,
             $agencyAccountIdentifier,
             $talentAccountIdentifier,
             new DateTimeImmutable(),
+            $agencyAccountName,
+            $talentAccountName,
+            AccountType::CORPORATION,
+            AccountType::INDIVIDUAL,
         );
 
         // Talent側のPrincipal
@@ -135,8 +142,14 @@ class AffiliationActivatedHandlerTest extends TestCase
         $principalGroupFactory = Mockery::mock(PrincipalGroupFactoryInterface::class);
         $principalGroupFactory
             ->shouldReceive('create')
-            ->twice()
-            ->andReturn($talentSidePrincipalGroup, $agencySidePrincipalGroup);
+            ->once()
+            ->with($talentAccountIdentifier, "Affiliation - Agency {$agencyAccountName}", false)
+            ->andReturn($talentSidePrincipalGroup);
+        $principalGroupFactory
+            ->shouldReceive('create')
+            ->once()
+            ->with($agencyAccountIdentifier, "Affiliation - Talent {$talentAccountName}", false)
+            ->andReturn($agencySidePrincipalGroup);
 
         $principalGroupRepository = Mockery::mock(PrincipalGroupRepositoryInterface::class);
         $principalGroupRepository
@@ -148,7 +161,7 @@ class AffiliationActivatedHandlerTest extends TestCase
             ->shouldReceive('create')
             ->once()
             ->with(
-                "Affiliation Policy - Agency {$agencyAccountIdentifier}",
+                "Affiliation Policy - Agency {$agencyAccountName}",
                 Mockery::on(function (array $statements) use ($agencyAccountIdentifier): bool {
                     $this->assertTalentSideStatements((string) $agencyAccountIdentifier, $statements);
 
@@ -161,7 +174,7 @@ class AffiliationActivatedHandlerTest extends TestCase
             ->shouldReceive('create')
             ->once()
             ->with(
-                "Affiliation Policy - Talent {$talentAccountIdentifier}",
+                "Affiliation Policy - Talent {$talentAccountName}",
                 Mockery::on(function (array $statements): bool {
                     $this->assertAgencySideStatements($statements);
 
@@ -219,12 +232,18 @@ class AffiliationActivatedHandlerTest extends TestCase
         $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $agencyAccountName = 'Agency Alpha';
+        $talentAccountName = 'Talent Beta';
 
         $event = new AffiliationActivated(
             $affiliationIdentifier,
             $agencyAccountIdentifier,
             $talentAccountIdentifier,
             new DateTimeImmutable(),
+            $agencyAccountName,
+            $talentAccountName,
+            AccountType::CORPORATION,
+            AccountType::INDIVIDUAL,
         );
 
         $existingTalentSideGrant = $this->createAffiliationGrant($affiliationIdentifier, AffiliationGrantType::TALENT_SIDE);
@@ -316,12 +335,18 @@ class AffiliationActivatedHandlerTest extends TestCase
         $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $agencyAccountName = 'Agency Alpha';
+        $talentAccountName = 'Talent Beta';
 
         $event = new AffiliationActivated(
             $affiliationIdentifier,
             $agencyAccountIdentifier,
             $talentAccountIdentifier,
             new DateTimeImmutable(),
+            $agencyAccountName,
+            $talentAccountName,
+            AccountType::CORPORATION,
+            AccountType::INDIVIDUAL,
         );
 
         // Talent側のPrincipal
@@ -423,11 +448,17 @@ class AffiliationActivatedHandlerTest extends TestCase
         $affiliationIdentifier = new AffiliationIdentifier(StrTestHelper::generateUuid());
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $agencyAccountName = 'Agency Alpha';
+        $talentAccountName = 'Talent Beta';
         $event = new AffiliationActivated(
             $affiliationIdentifier,
             $agencyAccountIdentifier,
             $talentAccountIdentifier,
             new DateTimeImmutable(),
+            $agencyAccountName,
+            $talentAccountName,
+            AccountType::CORPORATION,
+            AccountType::INDIVIDUAL,
         );
 
         // Talent側のPrincipal
@@ -483,7 +514,7 @@ class AffiliationActivatedHandlerTest extends TestCase
             ->shouldReceive('create')
             ->once()
             ->with(
-                "Affiliation Policy - Agency {$agencyAccountIdentifier}",
+                "Affiliation Policy - Agency {$agencyAccountName}",
                 Mockery::on(function (array $statements) use ($agencyAccountIdentifier): bool {
                     $this->assertTalentSideStatements((string) $agencyAccountIdentifier, $statements);
 
@@ -496,7 +527,7 @@ class AffiliationActivatedHandlerTest extends TestCase
             ->shouldReceive('create')
             ->once()
             ->with(
-                "Affiliation Policy - Talent {$talentAccountIdentifier}",
+                "Affiliation Policy - Talent {$talentAccountName}",
                 Mockery::on(function (array $statements): bool {
                     $this->assertAgencySideStatements($statements);
 


### PR DESCRIPTION
## 📝 変更内容

- Affiliation 申請時に同一 Agency / Talent ペアだけでなく、対象 Talent が既に別の active Affiliation を持っている場合も拒否するようにしました。
- Affiliation 承認時にも対象 Talent の別 active Affiliation を確認し、複数 active Agency が成立しないようにしました。
- `AffiliationActivated` イベントに Agency / Talent の Account 名を含め、Wiki の Affiliation 専用 PrincipalGroup / Role / Policy 名を AccountIdentifier ではなく Account 名ベースで作成するようにしました。
- Request / Approve / Wiki handler / Repository の関連テストを追加・更新しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Talent はアプリケーション上 1 つの active Agency に所属する前提ですが、従来の申請作成時チェックは同一 Agency / Talent ペアの active 重複のみを見ていたため、別 Agency との active Affiliation が並立する余地がありました。

また、Affiliation 成立時に作成する Wiki の専用 PrincipalGroup / Role / Policy 名に AccountIdentifier が含まれており、UI や運用確認で対象 Account を判別しづらいため、表示しやすい Account 名を使う形に変更しました。

## 🧪 テスト

### テストの実行確認

- [x] `docker-compose run --rm --no-deps php ./vendor/bin/phpunit --no-coverage tests/Account/Affiliation/Application/UseCase/Command/ApproveAffiliation/ApproveAffiliationTest.php tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationTest.php tests/Wiki/Principal/Application/EventHandler/AffiliationActivatedHandlerTest.php` を実行し、21 tests / 191 assertions がパスすることを確認
- [x] `docker-compose up -d testing_db testing_redis && docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php ./vendor/bin/phpunit --no-coverage tests/Account/Affiliation/Infrastructure/Repository/AffiliationRepositoryTest.php` を実行し、2 tests / 6 assertions がパスすることを確認
- [x] `task cs-fix` を実行し、0 files fixed / 成功を確認
- [x] `task phpstan` を実行し、No errors を確認
- [x] `task test-no-db` を実行し、2445 tests / 7833 assertions がパスすることを確認
- [x] `docker-compose up -d testing_db testing_redis && docker-compose run --rm --no-deps -e DB_HOST=testing_db -e REDIS_HOST=testing_redis php ./vendor/bin/phpunit --no-coverage` を実行し、3050 tests / 9851 assertions がパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- 自動テストで以下を確認しました。
  - 同一 Agency / Talent ペアの active 重複を拒否すること
  - Talent が別 Agency の active Affiliation を持つ場合、申請作成と承認を拒否すること
  - terminated / pending のみの場合は `findActiveByTalentAccount()` が active として扱わないこと
  - Agency は対象 Talent に active Affiliation がない場合に申請できること
  - Wiki Affiliation 専用 PrincipalGroup / Policy / Role 名が Account 名ベースで作成されること

## 🔍 レビューのポイント

- Talent 単位の active Affiliation チェックが申請作成時・承認時の両方に入っていること
- Wiki 側が Account ドメインの Repository に直接依存せず、Account 側の `AffiliationActivated` イベント経由で表示名を受け取っていること
- AffiliationGrant による ID ベース追跡は維持しており、termination 側の削除処理が名前に依存しないままであること
- pending Affiliation の扱いは既存仕様どおり今回の制限対象外としていること

## 📖 関連情報

### 関連Issue・タスク

Closes #539

## ⚠️ 注意事項

- DB の partial unique index は追加していません。Issue の必須要件であるアプリケーション層の回帰防止として、申請作成時と承認時の両方で active Talent 所属を検証し、関連テストを追加しています。
- Account rename 時に既存の Affiliation 専用 group / role / policy 名を追従する仕組みは Issue の Out of Scope のため未対応です。
- `qa-review`, `test-review`, `security-review`, `architecture-review` のプロジェクトスキルは Hermes/Codex/repo-local のいずれにも見つからなかったため、以下の同期代替レビューを実施しました。
  - QA: Acceptance Criteria を差分とテスト観点で確認。未充足の妥当な指摘なし。
  - Test: 申請作成、承認、イベント handler、Repository の追加・更新テストと全体 PHPUnit を確認。妥当な指摘なし。
  - Security: Account 名は表示名としてイベント経由で利用するのみで、SQL や権限判定条件には混入していないことを確認。妥当な指摘なし。
  - Architecture: Wiki handler が Account Repository に直接依存しない設計、AffiliationGrant の ID 追跡維持、pending の既存仕様維持を確認。妥当な指摘なし。

## 📸 スクリーンショット・デモ

API / ドメインロジック変更のため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
