### PR TITLE
Affiliationリクエストの重複制御を修正

### DIFF
--- a/database/migrations/2024_01_01_000024_create_account_affiliations_table.php
+++ b/database/migrations/2024_01_01_000024_create_account_affiliations_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -28,6 +29,8 @@ return new class extends Migration
             $table->index(['agency_account_id', 'talent_account_id', 'status']);
             $table->index(['requested_by', 'status']);
         });
+
+        DB::statement("CREATE UNIQUE INDEX account_affiliations_open_pair_unique ON account_affiliations (agency_account_id, talent_account_id) WHERE status IN ('pending', 'active')");
     }
 
     /**

--- a/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliation.php
+++ b/src/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliation.php
@@ -79,8 +79,8 @@ readonly class RequestAffiliation implements RequestAffiliationInterface
             $targetAccount->accountIdentifier(),
         );
 
-        if ($this->affiliationRepository->existsActiveAffiliation($agencyAccountIdentifier, $talentAccountIdentifier)) {
-            throw new AffiliationAlreadyExistsException('An active affiliation already exists between these accounts.');
+        if ($this->affiliationRepository->existsOpenAffiliation($agencyAccountIdentifier, $talentAccountIdentifier)) {
+            throw new AffiliationAlreadyExistsException('An affiliation request or active affiliation already exists between these accounts.');
         }
 
         if ($this->affiliationRepository->findActiveByTalentAccount($talentAccountIdentifier) !== null) {

--- a/src/Account/Affiliation/Domain/Repository/AffiliationRepositoryInterface.php
+++ b/src/Account/Affiliation/Domain/Repository/AffiliationRepositoryInterface.php
@@ -34,5 +34,5 @@ interface AffiliationRepositoryInterface
      */
     public function findPendingByApprover(AccountIdentifier $approverAccountIdentifier): array;
 
-    public function existsActiveAffiliation(AccountIdentifier $agencyAccountIdentifier, AccountIdentifier $talentAccountIdentifier): bool;
+    public function existsOpenAffiliation(AccountIdentifier $agencyAccountIdentifier, AccountIdentifier $talentAccountIdentifier): bool;
 }

--- a/src/Account/Affiliation/Infrastructure/Repository/AffiliationRepository.php
+++ b/src/Account/Affiliation/Infrastructure/Repository/AffiliationRepository.php
@@ -109,14 +109,17 @@ class AffiliationRepository implements AffiliationRepositoryInterface
             ->all();
     }
 
-    public function existsActiveAffiliation(
+    public function existsOpenAffiliation(
         AccountIdentifier $agencyAccountIdentifier,
         AccountIdentifier $talentAccountIdentifier,
     ): bool {
         return AffiliationEloquent::query()
             ->where('agency_account_id', (string) $agencyAccountIdentifier)
             ->where('talent_account_id', (string) $talentAccountIdentifier)
-            ->where('status', AffiliationStatus::ACTIVE->value)
+            ->whereIn('status', [
+                AffiliationStatus::PENDING->value,
+                AffiliationStatus::ACTIVE->value,
+            ])
             ->exists();
     }
 

--- a/src/Identity/Infrastructure/Service/AffiliationRequestNotificationService.php
+++ b/src/Identity/Infrastructure/Service/AffiliationRequestNotificationService.php
@@ -42,6 +42,6 @@ readonly class AffiliationRequestNotificationService implements AffiliationReque
 
     private function buildAffiliationUrl(): string
     {
-        return rtrim($this->frontendBaseUrl, '/') . '/admin/account/affiliation';
+        return rtrim($this->frontendBaseUrl, '/') . '/admin/account/affiliations';
     }
 }

--- a/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationTest.php
+++ b/tests/Account/Affiliation/Application/UseCase/Command/RequestAffiliation/RequestAffiliationTest.php
@@ -99,13 +99,13 @@ class RequestAffiliationTest extends TestCase
         }
     }
 
-    public function testThrowsWhenSameAgencyTalentActiveAffiliationAlreadyExists(): void
+    public function testThrowsWhenSameAgencyTalentOpenAffiliationAlreadyExists(): void
     {
-        $data = $this->createTestData(AccountCategory::TALENT, activeExists: true);
+        $data = $this->createTestData(AccountCategory::TALENT, openExists: true);
         $useCase = $this->createUseCase($data);
 
         $this->expectException(AffiliationAlreadyExistsException::class);
-        $this->expectExceptionMessage('An active affiliation already exists between these accounts.');
+        $this->expectExceptionMessage('An affiliation request or active affiliation already exists between these accounts.');
         $useCase->process($data->input, new RequestAffiliationOutput());
     }
 
@@ -179,10 +179,10 @@ class RequestAffiliationTest extends TestCase
 
         $affiliationRepository = Mockery::mock(AffiliationRepositoryInterface::class);
         if ($data->expectAffiliationLookup) {
-            $affiliationRepository->shouldReceive('existsActiveAffiliation')
+            $affiliationRepository->shouldReceive('existsOpenAffiliation')
                 ->with($data->agencyAccountIdentifier, $data->talentAccountIdentifier)
-                ->andReturn($data->activeExists);
-            if (! $data->activeExists) {
+                ->andReturn($data->openExists);
+            if (! $data->openExists) {
                 $affiliationRepository->shouldReceive('findActiveByTalentAccount')
                     ->with($data->talentAccountIdentifier)
                     ->andReturn($data->activeTalentAffiliation);
@@ -228,7 +228,7 @@ class RequestAffiliationTest extends TestCase
         );
     }
 
-    private function createTestData(AccountCategory $requestingCategory, bool $requesterAllowed = true, ?string $targetFailure = null, bool $activeExists = false, bool $activeTalentExists = false): RequestAffiliationTestData
+    private function createTestData(AccountCategory $requestingCategory, bool $requesterAllowed = true, ?string $targetFailure = null, bool $openExists = false, bool $activeTalentExists = false): RequestAffiliationTestData
     {
         $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
         $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
@@ -265,12 +265,12 @@ class RequestAffiliationTest extends TestCase
             new RequestAffiliationInput($requestingPrincipal, $targetEmail, $terms),
             $requesterAllowed,
             $targetAllowed,
-            $activeExists,
+            $openExists,
             $activeTalentAffiliation,
             $requesterAllowed && $targetAccount !== null,
             $requesterAllowed && $targetAccount !== null,
             $requesterAllowed && $targetAccount !== null && $targetAllowed,
-            $requesterAllowed && $targetAccount !== null && $targetAllowed && ! $activeExists && $activeTalentAffiliation === null,
+            $requesterAllowed && $targetAccount !== null && $targetAllowed && ! $openExists && $activeTalentAffiliation === null,
         );
     }
 
@@ -307,7 +307,7 @@ readonly class RequestAffiliationTestData
         public RequestAffiliationInput $input,
         public bool $requesterAllowed,
         public bool $targetAllowed,
-        public bool $activeExists,
+        public bool $openExists,
         public ?Affiliation $activeTalentAffiliation,
         public bool $expectTargetPrincipalLookup,
         public bool $expectTargetPolicyEvaluation,

--- a/tests/Account/Affiliation/Http/Action/Command/RequestAffiliation/RequestAffiliationActionTest.php
+++ b/tests/Account/Affiliation/Http/Action/Command/RequestAffiliation/RequestAffiliationActionTest.php
@@ -128,7 +128,7 @@ class RequestAffiliationActionTest extends TestCase
         $useCase = Mockery::mock(RequestAffiliationInterface::class);
         $useCase->shouldReceive('process')
             ->once()
-            ->andThrow(new AffiliationAlreadyExistsException('An active affiliation already exists between these accounts.'));
+            ->andThrow(new AffiliationAlreadyExistsException('An affiliation request or active affiliation already exists between these accounts.'));
 
         /** @var LoggerInterface&Mockery\MockInterface $logger */
         $logger = Mockery::mock(LoggerInterface::class);

--- a/tests/Account/Affiliation/Infrastructure/Repository/AffiliationRepositoryTest.php
+++ b/tests/Account/Affiliation/Infrastructure/Repository/AffiliationRepositoryTest.php
@@ -78,6 +78,43 @@ class AffiliationRepositoryTest extends TestCase
         $this->assertNull((new AffiliationRepository())->findActiveByTalentAccount($talentAccountIdentifier));
     }
 
+    #[Group('useDb')]
+    public function testExistsOpenAffiliationReturnsTrueForPendingOrActiveSamePair(): void
+    {
+        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $repository = new AffiliationRepository();
+
+        $this->assertFalse($repository->existsOpenAffiliation($agencyAccountIdentifier, $talentAccountIdentifier));
+
+        $this->insertAffiliation(
+            StrTestHelper::generateUuid(),
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            AffiliationStatus::PENDING,
+        );
+
+        $this->assertTrue($repository->existsOpenAffiliation($agencyAccountIdentifier, $talentAccountIdentifier));
+    }
+
+    #[Group('useDb')]
+    public function testExistsOpenAffiliationReturnsFalseForTerminatedSamePair(): void
+    {
+        $agencyAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+        $talentAccountIdentifier = new AccountIdentifier(StrTestHelper::generateUuid());
+
+        $this->insertAffiliation(
+            StrTestHelper::generateUuid(),
+            $agencyAccountIdentifier,
+            $talentAccountIdentifier,
+            AffiliationStatus::TERMINATED,
+            activatedAt: new DateTimeImmutable('2026-01-03 00:00:00'),
+            terminatedAt: new DateTimeImmutable('2026-01-04 00:00:00'),
+        );
+
+        $this->assertFalse((new AffiliationRepository())->existsOpenAffiliation($agencyAccountIdentifier, $talentAccountIdentifier));
+    }
+
     private function insertAffiliation(
         string $identifier,
         AccountIdentifier $agencyAccountIdentifier,

--- a/tests/Identity/Infrastructure/Service/AffiliationRequestNotificationServiceTest.php
+++ b/tests/Identity/Infrastructure/Service/AffiliationRequestNotificationServiceTest.php
@@ -50,7 +50,7 @@ class AffiliationRequestNotificationServiceTest extends TestCase
 
         Mail::assertSent(AffiliationRequestMail::class, static fn (AffiliationRequestMail $mail): bool => $mail->hasTo((string) $email)
             && $mail->language === Language::JAPANESE
-            && $mail->affiliationUrl === 'http://localhost:3000/admin/account/affiliation');
+            && $mail->affiliationUrl === 'http://localhost:3000/admin/account/affiliations');
     }
 
     public function testSendAffiliationRequestNotificationDoesNothingWhenIdentityIsMissing(): void
@@ -78,7 +78,7 @@ class AffiliationRequestNotificationServiceTest extends TestCase
         $service = new AffiliationRequestNotificationService($identityRepository, 'https://frontend.example.com');
         $service->sendAffiliationRequestNotification($email);
 
-        Mail::assertSent(AffiliationRequestMail::class, static fn (AffiliationRequestMail $mail): bool => str_contains($mail->affiliationUrl, '/admin/account/affiliation'));
+        Mail::assertSent(AffiliationRequestMail::class, static fn (AffiliationRequestMail $mail): bool => str_contains($mail->affiliationUrl, '/admin/account/affiliations'));
     }
 
     public function testSendAffiliationRequestNotificationDefersUntilAfterCommitInTransaction(): void
@@ -100,7 +100,7 @@ class AffiliationRequestNotificationServiceTest extends TestCase
 
     public function testMailBodyRendersHtmlForAllLanguages(): void
     {
-        $affiliationUrl = 'https://frontend.example.com/admin/account/affiliation';
+        $affiliationUrl = 'https://frontend.example.com/admin/account/affiliations';
 
         foreach (Language::cases() as $language) {
             $html = (new AffiliationRequestMail($affiliationUrl, $language))->render();


### PR DESCRIPTION
## 📝 変更内容

- Affiliation リクエスト作成時、同じ agency/talent の組み合わせで pending または active の Affiliation が既にある場合は拒否するように変更
- account_affiliations 作成 migration に pending/active の同一ペアを防ぐ partial unique index を追加
- 所属リクエスト承認依頼メールの遷移先を `/admin/account/affiliations` に修正
- 関連する UseCase / Repository / 通知サービスのテストを更新

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

同じ agency/talent の組み合わせで未処理の所属リクエストが重複作成できていたため、pending/active の間は再作成できないようにする必要がありました。
Reject 後はレコード削除、失効後は terminated になるため、再申請は引き続き可能です。

## 🧪 テスト

### テストの実行確認

- [x] `task test-no-db filter=RequestAffiliationTest`
- [x] `task test-no-db filter=RequestAffiliationActionTest`
- [x] `task test filter=AffiliationRepositoryTest`
- [x] `task test-no-db filter=AffiliationRequestNotificationServiceTest`
- [x] `task phpstan`

### 動作確認

手動確認なし

## 🔍 レビューのポイント

- pending/active の同一 agency/talent ペアだけがブロック対象になっていること
- terminated は再申請を妨げないこと
- メール遷移先がフロントの実パス `/admin/account/affiliations` と一致していること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

account_affiliations 作成 migration に partial unique index を追加しています。
既存環境への追加 migration ではなく、元 migration を直接編集しています。

## 📸 スクリーンショット・デモ

なし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
