### PR TITLE
Affiliation一覧取得APIを追加

### DIFF
--- a/application/Http/Action/Account/Affiliation/Query/ListAffiliations/ListAffiliationsAction.php
+++ b/application/Http/Action/Account/Affiliation/Query/ListAffiliations/ListAffiliationsAction.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Affiliation\Query\ListAffiliations;
+
+use Application\Http\Context\AccountContext;
+use Application\Http\Exceptions\ForbiddenHttpException;
+use Application\Http\Exceptions\InternalServerErrorHttpException;
+use Application\Http\Exceptions\UnprocessableEntityHttpException;
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Source\Account\Affiliation\Application\Exception\DisallowedAffiliationOperationException;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInput;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInterface;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsOutput;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+readonly class ListAffiliationsAction
+{
+    public function __construct(
+        private ListAffiliationsInterface $listAffiliations,
+        private AccountContext $accountContext,
+        // @phpstan-ignore property.onlyWritten
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(ListAffiliationsRequest $request): JsonResponse
+    {
+        try {
+            $language = $request->language();
+
+            try {
+                $input = new ListAffiliationsInput(
+                    principal: $this->accountContext->principal(),
+                    status: $request->status(),
+                    viewerRole: $request->viewerRole(),
+                    perPage: $request->perPage(),
+                    page: $request->page(),
+                );
+            } catch (InvalidArgumentException $e) {
+                throw new UnprocessableEntityHttpException(detail: $e->getMessage(), previous: $e);
+            }
+
+            try {
+                $output = new ListAffiliationsOutput();
+                $this->listAffiliations->process($input, $output);
+            } catch (DisallowedAffiliationOperationException $e) {
+                throw new ForbiddenHttpException(detail: error_message('disallowed', $language), previous: $e);
+            }
+        } catch (ForbiddenHttpException|UnprocessableEntityHttpException $e) {
+            $this->logger->error((string) $e);
+
+            return response()->json($e->toProblemDetails(), $e->getHttpStatus());
+        } catch (Throwable $e) {
+            $this->logger->error((string) $e);
+
+            throw new InternalServerErrorHttpException(detail: $e->getMessage(), previous: $e);
+        }
+
+        return response()->json($output->toArray(), Response::HTTP_OK);
+    }
+}

--- a/application/Http/Action/Account/Affiliation/Query/ListAffiliations/ListAffiliationsRequest.php
+++ b/application/Http/Action/Account/Affiliation/Query/ListAffiliations/ListAffiliationsRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Http\Action\Account\Affiliation\Query\ListAffiliations;
+
+use Application\Http\Action\Concerns\ResolvesLanguage;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListAffiliationsRequest extends FormRequest
+{
+    use ResolvesLanguage;
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'status' => ['nullable', 'string'],
+            'viewerRole' => ['nullable', 'string'],
+            'perPage' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ];
+    }
+
+    public function status(): ?string
+    {
+        return $this->query('status') !== null ? (string) $this->query('status') : null;
+    }
+
+    public function viewerRole(): ?string
+    {
+        return $this->query('viewerRole') !== null ? (string) $this->query('viewerRole') : null;
+    }
+
+    public function perPage(): ?int
+    {
+        return $this->query('perPage') !== null ? (int) $this->query('perPage') : null;
+    }
+
+    public function page(): int
+    {
+        return $this->query('page') !== null ? (int) $this->query('page') : 1;
+    }
+}

--- a/application/Models/Account/Affiliation.php
+++ b/application/Models/Account/Affiliation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Models\Account;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property string $id
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Illuminate\Support\Carbon $requested_at
  * @property ?\Illuminate\Support\Carbon $activated_at
  * @property ?\Illuminate\Support\Carbon $terminated_at
+ * @property-read Account|null $agencyAccount
+ * @property-read Account|null $talentAccount
  */
 #[\Illuminate\Database\Eloquent\Attributes\Fillable([
     'id',
@@ -45,5 +48,15 @@ class Affiliation extends Model
             'activated_at' => 'datetime',
             'terminated_at' => 'datetime',
         ];
+    }
+
+    public function agencyAccount(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'agency_account_id', 'id');
+    }
+
+    public function talentAccount(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'talent_account_id', 'id');
     }
 }

--- a/application/Providers/Account/UseCaseServiceProvider.php
+++ b/application/Providers/Account/UseCaseServiceProvider.php
@@ -37,6 +37,8 @@ use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\Re
 use Source\Account\Affiliation\Application\UseCase\Command\RequestAffiliation\RequestAffiliationInterface;
 use Source\Account\Affiliation\Application\UseCase\Command\TerminateAffiliation\TerminateAffiliation;
 use Source\Account\Affiliation\Application\UseCase\Command\TerminateAffiliation\TerminateAffiliationInterface;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInterface;
+use Source\Account\Affiliation\Infrastructure\Query\ListAffiliations;
 use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegation;
 use Source\Account\Delegation\Application\UseCase\Command\ApproveDelegation\ApproveDelegationInterface;
 use Source\Account\Delegation\Application\UseCase\Command\RequestDelegation\RequestDelegation;
@@ -89,6 +91,7 @@ class UseCaseServiceProvider extends ServiceProvider
         $this->app->singleton(RequestDelegationInterface::class, RequestDelegation::class);
         $this->app->singleton(ApproveDelegationInterface::class, ApproveDelegation::class);
         $this->app->singleton(ApproveAffiliationInterface::class, ApproveAffiliation::class);
+        $this->app->singleton(ListAffiliationsInterface::class, ListAffiliations::class);
         $this->app->singleton(TerminateAffiliationInterface::class, TerminateAffiliation::class);
         $this->app->singleton(RequestAffiliationInterface::class, RequestAffiliation::class);
         $this->app->singleton(RejectAffiliationInterface::class, RejectAffiliation::class);

--- a/doc/openapi/KPool.AccountApi.openapi.yaml
+++ b/doc/openapi/KPool.AccountApi.openapi.yaml
@@ -567,6 +567,71 @@ paths:
               schema:
                 $ref: '#/components/schemas/KPool.Common.ProblemDetails'
   /affiliations:
+    get:
+      operationId: AffiliationOperations_listAffiliations
+      description: List affiliations related to the authenticated account.
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            nullable: true
+          explode: false
+        - name: viewerRole
+          in: query
+          required: false
+          schema:
+            type: string
+            nullable: true
+          explode: false
+        - name: perPage
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            nullable: true
+          explode: false
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            nullable: true
+          explode: false
+      responses:
+        '200':
+          description: Response returned when listing affiliations succeeds.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAffiliationsResponseBody'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '422':
+          description: Client error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KPool.Common.ProblemDetails'
     post:
       operationId: AffiliationOperations_requestAffiliation
       description: Request an affiliation.
@@ -1584,12 +1649,32 @@ components:
             - $ref: '#/components/schemas/ContactAddressSummary'
           nullable: true
           description: Contact address.
+    AffiliationAccountSummary:
+      type: object
+      required:
+        - accountIdentifier
+        - name
+        - email
+      properties:
+        accountIdentifier:
+          allOf:
+            - $ref: '#/components/schemas/KPool.Common.Uuid'
+          description: Account identifier.
+        name:
+          type: string
+          description: Account display name.
+        email:
+          type: string
+          description: Account email address.
+      description: Account summary attached to an affiliation.
     AffiliationSummary:
       type: object
       required:
         - affiliationIdentifier
         - agencyAccountIdentifier
         - talentAccountIdentifier
+        - agencyAccount
+        - talentAccount
         - requestedBy
         - status
         - requestedAt
@@ -1606,6 +1691,14 @@ components:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
           description: Talent account identifier.
+        agencyAccount:
+          allOf:
+            - $ref: '#/components/schemas/AffiliationAccountSummary'
+          description: Agency account.
+        talentAccount:
+          allOf:
+            - $ref: '#/components/schemas/AffiliationAccountSummary'
+          description: Talent account.
         requestedBy:
           allOf:
             - $ref: '#/components/schemas/KPool.Common.Uuid'
@@ -2008,6 +2101,37 @@ components:
             $ref: '#/components/schemas/AccountDocumentSummary'
           description: Saved documents.
       description: Response body for account document list.
+    ListAffiliationsResponseBody:
+      type: object
+      required:
+        - affiliations
+        - current_page
+        - last_page
+        - total
+        - per_page
+      properties:
+        affiliations:
+          type: array
+          items:
+            $ref: '#/components/schemas/AffiliationSummary'
+          description: Affiliations related to the authenticated account.
+        current_page:
+          type: integer
+          format: int32
+          description: Current page number.
+        last_page:
+          type: integer
+          format: int32
+          description: Last page number.
+        total:
+          type: integer
+          format: int32
+          description: Total number of affiliations matching the filters.
+        per_page:
+          type: integer
+          format: int32
+          description: Number of items per page.
+      description: Response body for affiliation list.
     ListMembersResponseBody:
       type: object
       required:

--- a/routes/account_api.php
+++ b/routes/account_api.php
@@ -20,6 +20,7 @@ use Application\Http\Action\Account\Affiliation\Command\ApproveAffiliation\Appro
 use Application\Http\Action\Account\Affiliation\Command\RejectAffiliation\RejectAffiliationAction;
 use Application\Http\Action\Account\Affiliation\Command\RequestAffiliation\RequestAffiliationAction;
 use Application\Http\Action\Account\Affiliation\Command\TerminateAffiliation\TerminateAffiliationAction;
+use Application\Http\Action\Account\Affiliation\Query\ListAffiliations\ListAffiliationsAction;
 use Application\Http\Action\Account\Delegation\Command\ApproveDelegation\ApproveDelegationAction;
 use Application\Http\Action\Account\Delegation\Command\RequestDelegation\RequestDelegationAction;
 use Application\Http\Action\Account\Delegation\Command\RevokeDelegation\RevokeDelegationAction;
@@ -79,6 +80,7 @@ Route::middleware(['auth.api', 'resolve.actor', 'resolve.account'])->group(funct
     Route::post('/account-category-change-requests/{requestId}/reject', RejectAccountCategoryChangeRequestAction::class);
 
     // Affiliation
+    Route::get('/affiliations', ListAffiliationsAction::class);
     Route::post('/affiliations', RequestAffiliationAction::class);
     Route::post('/affiliations/{affiliationId}/approve', ApproveAffiliationAction::class);
     Route::post('/affiliations/{affiliationId}/reject', RejectAffiliationAction::class);

--- a/src/Account/Affiliation/Application/UseCase/Query/AffiliationReadModel.php
+++ b/src/Account/Affiliation/Application/UseCase/Query/AffiliationReadModel.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Application\UseCase\Query;
+
+readonly class AffiliationReadModel
+{
+    /**
+     * @param array{accountIdentifier: string, name: string, email: string} $agencyAccount
+     * @param array{accountIdentifier: string, name: string, email: string} $talentAccount
+     * @param array{revenueSharePercentage: int|null, contractNotes: string|null}|null $terms
+     */
+    public function __construct(
+        private string $affiliationIdentifier,
+        private string $agencyAccountIdentifier,
+        private string $talentAccountIdentifier,
+        private array $agencyAccount,
+        private array $talentAccount,
+        private string $requestedBy,
+        private string $status,
+        private ?array $terms,
+        private string $requestedAt,
+        private ?string $activatedAt,
+        private ?string $terminatedAt,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     affiliationIdentifier: string,
+     *     agencyAccountIdentifier: string,
+     *     talentAccountIdentifier: string,
+     *     agencyAccount: array{accountIdentifier: string, name: string, email: string},
+     *     talentAccount: array{accountIdentifier: string, name: string, email: string},
+     *     requestedBy: string,
+     *     status: string,
+     *     terms: array{revenueSharePercentage: int|null, contractNotes: string|null}|null,
+     *     requestedAt: string,
+     *     activatedAt: string|null,
+     *     terminatedAt: string|null
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'affiliationIdentifier' => $this->affiliationIdentifier,
+            'agencyAccountIdentifier' => $this->agencyAccountIdentifier,
+            'talentAccountIdentifier' => $this->talentAccountIdentifier,
+            'agencyAccount' => $this->agencyAccount,
+            'talentAccount' => $this->talentAccount,
+            'requestedBy' => $this->requestedBy,
+            'status' => $this->status,
+            'terms' => $this->terms,
+            'requestedAt' => $this->requestedAt,
+            'activatedAt' => $this->activatedAt,
+            'terminatedAt' => $this->terminatedAt,
+        ];
+    }
+}

--- a/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInput.php
+++ b/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInput.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations;
+
+use InvalidArgumentException;
+use Source\Account\Affiliation\Domain\ValueObject\AffiliationStatus;
+use Source\Account\Principal\Domain\Entity\Principal;
+
+readonly class ListAffiliationsInput implements ListAffiliationsInputPort
+{
+    private const DEFAULT_PER_PAGE = 50;
+    private const MAX_PER_PAGE = 100;
+    public const VIEWER_ROLE_REQUESTER = 'requester';
+    public const VIEWER_ROLE_APPROVER = 'approver';
+
+    private int $perPage;
+
+    public function __construct(
+        private Principal $principal,
+        private ?string $status = null,
+        private ?string $viewerRole = null,
+        ?int $perPage = null,
+        private int $page = 1,
+    ) {
+        if ($this->status !== null && AffiliationStatus::tryFrom($this->status) === null) {
+            throw new InvalidArgumentException('Invalid affiliation status.');
+        }
+
+        if ($this->viewerRole !== null && ! in_array($this->viewerRole, [self::VIEWER_ROLE_REQUESTER, self::VIEWER_ROLE_APPROVER], true)) {
+            throw new InvalidArgumentException('Invalid affiliation viewer role.');
+        }
+
+        if ($perPage !== null && ($perPage < 1 || $perPage > self::MAX_PER_PAGE)) {
+            throw new InvalidArgumentException('Per page must be between 1 and 100.');
+        }
+
+        if ($this->page < 1) {
+            throw new InvalidArgumentException('Page must be greater than or equal to 1.');
+        }
+
+        $this->perPage = $perPage ?? self::DEFAULT_PER_PAGE;
+    }
+
+    public function principal(): Principal
+    {
+        return $this->principal;
+    }
+
+    public function status(): ?string
+    {
+        return $this->status;
+    }
+
+    public function viewerRole(): ?string
+    {
+        return $this->viewerRole;
+    }
+
+    public function perPage(): int
+    {
+        return $this->perPage;
+    }
+
+    public function page(): int
+    {
+        return $this->page;
+    }
+}

--- a/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInputPort.php
+++ b/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInputPort.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations;
+
+use Source\Account\Principal\Domain\Entity\Principal;
+
+interface ListAffiliationsInputPort
+{
+    public function principal(): Principal;
+
+    public function status(): ?string;
+
+    public function viewerRole(): ?string;
+
+    public function perPage(): int;
+
+    public function page(): int;
+}

--- a/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInterface.php
+++ b/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations;
+
+interface ListAffiliationsInterface
+{
+    public function process(ListAffiliationsInputPort $input, ListAffiliationsOutputPort $output): void;
+}

--- a/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsOutput.php
+++ b/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsOutput.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations;
+
+use Source\Account\Affiliation\Application\UseCase\Query\AffiliationReadModel;
+
+class ListAffiliationsOutput implements ListAffiliationsOutputPort
+{
+    /** @var AffiliationReadModel[] */
+    private array $affiliations = [];
+
+    private ?int $currentPage = null;
+
+    private ?int $lastPage = null;
+
+    private ?int $total = null;
+
+    private ?int $perPage = null;
+
+    /** @param AffiliationReadModel[] $affiliations */
+    public function output(array $affiliations, int $currentPage, int $lastPage, int $total, int $perPage): void
+    {
+        $this->affiliations = $affiliations;
+        $this->currentPage = $currentPage;
+        $this->lastPage = $lastPage;
+        $this->total = $total;
+        $this->perPage = $perPage;
+    }
+
+    /** @return array{affiliations: array<int, array<string, mixed>>, current_page: int|null, last_page: int|null, total: int|null, per_page: int|null} */
+    public function toArray(): array
+    {
+        return [
+            'affiliations' => array_map(
+                static fn (AffiliationReadModel $affiliation): array => $affiliation->toArray(),
+                $this->affiliations,
+            ),
+            'current_page' => $this->currentPage,
+            'last_page' => $this->lastPage,
+            'total' => $this->total,
+            'per_page' => $this->perPage,
+        ];
+    }
+}

--- a/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsOutputPort.php
+++ b/src/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsOutputPort.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations;
+
+use Source\Account\Affiliation\Application\UseCase\Query\AffiliationReadModel;
+
+interface ListAffiliationsOutputPort
+{
+    /** @param AffiliationReadModel[] $affiliations */
+    public function output(array $affiliations, int $currentPage, int $lastPage, int $total, int $perPage): void;
+
+    /** @return array{affiliations: array<int, array<string, mixed>>, current_page: int|null, last_page: int|null, total: int|null, per_page: int|null} */
+    public function toArray(): array;
+}

--- a/src/Account/Affiliation/Infrastructure/Query/ListAffiliations.php
+++ b/src/Account/Affiliation/Infrastructure/Query/ListAffiliations.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Source\Account\Affiliation\Infrastructure\Query;
+
+use Application\Models\Account\Account as AccountModel;
+use Application\Models\Account\Affiliation as AffiliationModel;
+use DateTimeInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use RuntimeException;
+use Source\Account\Affiliation\Application\Exception\DisallowedAffiliationOperationException;
+use Source\Account\Affiliation\Application\UseCase\Query\AffiliationReadModel;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInput;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInputPort;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInterface;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsOutputPort;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Account\Shared\Domain\ValueObject\AccountCategory;
+use Source\Account\Shared\Domain\ValueObject\AccountType;
+
+readonly class ListAffiliations implements ListAffiliationsInterface
+{
+    public function __construct(
+        private PolicyEvaluatorInterface $policyEvaluator,
+    ) {
+    }
+
+    public function process(ListAffiliationsInputPort $input, ListAffiliationsOutputPort $output): void
+    {
+        $principalAccountIdentifier = $input->principal()->accountIdentifier();
+        $account = AccountModel::query()->find((string) $principalAccountIdentifier);
+        if (! $account instanceof AccountModel) {
+            throw new DisallowedAffiliationOperationException('Affiliation list is not allowed.');
+        }
+
+        if (! $this->canUseAffiliationApprovalOrRejectionPolicy($input, $account)) {
+            throw new DisallowedAffiliationOperationException('Affiliation list is not allowed.');
+        }
+
+        $principalAccountId = (string) $principalAccountIdentifier;
+        $query = AffiliationModel::query()
+            ->with([
+                'agencyAccount:id,name,email',
+                'talentAccount:id,name,email',
+            ])
+            ->where(static function ($query) use ($principalAccountId): void {
+                $query->where('account_affiliations.agency_account_id', $principalAccountId)
+                    ->orWhere('account_affiliations.talent_account_id', $principalAccountId);
+            });
+
+        if ($input->status() !== null) {
+            $query->where('account_affiliations.status', $input->status());
+        }
+
+        if ($input->viewerRole() === ListAffiliationsInput::VIEWER_ROLE_REQUESTER) {
+            $query->where('account_affiliations.requested_by', $principalAccountId);
+        }
+
+        if ($input->viewerRole() === ListAffiliationsInput::VIEWER_ROLE_APPROVER) {
+            $query->where('account_affiliations.requested_by', '<>', $principalAccountId);
+        }
+
+        /** @var LengthAwarePaginator<int, AffiliationModel> $paginator */
+        $paginator = $query
+            ->orderByDesc('account_affiliations.requested_at')
+            ->orderByDesc('account_affiliations.id')
+            ->paginate($input->perPage(), ['*'], 'page', $input->page());
+
+        $affiliations = array_map(
+            static fn (AffiliationModel $affiliation): AffiliationReadModel => self::toReadModel($affiliation),
+            $paginator->items(),
+        );
+
+        $output->output(
+            $affiliations,
+            $paginator->currentPage(),
+            $paginator->lastPage(),
+            $paginator->total(),
+            $paginator->perPage(),
+        );
+    }
+
+    private static function toReadModel(AffiliationModel $affiliation): AffiliationReadModel
+    {
+        $agencyAccount = self::relatedAccount($affiliation, 'agencyAccount');
+        $talentAccount = self::relatedAccount($affiliation, 'talentAccount');
+
+        return new AffiliationReadModel(
+            affiliationIdentifier: $affiliation->id,
+            agencyAccountIdentifier: $affiliation->agency_account_id,
+            talentAccountIdentifier: $affiliation->talent_account_id,
+            agencyAccount: self::accountSummary($agencyAccount),
+            talentAccount: self::accountSummary($talentAccount),
+            requestedBy: $affiliation->requested_by,
+            status: $affiliation->status,
+            terms: self::terms($affiliation),
+            requestedAt: $affiliation->requested_at->format(DateTimeInterface::ATOM),
+            activatedAt: $affiliation->activated_at?->format(DateTimeInterface::ATOM),
+            terminatedAt: $affiliation->terminated_at?->format(DateTimeInterface::ATOM),
+        );
+    }
+
+    private static function relatedAccount(AffiliationModel $affiliation, string $relation): AccountModel
+    {
+        $account = $affiliation->getRelation($relation);
+        if (! $account instanceof AccountModel) {
+            throw new RuntimeException("Affiliation related account '{$relation}' is missing.");
+        }
+
+        return $account;
+    }
+
+    /** @return array{accountIdentifier: string, name: string, email: string} */
+    private static function accountSummary(AccountModel $account): array
+    {
+        return [
+            'accountIdentifier' => $account->id,
+            'name' => $account->name,
+            'email' => $account->email,
+        ];
+    }
+
+    /** @return array{revenueSharePercentage: int|null, contractNotes: string|null}|null */
+    private static function terms(AffiliationModel $affiliation): ?array
+    {
+        if ($affiliation->revenue_share_percentage === null && $affiliation->contract_notes === null) {
+            return null;
+        }
+
+        return [
+            'revenueSharePercentage' => $affiliation->revenue_share_percentage,
+            'contractNotes' => $affiliation->contract_notes,
+        ];
+    }
+
+    private function canUseAffiliationApprovalOrRejectionPolicy(ListAffiliationsInputPort $input, AccountModel $account): bool
+    {
+        $accountType = AccountType::tryFrom((string) $account->type);
+        $accountCategory = AccountCategory::tryFrom((string) $account->category);
+
+        foreach ([AccountCategory::AGENCY, AccountCategory::TALENT] as $requestingAccountCategory) {
+            $resource = Resource::account(
+                $input->principal()->accountIdentifier(),
+                $accountType,
+                $accountCategory,
+                $requestingAccountCategory,
+            );
+
+            if ($this->policyEvaluator->evaluate($input->principal(), Action::AFFILIATION_APPROVE, $resource)
+                || $this->policyEvaluator->evaluate($input->principal(), Action::AFFILIATION_REJECT, $resource)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Account/Affiliation/Application/UseCase/Query/AffiliationReadModelTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Query/AffiliationReadModelTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Affiliation\Application\UseCase\Query;
+
+use PHPUnit\Framework\TestCase;
+use Source\Account\Affiliation\Application\UseCase\Query\AffiliationReadModel;
+
+class AffiliationReadModelTest extends TestCase
+{
+    public function testToArrayReturnsAffiliationSummaryWithAccounts(): void
+    {
+        $readModel = new AffiliationReadModel(
+            affiliationIdentifier: 'affiliation-id',
+            agencyAccountIdentifier: 'agency-id',
+            talentAccountIdentifier: 'talent-id',
+            agencyAccount: [
+                'accountIdentifier' => 'agency-id',
+                'name' => 'Agency Account',
+                'email' => 'agency@example.com',
+            ],
+            talentAccount: [
+                'accountIdentifier' => 'talent-id',
+                'name' => 'Talent Account',
+                'email' => 'talent@example.com',
+            ],
+            requestedBy: 'agency-id',
+            status: 'active',
+            terms: ['revenueSharePercentage' => 30, 'contractNotes' => 'notes'],
+            requestedAt: '2026-08-11T10:00:00+00:00',
+            activatedAt: '2026-08-12T10:00:00+00:00',
+            terminatedAt: null,
+        );
+
+        $this->assertSame([
+            'affiliationIdentifier' => 'affiliation-id',
+            'agencyAccountIdentifier' => 'agency-id',
+            'talentAccountIdentifier' => 'talent-id',
+            'agencyAccount' => [
+                'accountIdentifier' => 'agency-id',
+                'name' => 'Agency Account',
+                'email' => 'agency@example.com',
+            ],
+            'talentAccount' => [
+                'accountIdentifier' => 'talent-id',
+                'name' => 'Talent Account',
+                'email' => 'talent@example.com',
+            ],
+            'requestedBy' => 'agency-id',
+            'status' => 'active',
+            'terms' => ['revenueSharePercentage' => 30, 'contractNotes' => 'notes'],
+            'requestedAt' => '2026-08-11T10:00:00+00:00',
+            'activatedAt' => '2026-08-12T10:00:00+00:00',
+            'terminatedAt' => null,
+        ], $readModel->toArray());
+    }
+
+    public function testToArrayReturnsNullableFields(): void
+    {
+        $readModel = new AffiliationReadModel(
+            affiliationIdentifier: 'affiliation-id',
+            agencyAccountIdentifier: 'agency-id',
+            talentAccountIdentifier: 'talent-id',
+            agencyAccount: [
+                'accountIdentifier' => 'agency-id',
+                'name' => 'Agency Account',
+                'email' => 'agency@example.com',
+            ],
+            talentAccount: [
+                'accountIdentifier' => 'talent-id',
+                'name' => 'Talent Account',
+                'email' => 'talent@example.com',
+            ],
+            requestedBy: 'talent-id',
+            status: 'pending',
+            terms: null,
+            requestedAt: '2026-08-11T10:00:00+00:00',
+            activatedAt: null,
+            terminatedAt: null,
+        );
+
+        $payload = $readModel->toArray();
+
+        $this->assertNull($payload['terms']);
+        $this->assertNull($payload['activatedAt']);
+        $this->assertNull($payload['terminatedAt']);
+    }
+}

--- a/tests/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInputTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsInputTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Affiliation\Application\UseCase\Query\ListAffiliations;
+
+use InvalidArgumentException;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInput;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ListAffiliationsInputTest extends TestCase
+{
+    public function testConstructWithDefaults(): void
+    {
+        $input = new ListAffiliationsInput($this->principal());
+
+        $this->assertNull($input->status());
+        $this->assertNull($input->viewerRole());
+        $this->assertSame(50, $input->perPage());
+        $this->assertSame(1, $input->page());
+    }
+
+    public function testConstructWithFiltersAndPagination(): void
+    {
+        $input = new ListAffiliationsInput(
+            principal: $this->principal(),
+            status: 'active',
+            viewerRole: 'approver',
+            perPage: 20,
+            page: 3,
+        );
+
+        $this->assertSame('active', $input->status());
+        $this->assertSame('approver', $input->viewerRole());
+        $this->assertSame(20, $input->perPage());
+        $this->assertSame(3, $input->page());
+    }
+
+    public function testInvalidStatusThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ListAffiliationsInput($this->principal(), status: 'unknown');
+    }
+
+    public function testInvalidViewerRoleThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ListAffiliationsInput($this->principal(), viewerRole: 'owner');
+    }
+
+    public function testInvalidPerPageThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ListAffiliationsInput($this->principal(), perPage: 101);
+    }
+
+    public function testInvalidPageThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ListAffiliationsInput($this->principal(), page: 0);
+    }
+
+    private function principal(): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            new AccountIdentifier(StrTestHelper::generateUuid()),
+        );
+    }
+}

--- a/tests/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsOutputTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Query/ListAffiliations/ListAffiliationsOutputTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Affiliation\Application\UseCase\Query\ListAffiliations;
+
+use PHPUnit\Framework\TestCase;
+use Source\Account\Affiliation\Application\UseCase\Query\AffiliationReadModel;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsOutput;
+
+class ListAffiliationsOutputTest extends TestCase
+{
+    public function testToArrayReturnsAffiliations(): void
+    {
+        $output = new ListAffiliationsOutput();
+        $output->output(
+            [
+                new AffiliationReadModel(
+                    affiliationIdentifier: 'affiliation-id',
+                    agencyAccountIdentifier: 'agency-id',
+                    talentAccountIdentifier: 'talent-id',
+                    agencyAccount: [
+                        'accountIdentifier' => 'agency-id',
+                        'name' => 'Agency Account',
+                        'email' => 'agency@example.com',
+                    ],
+                    talentAccount: [
+                        'accountIdentifier' => 'talent-id',
+                        'name' => 'Talent Account',
+                        'email' => 'talent@example.com',
+                    ],
+                    requestedBy: 'agency-id',
+                    status: 'active',
+                    terms: ['revenueSharePercentage' => 30, 'contractNotes' => 'notes'],
+                    requestedAt: '2026-08-11T10:00:00+00:00',
+                    activatedAt: '2026-08-12T10:00:00+00:00',
+                    terminatedAt: null,
+                ),
+            ],
+            2,
+            5,
+            41,
+            10,
+        );
+
+        $this->assertSame([
+            'affiliations' => [[
+                'affiliationIdentifier' => 'affiliation-id',
+                'agencyAccountIdentifier' => 'agency-id',
+                'talentAccountIdentifier' => 'talent-id',
+                'agencyAccount' => [
+                    'accountIdentifier' => 'agency-id',
+                    'name' => 'Agency Account',
+                    'email' => 'agency@example.com',
+                ],
+                'talentAccount' => [
+                    'accountIdentifier' => 'talent-id',
+                    'name' => 'Talent Account',
+                    'email' => 'talent@example.com',
+                ],
+                'requestedBy' => 'agency-id',
+                'status' => 'active',
+                'terms' => ['revenueSharePercentage' => 30, 'contractNotes' => 'notes'],
+                'requestedAt' => '2026-08-11T10:00:00+00:00',
+                'activatedAt' => '2026-08-12T10:00:00+00:00',
+                'terminatedAt' => null,
+            ]],
+            'current_page' => 2,
+            'last_page' => 5,
+            'total' => 41,
+            'per_page' => 10,
+        ], $output->toArray());
+    }
+
+    public function testToArrayReturnsEmptyAffiliationsByDefault(): void
+    {
+        $output = new ListAffiliationsOutput();
+
+        $this->assertSame([
+            'affiliations' => [],
+            'current_page' => null,
+            'last_page' => null,
+            'total' => null,
+            'per_page' => null,
+        ], $output->toArray());
+    }
+}

--- a/tests/Account/Affiliation/Infrastructure/Query/ListAffiliationsTest.php
+++ b/tests/Account/Affiliation/Infrastructure/Query/ListAffiliationsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Account\Affiliation\Infrastructure\Query;
+
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use PHPUnit\Framework\Attributes\Group;
+use Source\Account\Affiliation\Application\Exception\DisallowedAffiliationOperationException;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInput;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsInterface;
+use Source\Account\Affiliation\Application\UseCase\Query\ListAffiliations\ListAffiliationsOutput;
+use Source\Account\Affiliation\Infrastructure\Query\ListAffiliations;
+use Source\Account\Principal\Domain\Entity\Principal;
+use Source\Account\Principal\Domain\Service\PolicyEvaluatorInterface;
+use Source\Account\Principal\Domain\ValueObject\Action;
+use Source\Account\Principal\Domain\ValueObject\Resource;
+use Source\Account\Shared\Domain\ValueObject\PrincipalIdentifier;
+use Source\Shared\Domain\ValueObject\AccountIdentifier;
+use Source\Shared\Domain\ValueObject\IdentityIdentifier;
+use Tests\Helper\CreateAccount;
+use Tests\Helper\StrTestHelper;
+use Tests\TestCase;
+
+class ListAffiliationsTest extends TestCase
+{
+    public function test__construct(): void
+    {
+        $this->app->instance(PolicyEvaluatorInterface::class, Mockery::mock(PolicyEvaluatorInterface::class));
+
+        $this->assertInstanceOf(ListAffiliations::class, $this->app->make(ListAffiliationsInterface::class));
+    }
+
+    #[Group('useDb')]
+    public function testProcessReturnsRelatedAffiliationsOrderedByRequestedAtAndId(): void
+    {
+        $operator = $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()));
+        $agency = $operator->accountIdentifier();
+        $talent = new AccountIdentifier(StrTestHelper::generateUuid());
+        $other = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $agency, ['category' => 'agency', 'name' => 'Agency Alpha', 'email' => 'agency@example.com']);
+        CreateAccount::create((string) $talent, ['category' => 'talent', 'name' => 'Talent Beta', 'email' => 'talent@example.com']);
+        CreateAccount::create((string) $other, ['category' => 'talent', 'name' => 'Other Gamma', 'email' => 'other@example.com']);
+
+        $oldId = StrTestHelper::generateUuid();
+        $newerLowId = '00000000-0000-0000-0000-000000000001';
+        $newerHighId = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+        $unrelatedId = StrTestHelper::generateUuid();
+        $this->insertAffiliation($oldId, $agency, $talent, $agency, 'pending', '2026-08-10 10:00:00');
+        $this->insertAffiliation($newerLowId, $other, $agency, $other, 'active', '2026-08-11 10:00:00', 30, 'notes', '2026-08-12 10:00:00');
+        $this->insertAffiliation($newerHighId, $agency, $other, $other, 'terminated', '2026-08-11 10:00:00', null, null, '2026-08-12 10:00:00', '2026-08-13 10:00:00');
+        $this->insertAffiliation($unrelatedId, $talent, $other, $talent, 'pending', '2026-08-12 10:00:00');
+
+        $output = new ListAffiliationsOutput();
+        (new ListAffiliations($this->allowingPolicyEvaluator($operator)))
+            ->process(new ListAffiliationsInput($operator, perPage: 10), $output);
+
+        $payload = $output->toArray();
+        $this->assertSame([$newerHighId, $newerLowId, $oldId], array_column($payload['affiliations'], 'affiliationIdentifier'));
+        $this->assertSame([
+            'accountIdentifier' => (string) $agency,
+            'name' => 'Agency Alpha',
+            'email' => 'agency@example.com',
+        ], $payload['affiliations'][0]['agencyAccount']);
+        $this->assertSame([
+            'accountIdentifier' => (string) $other,
+            'name' => 'Other Gamma',
+            'email' => 'other@example.com',
+        ], $payload['affiliations'][0]['talentAccount']);
+        $this->assertSame([
+            'accountIdentifier' => (string) $other,
+            'name' => 'Other Gamma',
+            'email' => 'other@example.com',
+        ], $payload['affiliations'][1]['agencyAccount']);
+        $this->assertSame([
+            'accountIdentifier' => (string) $agency,
+            'name' => 'Agency Alpha',
+            'email' => 'agency@example.com',
+        ], $payload['affiliations'][1]['talentAccount']);
+        $this->assertSame(['revenueSharePercentage' => 30, 'contractNotes' => 'notes'], $payload['affiliations'][1]['terms']);
+        $this->assertSame(1, $payload['current_page']);
+        $this->assertSame(1, $payload['last_page']);
+        $this->assertSame(3, $payload['total']);
+        $this->assertSame(10, $payload['per_page']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByStatusAndPagination(): void
+    {
+        $operator = $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()));
+        $agency = $operator->accountIdentifier();
+        $talent = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $agency, ['category' => 'agency']);
+        CreateAccount::create((string) $talent, ['category' => 'talent']);
+
+        $pending1 = StrTestHelper::generateUuid();
+        $pending2 = StrTestHelper::generateUuid();
+        $active = StrTestHelper::generateUuid();
+        $this->insertAffiliation($pending1, $agency, $talent, $agency, 'pending', '2026-08-10 10:00:00');
+        $this->insertAffiliation($active, $agency, $talent, $talent, 'active', '2026-08-11 10:00:00');
+        $this->insertAffiliation($pending2, $agency, $talent, $talent, 'pending', '2026-08-12 10:00:00');
+
+        $output = new ListAffiliationsOutput();
+        (new ListAffiliations($this->allowingPolicyEvaluator($operator)))
+            ->process(new ListAffiliationsInput($operator, status: 'pending', perPage: 1, page: 2), $output);
+
+        $payload = $output->toArray();
+        $this->assertSame([$pending1], array_column($payload['affiliations'], 'affiliationIdentifier'));
+        $this->assertSame(2, $payload['current_page']);
+        $this->assertSame(2, $payload['last_page']);
+        $this->assertSame(2, $payload['total']);
+        $this->assertSame(1, $payload['per_page']);
+    }
+
+    #[Group('useDb')]
+    public function testProcessFiltersByRequesterAndApproverViewerRole(): void
+    {
+        $operator = $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()));
+        $agency = $operator->accountIdentifier();
+        $talent = new AccountIdentifier(StrTestHelper::generateUuid());
+        CreateAccount::create((string) $agency, ['category' => 'agency']);
+        CreateAccount::create((string) $talent, ['category' => 'talent']);
+
+        $requester = StrTestHelper::generateUuid();
+        $approver = StrTestHelper::generateUuid();
+        $this->insertAffiliation($requester, $agency, $talent, $agency, 'pending', '2026-08-10 10:00:00');
+        $this->insertAffiliation($approver, $agency, $talent, $talent, 'pending', '2026-08-11 10:00:00');
+
+        $requesterOutput = new ListAffiliationsOutput();
+        (new ListAffiliations($this->allowingPolicyEvaluator($operator)))
+            ->process(new ListAffiliationsInput($operator, viewerRole: 'requester'), $requesterOutput);
+        $this->assertSame([$requester], array_column($requesterOutput->toArray()['affiliations'], 'affiliationIdentifier'));
+
+        $approverOutput = new ListAffiliationsOutput();
+        (new ListAffiliations($this->allowingPolicyEvaluator($operator)))
+            ->process(new ListAffiliationsInput($operator, viewerRole: 'approver'), $approverOutput);
+        $this->assertSame([$approver], array_column($approverOutput->toArray()['affiliations'], 'affiliationIdentifier'));
+    }
+
+    #[Group('useDb')]
+    public function testProcessThrowsForbiddenWhenPolicyDoesNotAllow(): void
+    {
+        $operator = $this->principal(new AccountIdentifier(StrTestHelper::generateUuid()));
+        CreateAccount::create((string) $operator->accountIdentifier(), ['category' => 'agency']);
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')->times(4)->andReturnFalse();
+
+        $this->expectException(DisallowedAffiliationOperationException::class);
+
+        (new ListAffiliations($policyEvaluator))->process(new ListAffiliationsInput($operator), new ListAffiliationsOutput());
+    }
+
+    private function allowingPolicyEvaluator(Principal $principal): PolicyEvaluatorInterface
+    {
+        /** @var PolicyEvaluatorInterface&Mockery\MockInterface $policyEvaluator */
+        $policyEvaluator = Mockery::mock(PolicyEvaluatorInterface::class);
+        $policyEvaluator->shouldReceive('evaluate')
+            ->with($principal, Action::AFFILIATION_APPROVE, Mockery::on(static fn (Resource $resource): bool => (string) $resource->accountIdentifier() === (string) $principal->accountIdentifier()))
+            ->andReturnTrue();
+
+        return $policyEvaluator;
+    }
+
+    private function insertAffiliation(string $id, AccountIdentifier $agency, AccountIdentifier $talent, AccountIdentifier $requestedBy, string $status, string $requestedAt, ?int $revenueSharePercentage = null, ?string $contractNotes = null, ?string $activatedAt = null, ?string $terminatedAt = null): void
+    {
+        DB::table('account_affiliations')->insert([
+            'id' => $id,
+            'agency_account_id' => (string) $agency,
+            'talent_account_id' => (string) $talent,
+            'requested_by' => (string) $requestedBy,
+            'status' => $status,
+            'revenue_share_percentage' => $revenueSharePercentage,
+            'contract_notes' => $contractNotes,
+            'requested_at' => $requestedAt,
+            'activated_at' => $activatedAt,
+            'terminated_at' => $terminatedAt,
+        ]);
+    }
+
+    private function principal(AccountIdentifier $accountIdentifier): Principal
+    {
+        return new Principal(
+            new PrincipalIdentifier(StrTestHelper::generateUuid()),
+            new IdentityIdentifier(StrTestHelper::generateUuid()),
+            $accountIdentifier,
+        );
+    }
+}

--- a/typespec/services/account-api/affiliation.tsp
+++ b/typespec/services/account-api/affiliation.tsp
@@ -29,8 +29,23 @@ model OkAffiliationResponse {
   @body body: AffiliationSummary;
 }
 
+@doc("Response returned when listing affiliations succeeds.")
+model ListAffiliationsResponse {
+  @statusCode statusCode: 200;
+  @body body: ListAffiliationsResponseBody;
+}
+
 @route("/affiliations")
 interface AffiliationOperations {
+  @get
+  @doc("List affiliations related to the authenticated account.")
+  listAffiliations(
+    @query status?: string | null,
+    @query viewerRole?: string | null,
+    @query perPage?: int32 | null,
+    @query page?: int32 | null,
+  ): ListAffiliationsResponse | KPool.Common.UnauthorizedProblemResponse | KPool.Common.ForbiddenProblemResponse | KPool.Common.UnprocessableEntityProblemResponse | KPool.Common.InternalServerErrorProblemResponse;
+
   @post
   @doc("Request an affiliation.")
   requestAffiliation(

--- a/typespec/services/account-api/common.tsp
+++ b/typespec/services/account-api/common.tsp
@@ -101,6 +101,16 @@ model AffiliationTermsSummary {
   contractNotes?: string;
 }
 
+@doc("Account summary attached to an affiliation.")
+model AffiliationAccountSummary {
+  @doc("Account identifier.")
+  accountIdentifier: Uuid;
+  @doc("Account display name.")
+  name: string;
+  @doc("Account email address.")
+  email: string;
+}
+
 @doc("Affiliation state.")
 model AffiliationSummary {
   @doc("Affiliation identifier.")
@@ -109,6 +119,10 @@ model AffiliationSummary {
   agencyAccountIdentifier: Uuid;
   @doc("Talent account identifier.")
   talentAccountIdentifier: Uuid;
+  @doc("Agency account.")
+  agencyAccount: AffiliationAccountSummary;
+  @doc("Talent account.")
+  talentAccount: AffiliationAccountSummary;
   @doc("Account that initiated the affiliation workflow.")
   requestedBy: Uuid;
   @doc("Affiliation status.")
@@ -121,6 +135,20 @@ model AffiliationSummary {
   activatedAt?: Timestamp | null;
   @doc("Timestamp when the affiliation was terminated.")
   terminatedAt?: Timestamp | null;
+}
+
+@doc("Response body for affiliation list.")
+model ListAffiliationsResponseBody {
+  @doc("Affiliations related to the authenticated account.")
+  affiliations: AffiliationSummary[];
+  @doc("Current page number.")
+  current_page: int32;
+  @doc("Last page number.")
+  last_page: int32;
+  @doc("Total number of affiliations matching the filters.")
+  total: int32;
+  @doc("Number of items per page.")
+  per_page: int32;
 }
 
 @doc("Delegation state.")


### PR DESCRIPTION
## 📝 変更内容

- Account API に `GET /affiliations` を追加しました。
- `status`, `viewerRole`, `perPage`, `page` の query parameter を受け取り、ログイン中 principal の account が agency / talent のいずれかとして関係する Affiliation を `requested_at desc, id desc` でページング取得できるようにしました。
- `viewerRole=requester` / `viewerRole=approver` の絞り込み、Affiliation status / pagination 入力検証、Affiliation 承認・拒否権限に基づく 403 制御を追加しました。
- TypeSpec と生成済み OpenAPI を更新しました。
- Query / HTTP Action / Input / Output のテストを追加しました。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Affiliation には作成・承認・却下・終了 API はありましたが一覧取得 API がなく、フロントエンドが自アカウントに関係する Affiliation 状態を取得できませんでした。管理画面や申請確認画面で一覧表示できるよう、Account API に一覧 Query を追加しました。

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、すべてのテストがパスすることを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

実行結果:

- `task openapi-generate` 成功
- `task cs-fix` 成功（Fixed 0 files）
- `task phpstan` 成功（No errors）
- `task test-no-db filter=ListAffiliations` 成功（11 tests, 24 assertions）
- `docker-compose run --rm php ./vendor/bin/phpunit --filter=ListAffiliations --group useDb --no-coverage` 成功（4 tests, 15 assertions）
- `task test-no-db` 成功（2459 tests, 7880 assertions）
- `docker-compose run --rm php ./vendor/bin/phpunit --group useDb --no-coverage` 成功（609 tests, 2033 assertions）

補足: ローカルの Redis/Postgres port 競合があったため、同一プロジェクトの既存 `kpool-backend` DB/Redis コンテナを停止してから DB テストを実行しました。

### 動作確認

自動テストで以下を確認しました。

- agency / talent の両側に紐づく Affiliation が返ること
- 自アカウントに関係しない Affiliation が返らないこと
- `viewerRole=requester` / `viewerRole=approver` の絞り込み
- `status` filter と pagination
- 不正な `status`, `viewerRole`, `perPage`, `page` の validation
- 権限がない principal の 403 相当例外

## 🔍 レビューのポイント

- `ListAffiliations` が Domain Repository ではなく Eloquent Query + `paginate()` を使っている点
- `viewerRole=approver` を `requested_by <> principal.accountIdentifier` として、agency / talent の関連条件と組み合わせている点
- 一覧 API の認可を `Action::AFFILIATION_APPROVE` / `Action::AFFILIATION_REJECT` の既存ポリシー評価に合わせ、requesting category が agency / talent の両パターンで評価している点
- TypeSpec の nullable query parameter に `| null` を明示している点

Review skills used / unavailable skills and alternative review performed:

- `qa-review`, `test-review`, `security-review`, `architecture-review` は Hermes/Codex/repo-local で見つからなかったため、同一セッション内で代替同期レビューを実施しました。
- QA: Issue #548 の受け入れ条件に対して route / query parameter / pagination / response body / TypeSpec 更新 / OpenAPI 生成を確認しました。
- Test: Input/Output/Infrastructure Query/HTTP Action のテストと、全 no-DB / 全 useDb の PHPUnit、PHPStan、CS Fixer、OpenAPI 生成を確認しました。
- Security: `auth.api`, `resolve.actor`, `resolve.account` 配下に route を追加し、一覧 Query でも Affiliation approve/reject 既存ポリシー評価が通らない principal を拒否することを確認しました。
- Architecture: command use case / domain repository ではなく Query use case + Infrastructure Query に分離し、既存 `ListAccountCategoryChangeRequests` の pagination/read-model パターンに合わせていることを確認しました。

未対応のレビュー指摘:

- なし。

## 📖 関連情報

### 関連Issue・タスク

Closes #548

## ⚠️ 注意事項

- `AffiliationStatus` の現行 enum は `pending`, `active`, `terminated` のため、Issue 本文に想定値として記載されていた `rejected` は status validation の許可値には含めていません（実際の値は `AffiliationStatus` に合わせる、という指示に従っています）。
- マイグレーション変更はありません。

## 📸 スクリーンショット・デモ

API 追加のため該当なし。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
